### PR TITLE
Add lr_scheduler_type and lr_scheduler_args

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -178,9 +178,7 @@ def train(args):
     print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
   # lr schedulerを用意する
-  lr_scheduler = train_util.get_scheduler_fix(args.lr_scheduler, optimizer, num_warmup_steps=args.lr_warmup_steps,
-                                              num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
-                                              num_cycles=args.lr_scheduler_num_cycles, power=args.lr_scheduler_power)
+  lr_scheduler = train_util.get_scheduler_fix(args, optimizer)
 
   # 実験的機能：勾配も含めたfp16学習を行う　モデル全体をfp16にする
   if args.full_fp16:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1877,7 +1877,7 @@ def get_scheduler_fix(args,optimizer: Optimizer):
   power = args.lr_scheduler_power
 
   lr_scheduler_kwargs = {}  # get custom lr_scheduler kwargs
-  if args.lr_scheduler_args is not None and len(args.optimizer_args) > 0:
+  if args.lr_scheduler_args is not None and len(args.lr_scheduler_args) > 0:
     for arg in args.lr_scheduler_args:
       key, value = arg.split('=')
 
@@ -1886,11 +1886,11 @@ def get_scheduler_fix(args,optimizer: Optimizer):
         if value[i].lower() == "true" or value[i].lower() == "false":
           value[i] = (value[i].lower() == "true")
         else:
-          value[i] = float(value[i])
+          value[i] = eval(value[i]) # warning: not safe!!!
       if len(value) == 1:
         value = value[0]
       else:
-        value = tuple(value)
+        value = tuple(value)  # some may use list?
 
       lr_scheduler_kwargs[key] = value
 

--- a/train_db.py
+++ b/train_db.py
@@ -150,9 +150,7 @@ def train(args):
     args.stop_text_encoder_training = args.max_train_steps + 1                # do not stop until end
 
   # lr schedulerを用意する TODO gradient_accumulation_stepsの扱いが何かおかしいかもしれない。後で確認する
-  lr_scheduler = train_util.get_scheduler_fix(args.lr_scheduler, optimizer, num_warmup_steps=args.lr_warmup_steps,
-                                              num_training_steps=args.max_train_steps,
-                                              num_cycles=args.lr_scheduler_num_cycles, power=args.lr_scheduler_power)
+  lr_scheduler = train_util.get_scheduler_fix(args, optimizer)
 
   # 実験的機能：勾配も含めたfp16学習を行う　モデル全体をfp16にする
   if args.full_fp16:

--- a/train_network.py
+++ b/train_network.py
@@ -179,9 +179,7 @@ def train(args):
     print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
   # lr schedulerを用意する
-  lr_scheduler = train_util.get_scheduler_fix(args.lr_scheduler, optimizer, num_warmup_steps=args.lr_warmup_steps,
-                                              num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
-                                              num_cycles=args.lr_scheduler_num_cycles, power=args.lr_scheduler_power)
+  lr_scheduler = train_util.get_scheduler_fix(args, optimizer)
 
   # 実験的機能：勾配も含めたfp16学習を行う　モデル全体をfp16にする
   if args.full_fp16:

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -235,9 +235,7 @@ def train(args):
     print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
   # lr schedulerを用意する
-  lr_scheduler = train_util.get_scheduler_fix(args.lr_scheduler, optimizer, num_warmup_steps=args.lr_warmup_steps,
-                                              num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
-                                              num_cycles=args.lr_scheduler_num_cycles, power=args.lr_scheduler_power)
+  lr_scheduler = train_util.get_scheduler_fix(args, optimizer)
 
   # acceleratorがなんかよろしくやってくれるらしい
   text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(


### PR DESCRIPTION
- Add argument `lr_scheduler_type` and `lr_scheduler_args` to use lr_scheduler from another library

For example, to use `torch.optim.lr_scheduler.CosineAnnealingWarmRestarts` with t0=10 as lr_scheduler, we can just add 
`--lr_scheduler_type "CosineAnnealingWarmRestarts" --lr_scheduler_args "T_0=10"` or
`--lr_scheduler_type "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts" --lr_scheduler_args "T_0=10"`

I haven't fully tested it yet since some schedulers will use more complex inputs. 
I will open it as soon as I finish my test.

