### PR TITLE
LoRA レイヤー別学習率の実装、state_dict読み込みの際のdevice指定削除、typo修正

### DIFF
--- a/library/config_util.py
+++ b/library/config_util.py
@@ -445,7 +445,7 @@ def generate_dreambooth_subsets_config_by_subdirs(train_data_dir: Optional[str] 
     try:
       n_repeats = int(tokens[0])
     except ValueError as e:
-      print(f"ignore directory without repeats / 繰り返し回数のないディレクトリを無視します: {dir}")
+      print(f"ignore directory without repeats / 繰り返し回数のないディレクトリを無視します: {name}")
       return 0, ""
     caption_by_folder = '_'.join(tokens[1:])
     return n_repeats, caption_by_folder

--- a/library/model_util.py
+++ b/library/model_util.py
@@ -831,7 +831,7 @@ def is_safetensors(path):
   return os.path.splitext(path)[1].lower() == '.safetensors'
 
 
-def load_checkpoint_with_text_encoder_conversion(ckpt_path, device):
+def load_checkpoint_with_text_encoder_conversion(ckpt_path, device="cpu"):
   # text encoderの格納形式が違うモデルに対応する ('text_model'がない)
   TEXT_ENCODER_KEY_REPLACEMENTS = [
       ('cond_stage_model.transformer.embeddings.', 'cond_stage_model.transformer.text_model.embeddings.'),
@@ -866,7 +866,7 @@ def load_checkpoint_with_text_encoder_conversion(ckpt_path, device):
 
 # TODO dtype指定の動作が怪しいので確認する text_encoderを指定形式で作れるか未確認
 def load_models_from_stable_diffusion_checkpoint(v2, ckpt_path, device='cpu', dtype=None):
-  _, state_dict = load_checkpoint_with_text_encoder_conversion(ckpt_path, device)
+  _, state_dict = load_checkpoint_with_text_encoder_conversion(ckpt_path) # no need to specify device in loading state_dict
 
   # Convert the UNet2DConditionModel model.
   unet_config = create_unet_diffusers_config(v2)

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -441,7 +441,7 @@ class LoRANetwork(torch.nn.Module):
         def get_list(name) -> list[float]:
             import math 
             if name=="cosine":
-                return [math.cos(math.pi*(i/(max_len-1))/2) for i in range(max_len)]
+                return [math.sin(math.pi*(i/(max_len-1))/2) for i in reversed(range(max_len))]
             elif name=="sine":
                 return [math.sin(math.pi*(i/(max_len-1))/2) for i in range(max_len)]
             elif name=="linear":

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -202,7 +202,7 @@ def create_network(multiplier, network_dim, network_alpha, vae, text_encoder, un
         if "," in down_weight:
             down_weight = [float(s) for s in down_weight.split(",") if s]
 
-    network.set_stratified_lr_weight(up_weight,float(kwargs.get('mid_weight', 1.0)),down_weight,float(kwargs.get('lr_weight_threshold', 0.0)))
+    network.set_stratified_lr_weight(up_weight,float(kwargs.get('mid_weight', 1.0)),down_weight,float(kwargs.get('stratified_zero_threshold', 0.0)))
 
     return network
 

--- a/train_network.py
+++ b/train_network.py
@@ -191,7 +191,7 @@ def train(args):
     # 学習に必要なクラスを準備する
     print("prepare optimizer, data loader etc.")
 
-    trainable_params = network.prepare_optimizer_params(args.text_encoder_lr, args.unet_lr)
+    trainable_params = network.prepare_optimizer_params(args.text_encoder_lr, args.unet_lr, args.learning_rate)
     optimizer_name, optimizer_args, optimizer = train_util.get_optimizer(args, trainable_params)
 
     # dataloaderを準備する


### PR DESCRIPTION
# LoRA レイヤー別学習率の実装
`network_args`に`down_lr_weight`, `mid_lr_weight`, `up_lr_weight`の3つのオプションを用意します。指定された値と学習率の積を学習率とすることで、レイヤー毎に異なる学習率を適用します。また、weightが0のレイヤーはapplyしないように変更しています。現在実装してる引数は以下のようになります。
・down_lr_weight=0,0,0,0,0,1,1,1,1,1 (conv2d_3x3使用時)
・down_lr_weight=0,0.5,1 (conv2d_3x3未使用時)
・mid_lr_weight=0.5
・up_lr_weight=linear (0から1へと変化する。他にはsine, cosine, reverse_linear, zeros等)
・stratified_zero_threshold=0.1 (0.1以下のweightは0として扱う)

レイヤー構造は私自身があまり理解できていなかった為、以下のように階層化して適用しています(prefix等一部省略)。conv2d_3x3無効時はupとdownでそれぞれ3層、有効時は10層に分割しています。midは常に1層として扱います。

conv2d_3x3無効時
```
(1)down_blocks_0_attentions_{0,1}
(2)down_blocks_1_attentions_{0,1}
(3)down_blocks_2_attentions_{0,1}

mid_block_attentions_0
mid_block_resnets_{0,1}

(1)up_blocks_1_attentions_{0,1,2}
(2)up_blocks_2_attentions_{0,1,2}
(3)up_blocks_3_attentions_{0,1,2}
```

conv2d_3x3有効時
```
(1)down_blocks_0_resnets_{0,1}
(2)down_blocks_0_downsamplers
(3)down_blocks_0_attentions_{0,1}
(4)down_blocks_1_resnets_{0,1}
(5)down_blocks_1_downsamplers
(6)down_blocks_1_attentions_{0,1}
(7)down_blocks_2_resnets_{0,1}
(8)down_blocks_2_downsamplers
(9)down_blocks_2_attentions_{0,1}
(10)down_blocks_3_resnets_{0,1}

mid_block_attentions_0
mid_block_resnets_{0,1}

(1)up_blocks_0_resnets_{0,1,2}
(2)up_blocks_0_upsamplers
(3)up_blocks_1_attentions_{0,1,2}
(4)up_blocks_1_resnets_{0,1,2}
(5)up_blocks_1_upsamplers
(6)up_blocks_2_attentions_{0,1,2}
(7)up_blocks_2_resnets_{0,1,2}
(8)up_blocks_2_upsamplers
(9)up_blocks_3_attentions_{0,1,2}
(10)up_blocks_3_resnets_{0,1,2}
```

これによって、学習したい範囲(細かいディテールの部分、全体の色の塗り等)を限定して学習することが出来るようになります。  
例えば、`down_lr_weight=cosine mid_lr_weight=0 up_lr_weight=sine` とすればモデルの浅い層をメインに学習させることができます。
逆に、`down_lr_weight=sine mid_lr_weight=1 up_lr_weight=cosine` とすればモデルの深い層をメインに学習させられます。

以下に私が試した結果を示します。制服を着せたキャラクターをCM3D2で用意して、"test"というトークンに紐づくように800step程度学習させたLoRA(dim: 64, conv_dim:1, lr: 1e-4, text_encoder_lr: 5e-5)です。  
![xyz_grid-0018-1204636062](https://user-images.githubusercontent.com/40634644/228927407-4b4077c7-b2a9-4902-b239-c42e717260a2.png)
(down_lr_weight:mid_lr_weight:up_lr_weight)という表記で書くと左から順に
デフォルト(1:1:1)、sine:1:cosine、1:0:1、cosine:0:sine、LoRA無しです。

誤差レベルかもしれませんが、デフォルトでは3Dゲームっぽい画像が生成されるようになる(ゲームのスクショを使ってるため)のに対し、深い層のlrを下げた方はデフォルトに比べて色の塗り方が維持されているように思えます。

# state_dict読み込みの際のdevice指定削除
更新した際に`safetensors.torch.load_file`が`Exception: device cuda is invalid`というエラーを返すようになっていたのでその修正です。

他の環境では試せていませんが、私の環境で学習ができなくなっていたことと「`state_dict`読み込み時は`device`を指定する必要が無いだろう」という判断から`state_dict`読み込みの際の`device`の指定を外しています。モデルに`state_dict`を読み込む際の`.to(device)`等はそのままなので、特に問題ないかと思われます(私の環境では問題なく動作しています)。

# typo修正
`繰り返し回数のないディレクトリを無視します`の表示がバグっていたので修正です。