### PR TITLE
chore: adding training parameters to wandb ai experiments

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3081,7 +3081,7 @@ def prepare_accelerator(args: argparse.Namespace):
                 os.environ["WANDB_DIR"] = logging_dir
             if args.wandb_api_key is not None:
                 wandb.login(key=args.wandb_api_key)
-                wandb.init(project="Stable Diffision Training", name=args.output_name, config=args)
+                wandb.init(project="Stable Diffusion Training", name=args.output_name, config=args)
 
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3081,6 +3081,7 @@ def prepare_accelerator(args: argparse.Namespace):
                 os.environ["WANDB_DIR"] = logging_dir
             if args.wandb_api_key is not None:
                 wandb.login(key=args.wandb_api_key)
+                wandb.init(project="Stable Diffision Training", name=args.output_name, config=args)
 
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,


### PR DESCRIPTION
This change adds the parameters used with `accelerate` and sends them as a payload to `wandb.ai`. That allows the parameters to show up in the table of runs and helps to get a better understanding of what the difference is between runs. It also uses the model's name as run name to give more context.

<img width="1156" alt="image" src="https://github.com/kohya-ss/sd-scripts/assets/1324978/57506e88-1eda-477e-8b16-54adcb80f7e4">
