### PR TITLE
TOML support for sample prompt

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3303,6 +3303,9 @@ def sample_images(
         with open(args.sample_prompts, 'r') as f:
             data = toml.load(f)
         prompts = [dict(**data['prompt'], **subset) for subset in data['prompt']['subset']]
+    elif args.sample_prompts.endswith('.json'):
+        with open(args.sample_prompts, 'r') as f:
+            prompts = json.load(f)
     
     # schedulerを用意する
     sched_init_args = {}

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3291,9 +3291,19 @@ def sample_images(
     vae.to(device)
 
     # read prompts
-    with open(args.sample_prompts, "rt", encoding="utf-8") as f:
-        prompts = f.readlines()
 
+    # with open(args.sample_prompts, "rt", encoding="utf-8") as f:
+    #     prompts = f.readlines()
+
+    if args.sample_prompts.endswith('.txt'):
+        with open(args.sample_prompts, 'r') as f:
+            lines = f.readlines()
+        prompts = [line.strip() for line in lines if len(line.strip()) > 0 and line[0] != "#"]
+    elif args.sample_prompts.endswith('.toml'):
+        with open(args.sample_prompts, 'r') as f:
+            data = toml.load(f)
+        prompts = [dict(**data['prompt'], **subset) for subset in data['prompt']['subset']]
+    
     # schedulerを用意する
     sched_init_args = {}
     if args.sample_sampler == "ddim":
@@ -3362,53 +3372,63 @@ def sample_images(
             for i, prompt in enumerate(prompts):
                 if not accelerator.is_main_process:
                     continue
-                prompt = prompt.strip()
-                if len(prompt) == 0 or prompt[0] == "#":
-                    continue
+            
+                if isinstance(prompt, dict):
+                    negative_prompt = prompt.get("negative_prompt")
+                    sample_steps = prompt.get("sample_steps", 30)
+                    width = prompt.get("width", 512)
+                    height = prompt.get("height", 512)
+                    scale = prompt.get("scale", 7.5)
+                    seed = prompt.get("seed")
+                    prompt = prompt.get("prompt")
+                else:               
+                    # prompt = prompt.strip()
+                    # if len(prompt) == 0 or prompt[0] == "#":
+                    #     continue
 
-                # subset of gen_img_diffusers
-                prompt_args = prompt.split(" --")
-                prompt = prompt_args[0]
-                negative_prompt = None
-                sample_steps = 30
-                width = height = 512
-                scale = 7.5
-                seed = None
-                for parg in prompt_args:
-                    try:
-                        m = re.match(r"w (\d+)", parg, re.IGNORECASE)
-                        if m:
-                            width = int(m.group(1))
-                            continue
+                    # subset of gen_img_diffusers
+                    prompt_args = prompt.split(" --")
+                    prompt = prompt_args[0]
+                    negative_prompt = None
+                    sample_steps = 30
+                    width = height = 512
+                    scale = 7.5
+                    seed = None
+                    for parg in prompt_args:
+                        try:
+                            m = re.match(r"w (\d+)", parg, re.IGNORECASE)
+                            if m:
+                                width = int(m.group(1))
+                                continue
 
-                        m = re.match(r"h (\d+)", parg, re.IGNORECASE)
-                        if m:
-                            height = int(m.group(1))
-                            continue
+                            m = re.match(r"h (\d+)", parg, re.IGNORECASE)
+                            if m:
+                                height = int(m.group(1))
+                                continue
 
-                        m = re.match(r"d (\d+)", parg, re.IGNORECASE)
-                        if m:
-                            seed = int(m.group(1))
-                            continue
+                            m = re.match(r"d (\d+)", parg, re.IGNORECASE)
+                            if m:
+                                seed = int(m.group(1))
+                                continue
 
-                        m = re.match(r"s (\d+)", parg, re.IGNORECASE)
-                        if m:  # steps
-                            sample_steps = max(1, min(1000, int(m.group(1))))
-                            continue
+                            m = re.match(r"s (\d+)", parg, re.IGNORECASE)
+                            if m:  # steps
+                                sample_steps = max(1, min(1000, int(m.group(1))))
+                                continue
 
-                        m = re.match(r"l ([\d\.]+)", parg, re.IGNORECASE)
-                        if m:  # scale
-                            scale = float(m.group(1))
-                            continue
+                            m = re.match(r"l ([\d\.]+)", parg, re.IGNORECASE)
+                            if m:  # scale
+                                scale = float(m.group(1))
+                                continue
 
-                        m = re.match(r"n (.+)", parg, re.IGNORECASE)
-                        if m:  # negative prompt
-                            negative_prompt = m.group(1)
-                            continue
+                            m = re.match(r"n (.+)", parg, re.IGNORECASE)
+                            if m:  # negative prompt
+                                negative_prompt = m.group(1)
+                                continue
 
-                    except ValueError as ex:
-                        print(f"Exception in parsing / 解析エラー: {parg}")
-                        print(ex)
+                        except ValueError as ex:
+                            print(f"Exception in parsing / 解析エラー: {parg}")
+                            print(ex)
 
                 if seed is not None:
                     torch.manual_seed(seed)


### PR DESCRIPTION
Hi, I want to propose small changes for loading `args.sample_prompt`. I added `.toml` support so we can easily assign the sample prompt parameter to each key instead of putting all parameters in one line (using `.txt`). The sample prompt parameter is also more readable and easy to maintain. Not only that, we don't need to set the same parameter again because I borrowed the `dataset_config` approach by using `[[prompt.subset]]` to store additional parameters.

An example of `sample_prompt.toml` is as follows:

```toml
[prompt]
negative_prompt = "(worst quality, low quality:1.4)"
scale = 7
sample_steps = 20
width = 512
height = 768

[[prompt.subset]]
prompt = "masterpiece, best quality, masterpiece, best quality, solo, looking at viewer, short hair, bangs, red eyes, gloves, 1boy, holding, hair between eyes, closed mouth, upper body, weapon, male focus, red hair, black gloves, belt, sword, cape, holding weapon, armor, fur trim, holding sword, red background, red cape"

[[prompt.subset]]
prompt = "masterpiece, best quality, 1girl, solo, long hair, looking at viewer, smile, bangs, blue eyes, dress, ribbon, holding, bare shoulders, blue hair, flower, frills, teeth, sleeveless, hand up, signature, white dress, grin, red ribbon, blue sky, petals, neck ribbon, floating hair, sleeveless dress, blue background, light particles, blue theme, multicolored eyes, yellow flower, holding flower, orange flower, orange ribbon"

[[prompt.subset]]
prompt = "masterpiece, best quality, 1girl, solo, long hair, breasts, looking at viewer, smile, bangs, blue eyes, skirt, red eyes, thighhighs, holding, jewelry, medium breasts, very long hair, blue hair, weapon, braid, red hair, multicolored hair, sword, cape, holding weapon, armor, two-tone hair, thigh strap, heterochromia, holding sword, tiara, black background, crossed bangs, crown braid, split-color hair"
```

We can also set prompt into different resolution or using a different sampler for each prompt by putting important parameters to [[prompt.subset]].

Example:
```toml
[prompt]
negative_prompt = "(worst quality, low quality:1.4)"
scale = 7
sample_steps = 20

[[prompt.subset]]
prompt = "a dog"
width = 512
height = 768
seed = 1337

[[prompt.subset]]
prompt = "a cat"
width = 1024
height = 768
```

I also added `.json` support in the latest commit. 

Thank you 
