### PR TITLE
fix: can't load weights of Lycoris models due to wrong method calling s…

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -234,13 +234,14 @@ def train(args):
         )
         args.scale_weight_norms = False
 
-    train_unet = not args.network_train_text_encoder_only
-    train_text_encoder = not args.network_train_unet_only
-    network.apply_to(text_encoder, unet, train_text_encoder, train_unet)
-
     if args.network_weights is not None:
         info = network.load_weights(args.network_weights)
         print(f"loaded network weights from {args.network_weights}: {info}")
+    
+    train_unet = not args.network_train_text_encoder_only
+    train_text_encoder = not args.network_train_unet_only    
+    
+    network.apply_to(text_encoder, unet, train_text_encoder, train_unet)
 
     if args.gradient_checkpointing:
         unet.enable_gradient_checkpointing()


### PR DESCRIPTION
# Reason

The original code calls `network.apply_to` before `network.load_weights`. However, the `LycorisNetwork.load_weights` in lycoris module writes:

```python
def load_weights(self, file):
        if os.path.splitext(file)[1] == '.safetensors':
            from safetensors.torch import load_file, safe_open
            self.weights_sd = load_file(file)
        else:
            self.weights_sd = torch.load(file, map_location='cpu')
```

which loads the weight temporarily into `self.weights_sd` and actually loads the weight to the nn at the end of `LycorisNetwork.apply_to` with:

```python
if self.weights_sd:
            # if some weights are not in state dict, it is ok because initial LoRA does nothing (lora_up is initialized by zeros)
            info = self.load_state_dict(self.weights_sd, False)
            print(f"weights are loaded: {info}")
```

thus, if the `network.apply_to` is called before `network.load_weights`, the weight will never be loaded.

# Fix

Call `network.load_weights` before `network.apply_to` in `train_network.py`