### PR TITLE
Support JPEG XL

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -96,6 +96,13 @@ try:
 except:
     pass
 
+try:
+    from jxlpy import JXLImagePlugin
+
+    IMAGE_EXTENSIONS.extend([".jxl", ".JXL"])
+except:
+    pass
+
 IMAGE_TRANSFORMS = transforms.Compose(
     [
         transforms.ToTensor(),


### PR DESCRIPTION
Related issue: #782 
- Support JPEG XL `.jxl` format through [jxlpy](https://github.com/olokelo/jxlpy/tree/master) plugin