### PR TITLE
タグ数を徐々に増やしながら学習するオプションの追加、persistent_workersに関する軽微なバグ修正

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -62,6 +62,7 @@ def train(args):
         }
 
     blueprint = blueprint_generator.generate(user_config, args, tokenizer=tokenizer)
+    config_util.blueprint_args_conflict(args,blueprint)
     train_dataset_group = config_util.generate_dataset_group_by_blueprint(blueprint.dataset_group)
 
     if args.debug_dataset:
@@ -259,13 +260,13 @@ def train(args):
     for epoch in range(num_train_epochs):
         print(f"epoch {epoch+1}/{num_train_epochs}")
         train_dataset_group.set_current_epoch(epoch + 1)
+        train_dataset_group.set_current_step(global_step)
 
         for m in training_models:
             m.train()
 
         loss_total = 0
         for step, batch in enumerate(train_dataloader):
-            train_dataset_group.set_current_step(global_step)
             with accelerator.accumulate(training_models[0]):  # 複数モデルに対応していない模様だがとりあえずこうしておく
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -197,6 +197,9 @@ def train(args):
         args.max_train_steps = args.max_train_epochs * len(train_dataloader)
         print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
+    # データセット側にも学習ステップを送信
+    train_dataset_group.set_max_train_steps(args.max_train_steps)
+
     # lr schedulerを用意する
     lr_scheduler = train_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
 
@@ -263,6 +266,7 @@ def train(args):
         loss_total = 0
         for step, batch in enumerate(train_dataloader):
             with accelerator.accumulate(training_models[0]):  # 複数モデルに対応していない模様だがとりあえずこうしておく
+                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device)

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -265,8 +265,8 @@ def train(args):
 
         loss_total = 0
         for step, batch in enumerate(train_dataloader):
+            train_dataset_group.set_current_step(global_step)
             with accelerator.accumulate(training_models[0]):  # 複数モデルに対応していない模様だがとりあえずこうしておく
-                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device)

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -57,7 +57,7 @@ class BaseSubsetParams:
   caption_dropout_every_n_epochs: int = 0
   caption_tag_dropout_rate: float = 0.0
   token_warmup_min: int = 1
-  token_warmup_step: Union[float,int] = 0
+  token_warmup_step: float = 0
 
 @dataclass
 class DreamBoothSubsetParams(BaseSubsetParams):
@@ -140,7 +140,7 @@ class ConfigSanitizer:
     "shuffle_caption": bool,
     "keep_tokens": int,
     "token_warmup_min": int,
-    "token_warmup_step": Union[float,int],
+    "token_warmup_step": Any(float,int),
   }
   # DO means DropOut
   DO_SUBSET_ASCENDABLE_SCHEMA = {

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -497,6 +497,14 @@ def load_user_config(file: str) -> dict:
 
   return config
 
+def blueprint_args_conflict(args,blueprint:Blueprint):
+  # train_dataset_group.set_current_epoch()とtrain_dataset_group.set_current_step()がWorkerを生成するタイミングで適用される影響で、persistent_workers有効時はずっと一定になってしまうため無効にする
+  for b in blueprint.dataset_group.datasets:
+      for t in b.subsets:
+          if args.persistent_data_loader_workers and (t.params.caption_dropout_every_n_epochs > 0 or t.params.token_warmup_step>0):
+              print("Warning: %s: caption_dropout_every_n_epochs and token_warmup_step is ignored because --persistent_data_loader_workers option is used / --persistent_data_loader_workersオプションが使われているため、caption_dropout_every_n_epochs及びtoken_warmup_stepは無視されます。"%(t.params.image_dir))
+              t.params.caption_dropout_every_n_epochs = 0
+              t.params.token_warmup_step = 0
 
 # for config test
 if __name__ == "__main__":

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -56,6 +56,8 @@ class BaseSubsetParams:
   caption_dropout_rate: float = 0.0
   caption_dropout_every_n_epochs: int = 0
   caption_tag_dropout_rate: float = 0.0
+  token_warmup_min: int = 1
+  token_warmup_step: Union[float,int] = 0
 
 @dataclass
 class DreamBoothSubsetParams(BaseSubsetParams):
@@ -137,6 +139,8 @@ class ConfigSanitizer:
     "random_crop": bool,
     "shuffle_caption": bool,
     "keep_tokens": int,
+    "token_warmup_min": int,
+    "token_warmup_step": Union[float,int],
   }
   # DO means DropOut
   DO_SUBSET_ASCENDABLE_SCHEMA = {
@@ -406,6 +410,8 @@ def generate_dataset_group_by_blueprint(dataset_group_blueprint: DatasetGroupBlu
           flip_aug: {subset.flip_aug}
           face_crop_aug_range: {subset.face_crop_aug_range}
           random_crop: {subset.random_crop}
+          token_warmup_min: {subset.token_warmup_min},
+          token_warmup_step: {subset.token_warmup_step},
       """), "  ")
 
       if is_dreambooth:

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -502,9 +502,8 @@ def blueprint_args_conflict(args,blueprint:Blueprint):
   for b in blueprint.dataset_group.datasets:
       for t in b.subsets:
           if args.persistent_data_loader_workers and (t.params.caption_dropout_every_n_epochs > 0 or t.params.token_warmup_step>0):
-              print("Warning: %s: caption_dropout_every_n_epochs and token_warmup_step is ignored because --persistent_data_loader_workers option is used / --persistent_data_loader_workersオプションが使われているため、caption_dropout_every_n_epochs及びtoken_warmup_stepは無視されます。"%(t.params.image_dir))
-              t.params.caption_dropout_every_n_epochs = 0
-              t.params.token_warmup_step = 0
+              print("Warning: %s: --persistent_data_loader_workers option is disabled because it conflicts with caption_dropout_every_n_epochs and token_wormup_step. / caption_dropout_every_n_epochs及びtoken_warmup_stepと競合するため、--persistent_data_loader_workersオプションは無効になります。"%(t.params.image_dir))
+              args.persistent_data_loader_workers = False
 
 # for config test
 if __name__ == "__main__":

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2046,7 +2046,7 @@ def add_dataset_arguments(
     )
 
     parser.add_argument(
-        "--token_warmup_steps",
+        "--token_warmup_step",
         type=float,
         default=0,
         help="tag length reaches maximum on N steps (or N*max_train_steps if N<1) / N（N<1ならN*max_train_steps）ステップでタグ長が最大になる。デフォルトは0（最初から最大）",

--- a/train_db.py
+++ b/train_db.py
@@ -162,6 +162,9 @@ def train(args):
         args.max_train_steps = args.max_train_epochs * len(train_dataloader)
         print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
+    # データセット側にも学習ステップを送信
+    train_dataset_group.set_max_train_steps(args.max_train_steps)
+
     if args.stop_text_encoder_training is None:
         args.stop_text_encoder_training = args.max_train_steps + 1  # do not stop until end
 
@@ -246,6 +249,7 @@ def train(args):
                 text_encoder.requires_grad_(False)
 
             with accelerator.accumulate(unet):
+                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     # latentに変換
                     if cache_latents:

--- a/train_db.py
+++ b/train_db.py
@@ -57,6 +57,7 @@ def train(args):
         }
 
     blueprint = blueprint_generator.generate(user_config, args, tokenizer=tokenizer)
+    config_util.blueprint_args_conflict(args,blueprint)
     train_dataset_group = config_util.generate_dataset_group_by_blueprint(blueprint.dataset_group)
 
     if args.no_token_padding:
@@ -233,6 +234,7 @@ def train(args):
     for epoch in range(num_train_epochs):
         print(f"epoch {epoch+1}/{num_train_epochs}")
         train_dataset_group.set_current_epoch(epoch + 1)
+        train_dataset_group.set_current_step(global_step)
 
         # 指定したステップ数までText Encoderを学習する：epoch最初の状態
         unet.train()
@@ -241,7 +243,6 @@ def train(args):
             text_encoder.train()
 
         for step, batch in enumerate(train_dataloader):
-            train_dataset_group.set_current_step(global_step)
             # 指定したステップ数でText Encoderの学習を止める
             if global_step == args.stop_text_encoder_training:
                 print(f"stop text encoder training at step {global_step}")

--- a/train_db.py
+++ b/train_db.py
@@ -241,6 +241,7 @@ def train(args):
             text_encoder.train()
 
         for step, batch in enumerate(train_dataloader):
+            train_dataset_group.set_current_step(global_step)
             # 指定したステップ数でText Encoderの学習を止める
             if global_step == args.stop_text_encoder_training:
                 print(f"stop text encoder training at step {global_step}")
@@ -249,7 +250,6 @@ def train(args):
                 text_encoder.requires_grad_(False)
 
             with accelerator.accumulate(unet):
-                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     # latentに変換
                     if cache_latents:

--- a/train_network.py
+++ b/train_network.py
@@ -507,8 +507,8 @@ def train(args):
         network.on_epoch_start(text_encoder, unet)
 
         for step, batch in enumerate(train_dataloader):
+            train_dataset_group.set_current_step(global_step)
             with accelerator.accumulate(network):
-                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device)

--- a/train_network.py
+++ b/train_network.py
@@ -98,6 +98,7 @@ def train(args):
             }
 
     blueprint = blueprint_generator.generate(user_config, args, tokenizer=tokenizer)
+    config_util.blueprint_args_conflict(args,blueprint)
     train_dataset_group = config_util.generate_dataset_group_by_blueprint(blueprint.dataset_group)
 
     if args.debug_dataset:
@@ -501,13 +502,13 @@ def train(args):
         if is_main_process:
             print(f"epoch {epoch+1}/{num_train_epochs}")
         train_dataset_group.set_current_epoch(epoch + 1)
+        train_dataset_group.set_current_step(global_step)
 
         metadata["ss_epoch"] = str(epoch + 1)
 
         network.on_epoch_start(text_encoder, unet)
 
         for step, batch in enumerate(train_dataloader):
-            train_dataset_group.set_current_step(global_step)
             with accelerator.accumulate(network):
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:

--- a/train_network.py
+++ b/train_network.py
@@ -200,6 +200,9 @@ def train(args):
         if is_main_process:
             print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
+    # データセット側にも学習ステップを送信
+    train_dataset_group.set_max_train_steps(args.max_train_steps)
+
     # lr schedulerを用意する
     lr_scheduler = train_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
 
@@ -505,6 +508,7 @@ def train(args):
 
         for step, batch in enumerate(train_dataloader):
             with accelerator.accumulate(network):
+                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device)

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -340,8 +340,8 @@ def train(args):
 
         loss_total = 0
         for step, batch in enumerate(train_dataloader):
+            train_dataset_group.set_current_step(global_step)
             with accelerator.accumulate(text_encoder):
-                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device)

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -183,6 +183,7 @@ def train(args):
             }
 
     blueprint = blueprint_generator.generate(user_config, args, tokenizer=tokenizer)
+    config_util.blueprint_args_conflict(args,blueprint)
     train_dataset_group = config_util.generate_dataset_group_by_blueprint(blueprint.dataset_group)
 
     # make captions: tokenstring tokenstring1 tokenstring2 ...tokenstringn という文字列に書き換える超乱暴な実装
@@ -335,12 +336,12 @@ def train(args):
     for epoch in range(num_train_epochs):
         print(f"epoch {epoch+1}/{num_train_epochs}")
         train_dataset_group.set_current_epoch(epoch + 1)
+        train_dataset_group.set_current_step(global_step)
 
         text_encoder.train()
 
         loss_total = 0
         for step, batch in enumerate(train_dataloader):
-            train_dataset_group.set_current_step(global_step)
             with accelerator.accumulate(text_encoder):
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -260,6 +260,9 @@ def train(args):
         args.max_train_steps = args.max_train_epochs * len(train_dataloader)
         print(f"override steps. steps for {args.max_train_epochs} epochs is / 指定エポックまでのステップ数: {args.max_train_steps}")
 
+    # データセット側にも学習ステップを送信
+    train_dataset_group.set_max_train_steps(args.max_train_steps)
+
     # lr schedulerを用意する
     lr_scheduler = train_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
 
@@ -338,6 +341,7 @@ def train(args):
         loss_total = 0
         for step, batch in enumerate(train_dataloader):
             with accelerator.accumulate(text_encoder):
+                train_dataset_group.set_current_step(step + 1)
                 with torch.no_grad():
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device)


### PR DESCRIPTION
## token_warmup
token_warmup_minを基準として、token_warmup_stepになるまで徐々にタグ数を増やしながら学習させる実装です。どれだけ効果があるかは未知数ですが、学習したい要素以外のtokenへの影響が多少軽減されるはずです。

torch.utils.data.DataLoaderの関係でエポック毎にしか変更されないため、少ないエポック数だと正常に動作しない可能性があります。

## persistent_workersに関する軽微なバグ修正
persistent_workers使用時にcaption_dropout_every_n_epochsを使うと、エポック毎のワーカーのリセットがされない関係でset_current_epoch()が作用しなくなり、caption_dropout_every_n_epochsが使えなくなります(上記のtoken_warmupも同様)。

なので、競合時はargs.persistent_data_loader_workersをFalseに書き変えるようにしました。

思いつきの実装&修正なので、必要なければcloseしてもらって大丈夫です。