### PR TITLE
ネガティブプロンプトのスケーリング

### DIFF
--- a/gen_img_diffusers.py
+++ b/gen_img_diffusers.py
@@ -2517,7 +2517,7 @@ if __name__ == '__main__':
   parser.add_argument("--highres_fix_save_1st", action='store_true',
                       help="save 1st stage images for highres fix / highres fixの最初のステージの画像を保存する")
   parser.add_argument("--negative_scale", type=float, default=None,
-                      help="correctly cfg")
+                      help="scaling negative prompt")
 
   args = parser.parse_args()
   main(args)

--- a/gen_img_diffusers.py
+++ b/gen_img_diffusers.py
@@ -694,8 +694,21 @@ class PipelineLike():
         **kwargs,
     )
 
+    if args.negative_scale is not None:
+      _, real_uncond_embeddings, _ = get_weighted_text_embeddings(
+        pipe=self,
+        prompt=prompt,
+        uncond_prompt=[""]*batch_size,
+        max_embeddings_multiples=max_embeddings_multiples,
+        clip_skip=self.clip_skip,
+        **kwargs,
+    )	
+
     if do_classifier_free_guidance:
-      text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
+      if args.negative_scale is None:
+        text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
+      else:
+      	text_embeddings = torch.cat([uncond_embeddings, text_embeddings, real_uncond_embeddings])
 
     # CLIP guidanceで使用するembeddingsを取得する
     if self.clip_guidance_scale > 0:
@@ -828,16 +841,20 @@ class PipelineLike():
 
     for i, t in enumerate(tqdm(timesteps)):
       # expand the latents if we are doing classifier free guidance
-      latent_model_input = latents.repeat((2, 1, 1, 1)) if do_classifier_free_guidance else latents
+      repeats = 3 if args.negative_scale is not None else 2
+      latent_model_input = latents.repeat((repeats, 1, 1, 1)) if do_classifier_free_guidance else latents
       latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
-
       # predict the noise residual
       noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
 
       # perform guidance
       if do_classifier_free_guidance:
-        noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
-        noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+        if args.negative_scale is None:
+          noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+          noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+        else:
+          noise_pred_negative, noise_pred_text, noise_pred_uncond = noise_pred.chunk(3)
+          noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond) - args.negative_scale	* (noise_pred_negative - noise_pred_uncond)
 
       # perform clip guidance
       if self.clip_guidance_scale > 0 or self.clip_image_guidance_scale > 0 or self.vgg16_guidance_scale > 0:
@@ -2499,6 +2516,8 @@ if __name__ == '__main__':
                       help="1st stage steps for highres fix / highres fixの最初のステージのステップ数")
   parser.add_argument("--highres_fix_save_1st", action='store_true',
                       help="save 1st stage images for highres fix / highres fixの最初のステージの画像を保存する")
+  parser.add_argument("--negative_scale", type=float, default=None,
+                      help="correctly cfg")
 
   args = parser.parse_args()
   main(args)


### PR DESCRIPTION
ネガティブプロンプトの実装は、
$$\epsilon(x|neg) + g_{scale} * (\epsilon(x|cond) - \epsilon(x|neg))$$
で、ネガティブプロンプトによる生成を初期値としてプロンプトの方向へ向かっていくようなイメージですが、CFGの理論的には以下のように無条件生成を初期値としてスタートするべきなのでは？と思いつきました。
$$\epsilon(x|uncond) + g_{scale} * (\epsilon(x|cond) - \epsilon(x|neg))$$
さらに、ネガティブプロンプトの結果をどこまで参考にするか決める $n_{scale}$ を用いて、
$$\epsilon(x|uncond) + g_{scale}* (\epsilon(x|cond) - \epsilon(x|uncond)) -  n_{scale}* (\epsilon(x|neg) - \epsilon(x|uncond)) $$
とすればネガティブプロンプトのスケーリングができると考えました。( $g_{scale}=n_{scale}$ のとき真ん中の式と同じになる)

ただし生成に必要な計算量は1.5倍になります（だからネガティブプロンプトは最初の式のような実装になったんでしょうけど・・・）。

生成結果例は以下のような感じですが、生成時間の増加に見合う価値があるのかはよく分かりません。
https://raw.githubusercontent.com/laksjdjf/sd-scripts/main/test.jpg
model: wd14-anime
prompt: masterpiece,best quality,1girl,solo,sitting,blush,red eyes,blonde hair,twintails,hair ribbon,school uniform,blue sailor collar,blue skirt,black thighhighs
negative: worst quality, low quality, medium quality, deleted, lowres, comic, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, jpeg artifacts, signature, watermark, username, blurry
guidance_scale = 7.5

実装は動きはしますが、text_embeddingsの生成が冗長になっていたりと修正が必要そうです。


