### PR TITLE
Cast weights to correct precision before transferring them to GPU

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -358,6 +358,11 @@ class NetworkTrainer:
             accelerator.print("enable full fp16 training.")
             network.to(weight_dtype)
 
+        unet.requires_grad_(False)
+        unet.to(dtype=weight_dtype)
+        for t_enc in text_encoders:
+            t_enc.requires_grad_(False)
+
         # acceleratorがなんかよろしくやってくれるらしい
         # TODO めちゃくちゃ冗長なのでコードを整理する
         if train_unet and train_text_encoder:
@@ -396,11 +401,6 @@ class NetworkTrainer:
         # transform DDP after prepare (train_network here only)
         text_encoders = train_util.transform_models_if_DDP(text_encoders)
         unet, network = train_util.transform_models_if_DDP([unet, network])
-
-        unet.requires_grad_(False)
-        unet.to(accelerator.device, dtype=weight_dtype)
-        for t_enc in text_encoders:
-            t_enc.requires_grad_(False)
 
         if args.gradient_checkpointing:
             # according to TI example in Diffusers, train is required


### PR DESCRIPTION
Currently `accelerator.prepare` will transfer the weights to GPU in fp32 precision and they are casted to `weight_dtype` after that. With SDXL since unet has 2.6B parameters this requires at least 10.4 GB of VRAM. Instead in this PR the weights are casted on CPU which drops the VRAM requirement when using fp16 or bf16 precision. It's possible to train LoRA with 8GB VRAM with this change which was not possible before.