### PR TITLE
Cache latents VRAM leak fix

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2141,6 +2141,8 @@ def cache_batch_latents(
             info.latents = latent
             if flip_aug:
                 info.latents_flipped = flipped_latent
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
 
 def cache_batch_text_encoder_outputs(


### PR DESCRIPTION
Probably related to #651. I also had a problem with caching images from a small dataset (50-100 images) at 512 resolution, causing VRAM to exceed 24GB.

This should fix problems with vram leakage during "caching latents..." stage (tested on Windows).