### PR TITLE
Append sys path for import_module

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -134,6 +134,8 @@ def train(args):
     gc.collect()
 
   # prepare network
+  import sys
+  sys.path.append(os.path.dirname(__file__))
   print("import network module:", args.network_module)
   network_module = importlib.import_module(args.network_module)
 


### PR DESCRIPTION
This will be better if we run the scripts we do not run the training script from the current directory.  This is reasonable as some other projects will use this as a subfolder, such as https://github.com/ddPn08/kohya-sd-scripts-webui. I can not run the script without adding this.