### PR TITLE
Fixes

### DIFF
--- a/networks/lora_interrogator.py
+++ b/networks/lora_interrogator.py
@@ -2,6 +2,7 @@
 
 from tqdm import tqdm
 from library import model_util
+import library.train_util as train_util
 import argparse
 from transformers import CLIPTokenizer
 import torch
@@ -18,14 +19,14 @@ DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 def interrogate(args):
   # いろいろ準備する
   print(f"loading SD model: {args.sd_model}")
-  text_encoder, vae, unet = model_util.load_models_from_stable_diffusion_checkpoint(args.v2, args.sd_model)
+  text_encoder, vae, unet, _ = train_util.load_target_model(args, args.sd_model, DEVICE)
 
   print(f"loading LoRA: {args.model}")
-  network = lora.create_network_from_weights(1.0, args.model, vae, text_encoder, unet)
+  network, weights_sd = lora.create_network_from_weights(1.0, args.model, vae, text_encoder, unet)
 
   # text encoder向けの重みがあるかチェックする：本当はlora側でやるのがいい
   has_te_weight = False
-  for key in network.weights_sd.keys():
+  for key in weights_sd.keys():
     if 'lora_te' in key:
       has_te_weight = True
       break


### PR DESCRIPTION
This fixes some problems in the lora interrogator. However I'm facing an stacktrace error when I run the script, I don't know how to resolve it so I will leave here:
```
Traceback (most recent call last):
  File "D:\GitHub\sd-scripts\networks\lora_interrogator.py", line 137, in <module>
    interrogate(args)
  File "D:\GitHub\sd-scripts\networks\lora_interrogator.py", line 95, in interrogate
    lora_embs = get_all_embeddings(text_encoder)
  File "D:\GitHub\sd-scripts\networks\lora_interrogator.py", line 76, in get_all_embeddings
    encoder_hidden_states = text_encoder(batch)[0]
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
  File "D:\compiler\Python\lib\site-packages\transformers\models\clip\modeling_clip.py", line 816, in forward
    return self.text_model(
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "D:\compiler\Python\lib\site-packages\transformers\models\clip\modeling_clip.py", line 725, in forward
    encoder_outputs = self.encoder(
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "D:\compiler\Python\lib\site-packages\transformers\models\clip\modeling_clip.py", line 654, in forward
    layer_outputs = encoder_layer(
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "D:\compiler\Python\lib\site-packages\transformers\models\clip\modeling_clip.py", line 383, in forward
    hidden_states, attn_weights = self.self_attn(
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "D:\compiler\Python\lib\site-packages\transformers\models\clip\modeling_clip.py", line 272, in forward
    query_states = self.q_proj(hidden_states) * self.scale
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "D:\GitHub\sd-scripts\networks\lora.py", line 105, in forward
    return self.org_forward(x) + self.lora_up(self.lora_down(x)) * self.multiplier * self.scale
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "D:\compiler\Python\lib\site-packages\torch\nn\modules\linear.py", line 114, in forward
    return F.linear(input, self.weight, self.bias)
RuntimeError: expected scalar type Half but found Float
```