### PR TITLE
Add WandB logging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 *.egg-info
 build
 .vscode
+wandb

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -260,7 +260,7 @@ def train(args):
     )
 
     if accelerator.is_main_process:
-        accelerator.init_trackers("finetuning")
+        accelerator.init_trackers("finetuning" if args.log_tracker_name is None else args.log_tracker_name)
 
     for epoch in range(num_train_epochs):
         print(f"epoch {epoch+1}/{num_train_epochs}")

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2745,15 +2745,19 @@ def prepare_accelerator(args: argparse.Namespace):
         log_prefix = "" if args.log_prefix is None else args.log_prefix
         logging_dir = args.logging_dir + "/" + log_prefix + time.strftime("%Y%m%d%H%M%S", time.localtime())
 
-    log_with = "tensorboard" if args.log_with is None else args.log_with
-    if log_with in ["wandb", "all"]:
-        if logging_dir is not None:
-            os.makedirs(logging_dir)
-            os.environ["WANDB_DIR"] = logging_dir
-        try:
-            import wandb
-        except ImportError:
-            raise ImportError("No wandb / wandb がインストールされていないようです")
+    if args.log_with is not None:
+        log_with = "tensorboard" if args.log_with is None else args.log_with
+        if log_with in ["tensorboard", "all"]:
+            if logging_dir is None:
+                raise ValueError("logging_dir is required when log_with is tensorboard / Tensorboardを使う場合、logging_dirを指定してください")
+        if log_with in ["wandb", "all"]:
+            try:
+                import wandb
+            except ImportError:
+                raise ImportError("No wandb / wandb がインストールされていないようです")
+            if logging_dir is not None:
+                os.makedirs(logging_dir)
+                os.environ["WANDB_DIR"] = logging_dir
 
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2740,17 +2740,20 @@ def load_tokenizer(args: argparse.Namespace):
 
 def prepare_accelerator(args: argparse.Namespace):
     if args.logging_dir is None:
-        log_with = None
         logging_dir = None
     else:
-        log_with = "tensorboard" if args.log_with is None else args.log_with
-        if log_with in ["wandb", "all"]:
-            try:
-                import wandb
-            except ImportError:
-                raise ImportError("No wandb / wandb がインストールされていないようです")
         log_prefix = "" if args.log_prefix is None else args.log_prefix
         logging_dir = args.logging_dir + "/" + log_prefix + time.strftime("%Y%m%d%H%M%S", time.localtime())
+
+    log_with = "tensorboard" if args.log_with is None else args.log_with
+    if log_with in ["wandb", "all"]:
+        if logging_dir is not None:
+            os.makedirs(logging_dir)
+            os.environ["WANDB_DIR"] = logging_dir
+        try:
+            import wandb
+        except ImportError:
+            raise ImportError("No wandb / wandb がインストールされていないようです")
 
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,

--- a/train_db.py
+++ b/train_db.py
@@ -231,7 +231,7 @@ def train(args):
     )
 
     if accelerator.is_main_process:
-        accelerator.init_trackers("dreambooth")
+        accelerator.init_trackers("dreambooth" if args.log_tracker_name is None else args.log_tracker_name)
 
     loss_list = []
     loss_total = 0.0

--- a/train_network.py
+++ b/train_network.py
@@ -538,7 +538,7 @@ def train(args):
         beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000, clip_sample=False
     )
     if accelerator.is_main_process:
-        accelerator.init_trackers("network_train")
+        accelerator.init_trackers("network_train" if args.log_tracker_name is None else args.log_tracker_name)
 
     loss_list = []
     loss_total = 0.0

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -337,7 +337,7 @@ def train(args):
     )
 
     if accelerator.is_main_process:
-        accelerator.init_trackers("textual_inversion")
+        accelerator.init_trackers("textual_inversion" if args.log_tracker_name is None else args.log_tracker_name)
 
     for epoch in range(num_train_epochs):
         print(f"epoch {epoch+1}/{num_train_epochs}")

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -371,7 +371,7 @@ def train(args):
     )
 
     if accelerator.is_main_process:
-        accelerator.init_trackers("textual_inversion")
+        accelerator.init_trackers("textual_inversion" if args.log_tracker_name is None else args.log_tracker_name)
 
     for epoch in range(num_train_epochs):
         print(f"epoch {epoch+1}/{num_train_epochs}")


### PR DESCRIPTION
関連 #418 

WandB でログを取得するオプションを追加しました。利用するには事前に `pip install wandb` で wandb のインストールと `wandb login` で必要になります。

以下の引数を追加しました。

- `--log_with`: 使用するログ取得ツールで、現在は `tensorboard`、`wandb`、`all` が選択できます。`all` ではすべてを同時に利用できます。指定されなかった場合は従来どおり tensorboard が使用されます。
- `--log_tracker_name`: WandB で表示されるプロジェクト名(トラッカー名)を指定できます。指定されなかった場合は、`textual_inversion` や `dreambooth` などの学習するものの名前が使われます。(`log_prefix` は wandb では適用されません)

`log_with` で wandb が有効のときに `logging_dir` が指定されなかった場合は、実行ディレクトリに `wandb` ディレクトリが作成されてそこに保存されます。そのため `.gitignore` に wandb ディレクトリを追加しました。

![image](https://user-images.githubusercontent.com/60182057/233195702-8cc6d05d-8e85-4a47-82d9-75f9ee070764.png)

`log_tracker_name` は全ての学習スクリプト上の `accelerate.init_trackers()` で設定しているのですが、ログに関するコードが増えたら、ログ用に何かの関数を用意してそこで設定するようにしたほうがよいかもしれないです...
