### PR TITLE
Add LoRA training supports for diffusers version from diffuser==0.10.x to latest 0.16.1

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1849,12 +1849,11 @@ def replace_unet_cross_attn_to_xformers(unet):
         out = self.to_out[1](out)
         return out
 
-    if hasattr(diffusers.models.attention, "CrossAttention") and \
+    if diffusers.__version__ >= "0.12":
+        unet.enable_xformers_memory_efficient_attention(attention_op=xformers.ops.MemoryEfficientAttentionFlashAttentionOp)
+    elif hasattr(diffusers.models.attention, "CrossAttention") and \
         hasattr(diffusers.models.attention.CrossAttention, "forward"):
         diffusers.models.attention.CrossAttention.forward = forward_xformers
-    elif hasattr(unet, "enable_xformers_memory_efficient_attention"):
-        unet.enable_xformers_memory_efficient_attention(attention_op=xformers.ops.MemoryEfficientAttentionFlashAttentionOp)
-        print(unet.enable_xformers_memory_efficient_attention())
     else:
         print('Do nothing...')
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1849,13 +1849,13 @@ def replace_unet_cross_attn_to_xformers(unet):
         out = self.to_out[1](out)
         return out
 
-    if diffusers.__version__ >= "0.12":
-        unet.enable_xformers_memory_efficient_attention(attention_op=xformers.ops.MemoryEfficientAttentionFlashAttentionOp)
+    print("diffusers version:", diffusers.__version__)
+    if diffusers.__version__ >= "0.11.0":
+        # let xformer to decide witch ops is more suitable, reference _dispatch_fwd in xformers.ops
+        unet.enable_xformers_memory_efficient_attention()
     elif hasattr(diffusers.models.attention, "CrossAttention") and \
         hasattr(diffusers.models.attention.CrossAttention, "forward"):
         diffusers.models.attention.CrossAttention.forward = forward_xformers
-    else:
-        print('Do nothing...')
 
 
 # endregion

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1849,7 +1849,6 @@ def replace_unet_cross_attn_to_xformers(unet):
         out = self.to_out[1](out)
         return out
 
-    print( hasattr(unet, "enable_xformers_memory_efficient_attention"))
     if hasattr(diffusers.models.attention, "CrossAttention") and \
         hasattr(diffusers.models.attention.CrossAttention, "forward"):
         diffusers.models.attention.CrossAttention.forward = forward_xformers

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -605,9 +605,9 @@ def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weigh
 
 class LoRANetwork(torch.nn.Module):
     NUM_OF_BLOCKS = 12  # フルモデル相当でのup,downの層の数
-
+    import diffusers
     # is it possible to apply conv_in and conv_out? -> yes, newer LoCon supports it (^^;)
-    UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel", "Attention"]
+    UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel", "Attention"] if diffusers.__version__ < "0.15.0" else ["Transformer2DModel"]
     UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
     TEXT_ENCODER_TARGET_REPLACE_MODULE = ["CLIPAttention", "CLIPMLP"]
     LORA_PREFIX_UNET = "lora_unet"


### PR DESCRIPTION
majorly 2 things have been changed since v0.10
1, xformers op injection has been handled by diffusers nicely, after v0.10, and if using the latest 0.16.x the memory consumption is no longer any big difference in regardless turn on/off the xformers option

2, the LoRA create_network function make the network layer duplicated in the latest lora version.

Please read the details in the code change.
Thank you for a great job