### PR TITLE
Fix JPEG-XL support

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -96,8 +96,17 @@ try:
 except:
     pass
 
+# JPEG-XL on Linux
 try:
     from jxlpy import JXLImagePlugin
+
+    IMAGE_EXTENSIONS.extend([".jxl", ".JXL"])
+except:
+    pass
+
+# JPEG-XL on Windows
+try:
+    import pillow_jxl
 
     IMAGE_EXTENSIONS.extend([".jxl", ".JXL"])
 except:


### PR DESCRIPTION
Update PR: #786

- Fix broken JPEG-XL support on Windows through [pillow-jpegxl-plugin](https://github.com/Isotr0py/pillow-jpegxl-plugin). 
- Because `jxlpy` haven't updated for a long time and unable to build on Windows now, I wrote another plugin to support JPEG-XL for Pillow.