### PR TITLE
add verbosity option for resize_lora.py

### DIFF
--- a/networks/resize_lora.py
+++ b/networks/resize_lora.py
@@ -38,9 +38,10 @@ def save_to_file(file_name, model, state_dict, dtype, metadata):
     torch.save(model, file_name)
 
 
-def resize_lora_model(lora_sd, new_rank, save_dtype, device):
+def resize_lora_model(lora_sd, new_rank, save_dtype, device, verbose):
   network_alpha = None
   network_dim = None
+  verbose_str = "\n"
 
   CLAMP_QUANTILE = 0.99
 
@@ -96,6 +97,12 @@ def resize_lora_model(lora_sd, new_rank, save_dtype, device):
 
         U, S, Vh = torch.linalg.svd(full_weight_matrix)
 
+        if verbose:
+          s_sum = torch.sum(torch.abs(S))
+          s_rank = torch.sum(torch.abs(S[:new_rank]))
+          verbose_str+=f"{block_down_name:76} | "
+          verbose_str+=f"sum(S) retained: {(s_rank)/s_sum:.1%}%, max(S) to max(S_dropped) ratio: {S[0]/S[new_rank]:0.1f}\n"
+
         U = U[:, :new_rank]
         S = S[:new_rank]
         U = U @ torch.diag(S)
@@ -113,7 +120,7 @@ def resize_lora_model(lora_sd, new_rank, save_dtype, device):
           U = U.unsqueeze(2).unsqueeze(3)
           Vh = Vh.unsqueeze(2).unsqueeze(3)
 
-        if args.device:
+        if device:
           U = U.to(org_device)
           Vh = Vh.to(org_device)
 
@@ -127,6 +134,8 @@ def resize_lora_model(lora_sd, new_rank, save_dtype, device):
         lora_up_weight = None
         weights_loaded = False
 
+  if verbose:
+    print(verbose_str)
   print("resizing complete")
   return o_lora_sd, network_dim, new_alpha
 
@@ -151,7 +160,7 @@ def resize(args):
   lora_sd, metadata = load_state_dict(args.model, merge_dtype)
 
   print("resizing rank...")
-  state_dict, old_dim, new_alpha = resize_lora_model(lora_sd, args.new_rank, save_dtype, args.device)
+  state_dict, old_dim, new_alpha = resize_lora_model(lora_sd, args.new_rank, save_dtype, args.device, args.verbose)
 
   # update metadata
   if metadata is None:
@@ -182,6 +191,8 @@ if __name__ == '__main__':
   parser.add_argument("--model", type=str, default=None,
                       help="LoRA model to resize at to new rank: ckpt or safetensors file / 読み込むLoRAモデル、ckptまたはsafetensors")
   parser.add_argument("--device", type=str, default=None, help="device to use, cuda for GPU / 計算を行うデバイス、cuda でGPUを使う")
+  parser.add_argument("--verbose", action="store_true", 
+                      help="Display verbose resizing information")
 
   args = parser.parse_args()
   resize(args)


### PR DESCRIPTION
- add `--verbose` flag to print additional statistics in `resize_lora_model` function 
- correct `device` parameter reference in `resize_lora_model` function

The verbose print statement will give some additional metrics on the SVD reduction at each layer. 

- **sum(S) retained** is the sum of magnitudes for the resized LoRA's singular values compared against sum of magnitudes for the original LoRA's singular values (reported as a percentage). 
- **max(S) to max(S_dropped) ratio** is the largest magnitude singular value compared against the largest magnitude singular value which was dropped during the resize.

General notes:
- Losing some "information" during resize does not always mean lower quality results, as lowering rank can have a denoising effect.
- Good target values for these metrics are domain specific, and to my knowledge, not known yet for this use case. 
- Initial recommendations are to pay more attention to the second metric (max s ratios) than the first. The closer the ratio is to 1, the less accurate the resized rank representation was able to represent that layer.
- Visual inspection of final resulting outputs from LoRA is still the best way to check effectiveness of resized LoRA at this time.

Example of partial output from resizing rank 128 to rank 32:

```
lora_unet_up_blocks_3_attentions_2_proj_in                                   | sum(S) retained: 59.3%%, max(S) to max(S_dropped) ratio: 8.2
lora_unet_up_blocks_3_attentions_2_proj_out                                  | sum(S) retained: 67.7%%, max(S) to max(S_dropped) ratio: 6.3
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn1_to_k           | sum(S) retained: 61.0%%, max(S) to max(S_dropped) ratio: 3.4
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn1_to_out_0       | sum(S) retained: 64.0%%, max(S) to max(S_dropped) ratio: 10.2
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn1_to_q           | sum(S) retained: 63.9%%, max(S) to max(S_dropped) ratio: 4.4
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn1_to_v           | sum(S) retained: 66.7%%, max(S) to max(S_dropped) ratio: 12.4
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn2_to_k           | sum(S) retained: 81.2%%, max(S) to max(S_dropped) ratio: 22.5
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn2_to_out_0       | sum(S) retained: 75.9%%, max(S) to max(S_dropped) ratio: 17.1
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn2_to_q           | sum(S) retained: 79.5%%, max(S) to max(S_dropped) ratio: 18.0
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn2_to_v           | sum(S) retained: 81.5%%, max(S) to max(S_dropped) ratio: 20.6
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_ff_net_0_proj        | sum(S) retained: 53.3%%, max(S) to max(S_dropped) ratio: 2.9
lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_ff_net_2             | sum(S) retained: 65.9%%, max(S) to max(S_dropped) ratio: 6.5
```