### PR TITLE
fix pynoise code bug

### DIFF
--- a/library/custom_train_functions.py
+++ b/library/custom_train_functions.py
@@ -347,7 +347,7 @@ def get_weighted_text_embeddings(
 
 # https://wandb.ai/johnowhitaker/multires_noise/reports/Multi-Resolution-Noise-for-Diffusion-Model-Training--VmlldzozNjYyOTU2
 def pyramid_noise_like(noise, device, iterations=6, discount=0.1):
-    b, c, w, h = noise.shape
+    b, c, w, h = noise.shape # EDIT: w and h get over-written, rename for a different variant!
     u = torch.nn.Upsample(size=(w, h), mode="bilinear").to(device)
     for i in range(iterations):
         r = random.random() * 2 + 2  # Rather than always going 2x,

--- a/library/custom_train_functions.py
+++ b/library/custom_train_functions.py
@@ -346,14 +346,14 @@ def get_weighted_text_embeddings(
 
 
 # https://wandb.ai/johnowhitaker/multires_noise/reports/Multi-Resolution-Noise-for-Diffusion-Model-Training--VmlldzozNjYyOTU2
-def pyramid_noise_like(noise, device, iterations=6, discount=0.3):
+def pyramid_noise_like(noise, device, iterations=6, discount=0.6):
     b, c, w, h = noise.shape
     u = torch.nn.Upsample(size=(w, h), mode="bilinear").to(device)
     for i in range(iterations):
         r = random.random() * 2 + 2  # Rather than always going 2x,
-        w, h = max(1, int(w / (r**i))), max(1, int(h / (r**i)))
-        noise += u(torch.randn(b, c, w, h).to(device)) * discount**i
-        if w == 1 or h == 1:
+        wn, hn = max(1, int(w / (r**i))), max(1, int(h / (r**i)))
+        noise += u(torch.randn(b, c, wn, hn).to(device)) * discount**i
+        if wn == 1 or hn == 1:
             break  # Lowest resolution is 1x1
     return noise / noise.std()  # Scaled back to roughly unit variance
 

--- a/library/custom_train_functions.py
+++ b/library/custom_train_functions.py
@@ -346,7 +346,7 @@ def get_weighted_text_embeddings(
 
 
 # https://wandb.ai/johnowhitaker/multires_noise/reports/Multi-Resolution-Noise-for-Diffusion-Model-Training--VmlldzozNjYyOTU2
-def pyramid_noise_like(noise, device, iterations=6, discount=0.6):
+def pyramid_noise_like(noise, device, iterations=6, discount=0.1):
     b, c, w, h = noise.shape
     u = torch.nn.Upsample(size=(w, h), mode="bilinear").to(device)
     for i in range(iterations):


### PR DESCRIPTION
I discussed pynoise with my friend, and he pointed out a coding bug in it. After the loop starts, w and h will be overwritten, requiring renaming new variable. Upon his testing, this issue indeed exists.

Before↓
![image](https://user-images.githubusercontent.com/8085926/237042425-7e81fb80-6427-40e6-b648-57551058d109.png)

After↓
![image](https://user-images.githubusercontent.com/8085926/237042497-75ae5440-2c32-471d-ad3e-247a720ae2aa.png)

I consulted with the author, and he agreed that the revised version better reflects the effects mentioned in the article, even though the original version also had good results. He has updated the article and added new notes, so I am submitting this new code to better align with the intended effect.

we can keep old code in a variant,too.