### PR TITLE
Update make_captions.py

### DIFF
--- a/finetune/make_captions.py
+++ b/finetune/make_captions.py
@@ -3,6 +3,7 @@ import glob
 import os
 import json
 import random
+import sys
 
 from pathlib import Path
 from PIL import Image
@@ -11,6 +12,7 @@ import numpy as np
 import torch
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
+sys.path.append(os.path.dirname(__file__))
 from blip.blip import blip_decoder
 import library.train_util as train_util
 


### PR DESCRIPTION
Append sys path for make_captions.py to load blip module in the same folder to fix the error when you don't run this script under the folder.

I run this script with [ddPn08/kohya-sd-scripts-webui
](https://github.com/ddPn08/kohya-sd-scripts-webui),and it got error 
```python
from blip.blip import blip_decoder
ModuleNotFoundError: No module named 'blip'
```

I update this script and it can be fixed

