### PR TITLE
Efficient Diffusion Training via Min-SNR Weighting Strategy

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1927,7 +1927,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         parser.add_argument(
             "--prior_loss_weight", type=float, default=1.0, help="loss weight for regularization images / 正則化画像のlossの重み"
         )
-
+    parser.add_argument("--min_snr_gamma", type=float, default=0, help="gamma for reducing the weight of high loss timesteps. Lower numbers have stronger effect. 5 is recommended by paper.")
 
 def verify_training_args(args: argparse.Namespace):
     if args.v_parameterization and not args.v2:


### PR DESCRIPTION
Implementation of https://arxiv.org/abs/2303.09556

Low noise timesteps produce outsized loss (as I discovered on my own here https://github.com/kohya-ss/sd-scripts/discussions/294), which can lead to training instability as single samples make large steps in a direction that may not be advantageous.

This paper introduces a scaling factor gamma, accessible with the new argument `--min_snr_gamma` that lowers the weight of these low timesteps by calculating the signal to noise ratio.

![image](https://user-images.githubusercontent.com/54461896/226486575-8581bad2-66d6-432e-8505-a52ca71f4ecc.png)
From the highest loss to lowest gamma=20,5,4,3,2,1

![image](https://user-images.githubusercontent.com/54461896/226487434-b58bd5f7-b0c0-455d-9121-2be40223a47c.png)
(Generated from the losses above)
