### PR TITLE
Refixed --debug_dataset option to work in non-Windows environments

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1445,8 +1445,8 @@ def debug_dataset(train_dataset, show_input_ids=False):
                     im = im[:, :, ::-1]  # RGB -> BGR (OpenCV)
                     if os.name == "nt":  # only windows
                         cv2.imshow("img", im)
-                    k = cv2.waitKey()
-                    cv2.destroyAllWindows()
+                        k = cv2.waitKey()
+                        cv2.destroyAllWindows()
                     if k == 27 or k == ord("s") or k == ord("e"):
                         break
             steps += 1


### PR DESCRIPTION
#144 で修正した箇所の追加修正です。
おそらくlibgtk2がインストールされていない環境でcv2.waitKey() および cv2.destroyAllWindows() がエラーを返すので除外しました。

imshowで開かれたウィンドウへの操作かと思いますので、おそらく問題ないはずです。

確認環境
Ubuntu 20.04.4 LTS 
Python 3.10.11