### PR TITLE
Include LoRACompatibleLinear in lora_diffusers modules

### DIFF
--- a/networks/lora_diffusers.py
+++ b/networks/lora_diffusers.py
@@ -318,7 +318,7 @@ class LoRANetwork(torch.nn.Module):
             for name, module in root_module.named_modules():
                 if module.__class__.__name__ in target_replace_modules:
                     for child_name, child_module in module.named_modules():
-                        is_linear = child_module.__class__.__name__ == "Linear"
+                        is_linear = child_module.__class__.__name__ == "Linear" or child_module.__class__.__name__ == "LoRACompatibleLinear"
                         is_conv2d = child_module.__class__.__name__ == "Conv2d"
 
                         if is_linear or is_conv2d:


### PR DESCRIPTION
Include "LoRACompatibleLinear" in modules to not ignore FeedForward modules.