### PR TITLE
Multi-GPU (DDP and deepspeed) fixes

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -148,10 +148,10 @@ def train(args):
         train_util.replace_unet_modules(unet, args.mem_eff_attn, args.xformers)
 
     # 学習を準備する
+    vae.to(accelerator.device, dtype=weight_dtype)
+    vae.requires_grad_(False)
+    vae.eval()
     if cache_latents:
-        vae.to(accelerator.device, dtype=weight_dtype)
-        vae.requires_grad_(False)
-        vae.eval()
         with torch.no_grad():
             train_dataset_group.cache_latents(vae, args.vae_batch_size, args.cache_latents_to_disk, accelerator.is_main_process)
         vae.to("cpu")
@@ -175,16 +175,7 @@ def train(args):
     else:
         text_encoder.to(accelerator.device, dtype=weight_dtype)
         text_encoder.requires_grad_(False)  # text encoderは学習しない
-        if args.gradient_checkpointing:
-            text_encoder.gradient_checkpointing_enable()
-            text_encoder.train()  # required for gradient_checkpointing
-        else:
-            text_encoder.eval()
-
-    if not cache_latents:
-        vae.requires_grad_(False)
-        vae.eval()
-        vae.to(accelerator.device, dtype=weight_dtype)
+        text_encoder.eval()
 
     for m in training_models:
         m.requires_grad_(True)
@@ -239,8 +230,13 @@ def train(args):
     else:
         unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 
-    # transform DDP after prepare
-    text_encoder, unet = train_util.transform_if_model_is_DDP(text_encoder, unet)
+    # save reference to wrapped self in the model, then work with unwrapped models by default
+    unet_accelerated = unet
+    unet = accelerator.unwrap_model(unet)
+    unet.accelerated = lambda: unet_accelerated
+    text_encoder_accelerated = text_encoder
+    text_encoder = accelerator.unwrap_model(text_encoder)
+    text_encoder.accelerated = lambda: text_encoder_accelerated
 
     # 実験的機能：勾配も含めたfp16学習を行う　PyTorchにパッチを当ててfp16でのgrad scaleを有効にする
     if args.full_fp16:
@@ -276,6 +272,9 @@ def train(args):
 
     if accelerator.is_main_process:
         accelerator.init_trackers("finetuning" if args.log_tracker_name is None else args.log_tracker_name)
+
+    if args.sample_before_training:
+        train_util.sample_images(accelerator, args, None, 0, accelerator.device, vae, tokenizer, text_encoder, unet)
 
     for epoch in range(num_train_epochs):
         print(f"\nepoch {epoch+1}/{num_train_epochs}")
@@ -331,7 +330,7 @@ def train(args):
 
                 # Predict the noise residual
                 with accelerator.autocast():
-                    noise_pred = unet(noisy_latents, timesteps, encoder_hidden_states).sample
+                    noise_pred = unet.accelerated()(noisy_latents, timesteps, encoder_hidden_states).sample
 
                 if args.v_parameterization:
                     # v-parameterization training
@@ -389,10 +388,15 @@ def train(args):
                             epoch,
                             num_train_epochs,
                             global_step,
-                            unwrap_model(text_encoder),
-                            unwrap_model(unet),
+                            text_encoder,
+                            unet,
                             vae,
                         )
+
+                    # State must be saved from all processes b/c it may contain rank-specific data
+                    # (random_states in DDP, optimizer state in deepspeed, etc.)
+                    if args.save_state:
+                        train_util.save_and_remove_state_stepwise(args, accelerator, global_step)
 
             current_loss = loss.detach().item()  # 平均なのでbatch sizeは関係ないはず
             if args.logging_dir is not None:
@@ -432,21 +436,21 @@ def train(args):
                     epoch,
                     num_train_epochs,
                     global_step,
-                    unwrap_model(text_encoder),
-                    unwrap_model(unet),
+                    text_encoder,
+                    unet,
                     vae,
                 )
+
+            if args.save_state:
+                train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
         train_util.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
     is_main_process = accelerator.is_main_process
-    if is_main_process:
-        unet = unwrap_model(unet)
-        text_encoder = unwrap_model(text_encoder)
 
     accelerator.end_training()
 
-    if args.save_state and is_main_process:
+    if args.save_state:
         train_util.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す

--- a/library/custom_train_functions.py
+++ b/library/custom_train_functions.py
@@ -259,9 +259,9 @@ def get_unweighted_text_embeddings(
                         text_input_chunk[j, 1] = eos
 
             if clip_skip is None or clip_skip == 1:
-                text_embedding = text_encoder(text_input_chunk)[0]
+                text_embedding = text_encoder.accelerated()(text_input_chunk)[0]
             else:
-                enc_out = text_encoder(text_input_chunk, output_hidden_states=True, return_dict=True)
+                enc_out = text_encoder.accelerated()(text_input_chunk, output_hidden_states=True, return_dict=True)
                 text_embedding = enc_out["hidden_states"][-clip_skip]
                 text_embedding = text_encoder.text_model.final_layer_norm(text_embedding)
 
@@ -280,9 +280,9 @@ def get_unweighted_text_embeddings(
         text_embeddings = torch.concat(text_embeddings, axis=1)
     else:
         if clip_skip is None or clip_skip == 1:
-            text_embeddings = text_encoder(text_input)[0]
+            text_embeddings = text_encoder.accelerated()(text_input)[0]
         else:
-            enc_out = text_encoder(text_input, output_hidden_states=True, return_dict=True)
+            enc_out = text_encoder.accelerated()(text_input, output_hidden_states=True, return_dict=True)
             text_embeddings = enc_out["hidden_states"][-clip_skip]
             text_embeddings = text_encoder.text_model.final_layer_norm(text_embeddings)
     return text_embeddings

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2309,6 +2309,11 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         help="generate sample images every N epochs (overwrites n_steps) / 学習中のモデルで指定エポックごとにサンプル出力する（ステップ数指定を上書きします）",
     )
     parser.add_argument(
+        "--sample_before_training",
+        action="store_true",
+        help="sample before epoch 0 / ステップ0前のサンプル"    
+    )
+    parser.add_argument(
         "--sample_prompts", type=str, default=None, help="file for prompts to generate sample images / 学習中モデルのサンプル出力用プロンプトのファイル"
     )
     parser.add_argument(
@@ -3177,15 +3182,15 @@ def patch_accelerator_for_fp16_training(accelerator):
 def get_hidden_states(args: argparse.Namespace, input_ids, tokenizer, text_encoder, weight_dtype=None):
     # with no_token_padding, the length is not max length, return result immediately
     if input_ids.size()[-1] != tokenizer.model_max_length:
-        return text_encoder(input_ids)[0]
+        return text_encoder.accelerated()(input_ids)[0]
 
     b_size = input_ids.size()[0]
     input_ids = input_ids.reshape((-1, tokenizer.model_max_length))  # batch_size*3, 77
 
     if args.clip_skip is None:
-        encoder_hidden_states = text_encoder(input_ids)[0]
+        encoder_hidden_states = text_encoder.accelerated()(input_ids)[0]
     else:
-        enc_out = text_encoder(input_ids, output_hidden_states=True, return_dict=True)
+        enc_out = text_encoder.accelerated()(input_ids, output_hidden_states=True, return_dict=True)
         encoder_hidden_states = enc_out["hidden_states"][-args.clip_skip]
         encoder_hidden_states = text_encoder.text_model.final_layer_norm(encoder_hidden_states)
 
@@ -3347,12 +3352,6 @@ def save_sd_model_on_epoch_end_or_stepwise(
             if os.path.exists(remove_out_dir):
                 print(f"removing old model: {remove_out_dir}")
                 shutil.rmtree(remove_out_dir)
-
-    if args.save_state:
-        if on_epoch_end:
-            save_and_remove_state_on_epoch_end(args, accelerator, epoch_no)
-        else:
-            save_and_remove_state_stepwise(args, accelerator, global_step)
 
 
 def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator, epoch_no):
@@ -3567,7 +3566,7 @@ def sample_images(
     with torch.no_grad():
         with accelerator.autocast():
             for i, prompt in enumerate(prompts):
-                if not accelerator.is_main_process:
+                if i % accelerator.num_processes != accelerator.process_index:
                     continue
 
                 if isinstance(prompt, dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ opencv-python==4.7.0.68
 einops==0.6.0
 diffusers[torch]==0.10.2
 pytorch-lightning==1.9.0
-bitsandbytes==0.35.0
+bitsandbytes==0.39.0
 tensorboard==2.10.1
 safetensors==0.2.6
 # gradio==3.16.2


### PR DESCRIPTION
- Fixed DDP bug where forward/backward are called on the *unwrapped* modules. As a result gradient synchronization won't happen, everything may look okay but you will actually get diverging (and undertrained) models on each GPU.
 See: https://github.com/kohya-ss/sd-scripts/blob/c7fd336c5d5c0f05378dd34e7b5ca6ac8e972773/fine_tune.py#L243

- `accelerator.save_state` needs to be called from all processes so that rank-specific data is saved, fixed.

- Also implemented multi-gpu inference, a new --sample_before_training flag and upgraded bitsandbytes to 0.39 for Lion8bit, Ada + Hopper, etc.

- Note only `fine_tune.py` was fixed, no LoRA changes. Comments more than welcome.