### PR TITLE
Fix RAM leak when loading model in lowram device

### DIFF
--- a/library/sdxl_model_util.py
+++ b/library/sdxl_model_util.py
@@ -141,7 +141,10 @@ def load_models_from_sdxl_checkpoint(model_version, ckpt_path, map_location):
     # Load the state dict
     if model_util.is_safetensors(ckpt_path):
         checkpoint = None
-        state_dict = load_file(ckpt_path, device=map_location)
+        try:
+            state_dict = load_file(ckpt_path, device=map_location)
+        except:
+            state_dict = load_file(ckpt_path)   # prevent device invalid Error
         epoch = None
         global_step = None
     else:


### PR DESCRIPTION
- Fix RAM leak on low RAM device like colab when `lowram = true`
- Fix `safetensors_rust.SafetensorError: device cuda:0 is invalid`. Same to #354

For low-ram device like Colab,  the usual workflow to load U-net may blow the RAM since it costs about 12.7Gib RAM to load the checkpoint and initialize the `SdxlUNet2DConditionModel()`.

Using `init_empty_weights()` context manager can initialize a model without using any RAM. It can solve the RAM leak on low RAM device.

However, since we didn't use `load_state_dict()` when loading U-Net from checkpoint, `_IncompatibleKeys` will not be warned for corrupted checkpoint with `missing_keys` and `unexpected_keys`...