### PR TITLE
Fix: simultaneous use of gradient_accumulation_steps and max_train_epochs

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -178,7 +178,7 @@ def train(args):
 
   # 学習ステップ数を計算する
   if args.max_train_epochs is not None:
-    args.max_train_steps = args.max_train_epochs * math.ceil(len(train_dataloader) / accelerator.num_processes)
+    args.max_train_steps = args.max_train_epochs * math.ceil(len(train_dataloader) / accelerator.num_processes / args.gradient_accumulation_steps)
     if is_main_process:
       print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 


### PR DESCRIPTION
 gradient_accumulation_steps を 2以上に指定した場合にmax_train_epochsが正しく設定されない問題の修正です。

現在、gradient_accumulation_stepsを指定するとmax_train_epochsに到達するためのstep数が (gradient_accumulation_steps)倍となってしまい、指定したepoch数で学習が終わらない状態です。
