### PR TITLE
load model may fail if symbolic link points to relative path

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3125,7 +3125,7 @@ def prepare_dtype(args: argparse.Namespace):
 
 def _load_target_model(args: argparse.Namespace, weight_dtype, device="cpu"):
     name_or_path = args.pretrained_model_name_or_path
-    name_or_path = os.readlink(name_or_path) if os.path.islink(name_or_path) else name_or_path
+    name_or_path = os.path.realpath(name_or_path) if os.path.islink(name_or_path) else name_or_path
     load_stable_diffusion_format = os.path.isfile(name_or_path)  # determine SD or Diffusers
     if load_stable_diffusion_format:
         print(f"load StableDiffusion checkpoint: {name_or_path}")


### PR DESCRIPTION
#### Sample directory structure
```
.
├── model.safetensors -> v1-5-pruned.safetensors
├── v1-5-pruned.safetensors
└── sd-scripts
```

In such a directory structure, running with `--pretrained_model_name_or_path=../model.safetensors` in the `sd-scripts` directory, the model will fail to load.
The test environment is Ubuntu 22.04.3 LTS and Python 3.10.12.

The `os.readlink` returns the path as seen from the link itself, not the current directory. If the link is relative, the path resolution fails.
Fixed to use `os.path.realpath` instead, which resolves to an absolute path.
