### PR TITLE
Update train_network.py

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -291,7 +291,7 @@ class NetworkTrainer:
                 vae,
                 text_encoder,
                 unet,
-                neuron_dropout=args.network_dropout,
+                dropout=args.network_dropout,
                 **net_kwargs,
             )
         if network is None:


### PR DESCRIPTION
Hello,

I've noticed that the `neuron_dropout` argument in the function call to `create_network` is not being correctly mapped to the underlying Lycoris library. In the Lycoris implementation, the argument for specifying dropout is called `dropout`, not `neuron_dropout`.

Because of this discrepancy, the user-defined value for dropout is not being effectively passed to the Lycoris library, resulting in the library defaulting to 0.0 for dropout even when the user specifies a different value.

To fix this issue, I've updated the argument name from `neuron_dropout` to `dropout` to ensure proper mapping and to allow the user-defined dropout value to take effect.

Thank you for considering this change.