### PR TITLE
Full bf16 support

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2416,6 +2416,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--mixed_precision", type=str, default="no", choices=["no", "fp16", "bf16"], help="use mixed precision / 混合精度を使う場合、その精度"
     )
     parser.add_argument("--full_fp16", action="store_true", help="fp16 training including gradients / 勾配も含めてfp16で学習する")
+    parser.add_argument("--full_bf16", action="store_true", help="bf16 training including gradients / 勾配も含めてbf16で学習する")
     parser.add_argument(
         "--clip_skip",
         type=int,

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -267,6 +267,14 @@ def train(args):
         unet.to(weight_dtype)
         text_encoder1.to(weight_dtype)
         text_encoder2.to(weight_dtype)
+    elif args.full_bf16:
+        assert (
+            args.mixed_precision == "bf16"
+        ), "full_bf16 requires mixed precision='bf16' / full_bf16を使う場合はmixed_precision='bf16'を指定してください。"
+        accelerator.print("enable full bf16 training.")
+        unet.to(weight_dtype)
+        text_encoder1.to(weight_dtype)
+        text_encoder2.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
     if args.train_text_encoder:


### PR DESCRIPTION
full fp16 will cause some unstable problem.
And if the GPU support bf16, use full bf16 will be better (bf16 weight + bf16 amp + bf16 grad)
The only problem of this thing is, if user want to use optimizer in the bitsandbytes, they will need the newest version to utilize full bf16 training.
Which is bad nes for windows user. (or we need to compile the newest bitsandbytes for windows, which could be tricky)

so just a tiny start for a useful feature, need more improvement. (like check if the gpu support bf16, if the bitsandbytes support bf16 grad ...)