### PR TITLE
Reduce peak RAM usage

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2536,13 +2536,13 @@ def prepare_dtype(args: argparse.Namespace):
     return weight_dtype, save_dtype
 
 
-def load_target_model(args: argparse.Namespace, weight_dtype):
+def load_target_model(args: argparse.Namespace, weight_dtype, device='cpu'):
     name_or_path = args.pretrained_model_name_or_path
     name_or_path = os.readlink(name_or_path) if os.path.islink(name_or_path) else name_or_path
     load_stable_diffusion_format = os.path.isfile(name_or_path)  # determine SD or Diffusers
     if load_stable_diffusion_format:
         print("load StableDiffusion checkpoint")
-        text_encoder, vae, unet = model_util.load_models_from_stable_diffusion_checkpoint(args.v2, name_or_path)
+        text_encoder, vae, unet = model_util.load_models_from_stable_diffusion_checkpoint(args.v2, name_or_path, device)
     else:
         print("load Diffusers pretrained models")
         try:


### PR DESCRIPTION
These are the changes I had to make to have LoRA training work in the Kaggle T4 x 2 environment.

What this PR does:
* Sequentially loads the SD model for each GPU so the peak usage doesn't grow linearly with number of GPUs
* Directly load state dicts into the correct device

Haven't tested if it breaks other stuff.