### PR TITLE
fix: VRAM memory leak in sdxl_gen_img.py

### DIFF
--- a/sdxl_gen_img.py
+++ b/sdxl_gen_img.py
@@ -754,6 +754,9 @@ class PipelineLike:
         # we always cast to float32 as this does not cause significant overhead and is compatible with bfloa16
         image = image.cpu().permute(0, 2, 3, 1).float().numpy()
 
+        if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
         if output_type == "pil":
             # image = self.numpy_to_pil(image)
             image = (image * 255).round().astype("uint8")


### PR DESCRIPTION
Addresses [773](https://github.com/kohya-ss/sd-scripts/issues/773).

No worries if you prefer to address this another way, just wanted to show what works for me.

Text from issue:

I noticed that there is a VRAM memory leak when I use sdxl_gen_img.py in non-interactive model, `images_per_prompt` > 0.

Although the image is pulled to `cpu` just before saving, the VRAM used does not go down unless I add `torch.cuda.empty_cache()`. Because of this, I am running out of memory when generating several images per prompt.

OS: Linux
Cuda: 1.18
PyTorch: 2.0.1
GPU: 2080 TI