### PR TITLE
Load train data outside of epochs loop

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -223,13 +223,16 @@ def train(args):
   if accelerator.is_main_process:
     accelerator.init_trackers("finetuning")
 
+  print(f"Loading train data")
+  preload_train_data = list(enumerate(train_dataloader))
+
   for epoch in range(num_train_epochs):
     print(f"epoch {epoch+1}/{num_train_epochs}")
     for m in training_models:
       m.train()
 
     loss_total = 0
-    for step, batch in enumerate(train_dataloader):
+    for step, batch in preload_train_data:
       with accelerator.accumulate(training_models[0]):  # 複数モデルに対応していない模様だがとりあえずこうしておく
         with torch.no_grad():
           if "latents" in batch and batch["latents"] is not None:

--- a/train_db.py
+++ b/train_db.py
@@ -200,6 +200,9 @@ def train(args):
   if accelerator.is_main_process:
     accelerator.init_trackers("dreambooth")
 
+  print(f"Loading train data")
+  preload_train_data = list(enumerate(train_dataloader))
+
   for epoch in range(num_train_epochs):
     print(f"epoch {epoch+1}/{num_train_epochs}")
 
@@ -210,7 +213,7 @@ def train(args):
       text_encoder.train()
 
     loss_total = 0
-    for step, batch in enumerate(train_dataloader):
+    for step, batch in preload_train_data:
       # 指定したステップ数でText Encoderの学習を止める
       if global_step == args.stop_text_encoder_training:
         print(f"stop text encoder training at step {global_step}")

--- a/train_network.py
+++ b/train_network.py
@@ -301,6 +301,9 @@ def train(args):
   if accelerator.is_main_process:
     accelerator.init_trackers("network_train")
 
+  print(f"Loading train data")
+  preload_train_data = list(enumerate(train_dataloader))
+
   for epoch in range(num_train_epochs):
     print(f"epoch {epoch+1}/{num_train_epochs}")
     metadata["ss_epoch"] = str(epoch+1)
@@ -308,7 +311,7 @@ def train(args):
     network.on_epoch_start(text_encoder, unet)
 
     loss_total = 0
-    for step, batch in enumerate(train_dataloader):
+    for step, batch in preload_train_data:
       with accelerator.accumulate(network):
         with torch.no_grad():
           if "latents" in batch and batch["latents"] is not None:

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -292,6 +292,9 @@ def train(args):
   if accelerator.is_main_process:
     accelerator.init_trackers("textual_inversion")
 
+  print(f"Loading train data")
+  preload_train_data = list(enumerate(train_dataloader))
+
   for epoch in range(num_train_epochs):
     print(f"epoch {epoch+1}/{num_train_epochs}")
 
@@ -299,7 +302,7 @@ def train(args):
 
     loss_total = 0
     bef_epo_embs = unwrap_model(text_encoder).get_input_embeddings().weight[token_ids].data.detach().clone()
-    for step, batch in enumerate(train_dataloader):
+    for step, batch in preload_train_data:
       with accelerator.accumulate(text_encoder):
         with torch.no_grad():
           if "latents" in batch and batch["latents"] is not None:


### PR DESCRIPTION
I'm trying to train some LoRA models and notice a long time gap between each epoch on my poor computer. I'm trying to findout where the time is spent and found the `train_dataloader` will load the data inside each epoch loop.

It doesn't seem necessary to reload the train data inside each epoch loop, I compared the data for each load and they appear to be equal, and the `train_dataset` and `train_dataloader` seems never change in the loop, so I try to move the load process outside the loop like this PR, it seems to work fine. (BTW, only test on `train_network.py` to train LoRA model)

I'm not yet familiar with this knowledge, so I'm not sure this thing is really correct, might need to check carefully about it.