### PR TITLE
fix git path

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1103,7 +1103,7 @@ def addnet_hash_safetensors(b):
 
 def get_git_revision_hash() -> str:
   try:
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=os.path.dirname(__file__)).decode('ascii').strip()
   except:
     return "(unknown)"
 


### PR DESCRIPTION
dont assume script is started from the repository folder - this prevents script to be used in path or using absolute path.
simple fix so git command is executed in script location instead of current folder which can be anything.