### PR TITLE
update parser format to match a global pattern

### DIFF
--- a/finetune/tag_images_by_wd14_tagger.py
+++ b/finetune/tag_images_by_wd14_tagger.py
@@ -224,7 +224,7 @@ def main(args):
     print("done!")
 
 
-if __name__ == "__main__":
+def setup_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("train_data_dir", type=str, help="directory for train images / 学習画像データのディレクトリ")
     parser.add_argument(
@@ -284,6 +284,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("--frequency_tags", action="store_true", help="Show frequency of tags for images / 画像ごとのタグの出現頻度を表示する")
 
+    return parser
+
+if __name__ == "__main__":
+    parser = setup_parser()
+    
     args = parser.parse_args()
 
     # スペルミスしていたオプションを復元する


### PR DESCRIPTION
I am using a [ webui plugin](https://github.com/ddPn08/kohya-sd-scripts-webui) for these scripts. The project must read your scripts arguments to generate correct UI. 
![image](https://user-images.githubusercontent.com/74481573/234572667-11531057-59b7-4782-b2c9-94d0e0beab63.png)

Could you accept this change to match a global pattern for parser argument as all your other script's parsers are  set up by this format using `setup_parser` function?