### PR TITLE
Update dependencies to fix etag errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ fairscale==0.4.13
 # for WD14 captioning
 # tensorflow<2.11
 tensorflow==2.10.1
-huggingface-hub==0.13.3
+huggingface-hub==0.14.0
 # for kohya_ss library
 .


### PR DESCRIPTION
huggingface-hub==0.13.3
only considered `ETag: W/"<etag_value>"`
and not `ETag: "<etag_value>"`
As a result, it's possible to receive etags of the form `W/"xxxxx`, and since this project generates file names based on etags, using such names in Python would result in exceptions being thrown on Windows.

You can access the implementation of this library and its first fix version, v0.14.0, at the following links:
https://github.com/huggingface/huggingface_hub/blob/v0.13.3/src/huggingface_hub/file_download.py#L819
https://github.com/huggingface/huggingface_hub/blob/v0.14.0/src/huggingface_hub/file_download.py#L828


My solution was to modify that line of Python code in the local venv folder. This solution worked, but I'm not sure if upgrading the dependency version will cause other issues. I haven't tested it. I don't know how to perform a comprehensive test.