### PR TITLE
fix no logging command line arg

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2761,6 +2761,8 @@ def prepare_accelerator(args: argparse.Namespace):
             if logging_dir is not None:
                 os.makedirs(logging_dir, exist_ok=True)
                 os.environ["WANDB_DIR"] = logging_dir
+    else:
+        log_with = None
 
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,


### PR DESCRIPTION
Currently, if you don't specify `--log_with` as  command line arg, the `log_with` variable is referenced before assignment as it is only created if the command line arg is specified. (see #432)