### PR TITLE
Add new args to pass API key for wandb

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2080,6 +2080,12 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--log_tracker_name", type=str, default=None, help="name of tracker to use for logging, default is script-specific default name / ログ出力に使用するtrackerの名前、省略時はスクリプトごとのデフォルト名"
     )
     parser.add_argument(
+        "--wandb_api_key", 
+        type=str, 
+        default=None, 
+        help="specify WandB API key to log in before starting training (optional)."
+    )
+    parser.add_argument(
         "--noise_offset",
         type=float,
         default=None,
@@ -2299,7 +2305,7 @@ def read_config_from_file(args: argparse.Namespace, parser: argparse.ArgumentPar
         args_dict = vars(args)
 
         # remove unnecessary keys
-        for key in ["config_file", "output_config"]:
+        for key in ["config_file", "output_config", "wandb_api_key"]:
             if key in args_dict:
                 del args_dict[key]
 
@@ -2761,6 +2767,8 @@ def prepare_accelerator(args: argparse.Namespace):
             if logging_dir is not None:
                 os.makedirs(logging_dir, exist_ok=True)
                 os.environ["WANDB_DIR"] = logging_dir
+            if args.wandb_api_key is not None:
+                wandb.login(key=args.wandb_api_key)
 
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,


### PR DESCRIPTION
Hi! Thanks for implementing wandb.

But I have encountered a problem while using wandb instead of tensorboard. I thought the training had already begun, so I left the notebook for 15 minutes. However, I realized that the training had not yet started because there was an input function asking the user to input the API key for wandb.

It would be great if there was a way to pass the API key before the training starts, so I create this PR.

1. Added `--wandb_api_key <str>` to pass API key before training.
2. Removed `wandb_api_key` key when saving args with `--output_config` for safety purpose.

Thanks!

Before / without `--wandb_api_key`
![image](https://user-images.githubusercontent.com/50163983/233775953-360acae8-230e-4484-9fe5-7d4598782686.png)

After / with `--wandb_api_key`
![image](https://user-images.githubusercontent.com/50163983/233775986-7c7c47de-4aa8-437d-a723-01ee4b9637ca.png)
![image](https://user-images.githubusercontent.com/50163983/233776012-48aa1381-5c99-4e9b-8de0-9874c54a7c34.png)

