### PR TITLE
Add EMA

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -240,21 +240,19 @@ def train(args):
         #ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
         ema = EMAModel(params_to_optimize, decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
         ema.to(accelerator.device, dtype=weight_dtype)
+    else:
+        ema = None
 
     # acceleratorがなんかよろしくやってくれるらしい
     if args.train_text_encoder:
-        if args.enable_ema:
-            unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-            unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler)
-        else:
-            unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                unet, text_encoder, optimizer, train_dataloader, lr_scheduler
-            )
+
+        unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+        unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler)
+
     else:
-        if args.enable_ema:
-            unet, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, ema, optimizer, train_dataloader, lr_scheduler)
-        else:
-            unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
+
+        unet, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, ema, optimizer, train_dataloader, lr_scheduler)
+
 
     # transform DDP after prepare
     text_encoder, unet = train_util.transform_if_model_is_DDP(text_encoder, unet)

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -410,16 +410,8 @@ def train(args):
             
             current_loss = loss.detach().item()  # 平均なのでbatch sizeは関係ないはず
             if args.logging_dir is not None:
-                logs = {"loss": current_loss, "lr": float(lr_scheduler.get_last_lr()[0])}
-                if (
-                    args.optimizer_type.lower().startswith("DAdapt".lower()) or args.optimizer_type.lower() == "Prodigy".lower()
-                ):  # tracking d*lr value
-                    logs["lr/d*lr"] = (
-                        lr_scheduler.optimizers[0].param_groups[0]["d"] * lr_scheduler.optimizers[0].param_groups[0]["lr"]
-                    )
-                if args.enable_ema:
-                    logs["loss/ema_decay"] = ema.get_decay(global_step)
-                    # logs["lr/lr*(1-ema_decay)"] = float(lr_scheduler.get_last_lr()[0]) * (1.0 - ema.get_decay(global_step))
+                logs = {"loss": current_loss}
+                train_util.append_lr_to_logs(logs, lr_scheduler, args.optimizer_type, including_unet=True)
                 accelerator.log(logs, step=global_step)
 
             # TODO moving averageにする

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -237,9 +237,9 @@ def train(args):
         text_encoder.to(weight_dtype)
 
     if args.enable_ema:
-        ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
+        #ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
         ema = EMAModel(params_to_optimize, decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
-        ema.to(accelerator.device, dtype=ema_dtype)
+        ema.to(accelerator.device, dtype=weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
     if args.train_text_encoder:
@@ -377,7 +377,7 @@ def train(args):
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
                 if args.enable_ema:
-                    with torch.no_grad():
+                    with torch.no_grad(), accelerator.autocast():
                         ema.step(params_to_optimize)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -260,7 +260,8 @@ def train(args):
     # acceleratorがなんかよろしくやってくれるらしい
     if args.train_text_encoder:
         unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        unet, text_encoder, optimizer, train_dataloader, lr_scheduler)
+            unet, text_encoder, optimizer, train_dataloader, lr_scheduler
+        )
     else:
         unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3061,8 +3061,8 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--ema_decay", type=float, default=0.999, help="Max EMA decay. Typical values: 0.999 - 0.9999 / 最大EMA減衰。標準的な値： 0.999 - 0.9999 "
     )
     parser.add_argument(
-        "--ema_beta", type=float, default=0, help="Sets decay schedule. If beta==0: use default (1+x)/(10+x). If beta>0: use exponential schedule. If using exponential, recommended values are around 10-15 "
-        + "/ 減衰スケジュールを設定する。beta==0 の場合: デフォルトの (1+x)/(10+x) を使う。beta>0 の場合: 指数スケジュールを使用する。exponentialを使う場合、推奨値は10-15程度。"
+        "--ema_beta", type=float, default=0, help="Sets EMA decay schedule. If beta==0: uses default (1+x)/(10+x). If beta>0: use exponential schedule scaled to max_train_steps. If beta>0, recommended values are around 10-15 "
+        + "/ EMAの減衰スケジュールを設定する。beta==0 の場合: デフォルトの (1+x)/(10+x) を使用。beta>0 の場合: max_train_steps にスケーリングされた指数スケジュールを使用。beta>0 の場合、推奨値は 10-15 程度。"
     )
     parser.add_argument(
         "--ema_save_only_ema_weights", action="store_true", help="By default both EMA and non-EMA weights are saved. If enabled, saves only EMA / デフォルトでは、EMAウェイトと非EMAウェイトの両方が保存される。有効にすると、EMAのみが保存される "

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2289,7 +2289,7 @@ def load_text_encoder_outputs_from_disk(npz_path):
 # based mostly on https://github.com/fadel/pytorch_ema/blob/master/torch_ema/ema.py
 class EMAModel:
     """
-    Exponential Moving Average of models weights
+    Maintains (exponential) moving average of a set of parameters.
     """
     def __init__(self, parameters: Iterable[torch.nn.Parameter], decay: float, beta: float, max_train_steps=10000):
         parameters = list(parameters)
@@ -2304,7 +2304,7 @@ class EMAModel:
 
     def get_decay(self, optimization_step) -> float:
         """
-        Compute the decay factor for the exponential moving average.
+        Compute current decay for the exponential moving average.
         """
         if self.beta <= 0:
             return min(self.decay, (1 + optimization_step) / (10 + optimization_step))
@@ -3055,16 +3055,17 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
     #     help="enable perlin noise and set the octaves / perlin noiseを有効にしてoctavesをこの値に設定する",
     # )
     parser.add_argument(
-        "--enable_ema", action="store_true", help="Enable EMA / "
+        "--enable_ema", action="store_true", help="Enable EMA (Exponential Moving Average) of model parameters / モデルパラメータのEMA（指数移動平均）を有効にする "
     )
     parser.add_argument(
-        "--ema_decay", type=float, default=0.999, help="Max EMA decay. Typical values: 0.999 - 0.9999 / "
+        "--ema_decay", type=float, default=0.999, help="Max EMA decay. Typical values: 0.999 - 0.9999 / 最大EMA減衰。標準的な値： 0.999 - 0.9999 "
     )
     parser.add_argument(
-        "--ema_beta", type=float, default=0, help="sets decay schedule. If beta==0: use default (1+x)/(10+x). If beta>0: use exponential schedule. If using exponential, use values around 10-15 / "
+        "--ema_beta", type=float, default=0, help="Sets decay schedule. If beta==0: use default (1+x)/(10+x). If beta>0: use exponential schedule. If using exponential, recommended values are around 10-15 "
+        + "/ 減衰スケジュールを設定する。beta==0 の場合: デフォルトの (1+x)/(10+x) を使う。beta>0 の場合: 指数スケジュールを使用する。exponentialを使う場合、推奨値は10-15程度。"
     )
     parser.add_argument(
-        "--ema_save_only_ema_weights", action="store_true", help="By default both EMA and non-EMA weights are saved. If enabled, saves only EMA / "
+        "--ema_save_only_ema_weights", action="store_true", help="By default both EMA and non-EMA weights are saved. If enabled, saves only EMA / デフォルトでは、EMAウェイトと非EMAウェイトの両方が保存される。有効にすると、EMAのみが保存される "
     )
     parser.add_argument(
         "--multires_noise_discount",

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -384,6 +384,10 @@ def train(args):
         text_encoder1.to(weight_dtype)
         text_encoder2.to(weight_dtype)
 
+
+    if args.enable_ema:
+        print("--enable_ema not supported in this script yet. Training without EMA. / --enable_ema このスクリプトではサポートされていません。トレーニングはEMAなしで行われる ")
+
     # acceleratorがなんかよろしくやってくれるらしい
     if args.train_text_encoder:
         unet, text_encoder1, text_encoder2, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -279,6 +279,9 @@ def train(args):
 
     unet.to(weight_dtype)
 
+    if args.enable_ema:
+        print("--enable_ema not supported in this script yet. Training without EMA. / --enable_ema このスクリプトではサポートされていません。トレーニングはEMAなしで行われる ")
+
     # acceleratorがなんかよろしくやってくれるらしい
     unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -247,6 +247,9 @@ def train(args):
         unet.to(weight_dtype)
         network.to(weight_dtype)
 
+    if args.enable_ema:
+        print("--enable_ema not supported in this script yet. Training without EMA. / --enable_ema このスクリプトではサポートされていません。トレーニングはEMAなしで行われる ")
+
     # acceleratorがなんかよろしくやってくれるらしい
     unet, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
         unet, network, optimizer, train_dataloader, lr_scheduler

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -271,6 +271,8 @@ def train(args):
         accelerator.print("enable full fp16 training.")
         controlnet.to(weight_dtype)
 
+    if args.enable_ema:
+        print("--enable_ema not supported in this script yet. Training without EMA. / --enable_ema このスクリプトではサポートされていません。トレーニングはEMAなしで行われる ")
     # acceleratorがなんかよろしくやってくれるらしい
     controlnet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
         controlnet, optimizer, train_dataloader, lr_scheduler

--- a/train_db.py
+++ b/train_db.py
@@ -211,20 +211,16 @@ def train(args):
         #ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
         ema = EMAModel(trainable_params, decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
         ema.to(accelerator.device, dtype=weight_dtype)
+        ema = accelerator.prepare(ema)
+    else:
+        ema = None
     # acceleratorがなんかよろしくやってくれるらしい
     if train_text_encoder:
-        if args.enable_ema:
-            unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler)
-        else:
-            unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                unet, text_encoder, optimizer, train_dataloader, lr_scheduler
+        unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+            unet, text_encoder, optimizer, train_dataloader, lr_scheduler
         )
     else:
-        if args.enable_ema:
-            unet, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, ema, optimizer, train_dataloader, lr_scheduler)
-        else:
-            unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
+        unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 
     # transform DDP after prepare
     text_encoder, unet = train_util.transform_if_model_is_DDP(text_encoder, unet)
@@ -397,15 +393,8 @@ def train(args):
 
             current_loss = loss.detach().item()
             if args.logging_dir is not None:
-                logs = {"loss": current_loss, "lr": float(lr_scheduler.get_last_lr()[0])}
-                if args.enable_ema:
-                    logs["loss/ema_decay"] = ema.get_decay(global_step)
-                if (
-                    args.optimizer_type.lower().startswith("DAdapt".lower()) or args.optimizer_type.lower() == "Prodigy".lower()
-                ):  # tracking d*lr value
-                    logs["lr/d*lr"] = (
-                        lr_scheduler.optimizers[0].param_groups[0]["d"] * lr_scheduler.optimizers[0].param_groups[0]["lr"]
-                    )
+                logs = {"loss": current_loss}
+                train_util.append_lr_to_logs(logs, lr_scheduler, args.optimizer_type, including_unet=True)
                 accelerator.log(logs, step=global_step)
 
             if epoch == 0:

--- a/train_db.py
+++ b/train_db.py
@@ -36,7 +36,7 @@ from library.custom_train_functions import (
     apply_noise_offset,
     scale_v_prediction_loss_like_noise_prediction,
 )
-
+from library.train_util import EMAModel
 # perlin_noise,
 
 
@@ -207,13 +207,24 @@ def train(args):
         unet.to(weight_dtype)
         text_encoder.to(weight_dtype)
 
+    if args.enable_ema:
+        ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
+        ema = EMAModel(trainable_params, decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
+        ema.to(accelerator.device, dtype=ema_dtype)
     # acceleratorがなんかよろしくやってくれるらしい
     if train_text_encoder:
-        unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-            unet, text_encoder, optimizer, train_dataloader, lr_scheduler
+        if args.enable_ema:
+            unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                unet, text_encoder, ema, optimizer, train_dataloader, lr_scheduler)
+        else:
+            unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                unet, text_encoder, optimizer, train_dataloader, lr_scheduler
         )
     else:
-        unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
+        if args.enable_ema:
+            unet, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, ema, optimizer, train_dataloader, lr_scheduler)
+        else:
+            unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 
     # transform DDP after prepare
     text_encoder, unet = train_util.transform_if_model_is_DDP(text_encoder, unet)
@@ -350,6 +361,9 @@ def train(args):
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+                if args.enable_ema:
+                    with torch.no_grad():
+                        ema.step(trainable_params)
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:
@@ -384,6 +398,8 @@ def train(args):
             current_loss = loss.detach().item()
             if args.logging_dir is not None:
                 logs = {"loss": current_loss, "lr": float(lr_scheduler.get_last_lr()[0])}
+                if args.enable_ema:
+                    logs["loss/ema_decay"] = ema.get_decay(global_step)
                 if (
                     args.optimizer_type.lower().startswith("DAdapt".lower()) or args.optimizer_type.lower() == "Prodigy".lower()
                 ):  # tracking d*lr value
@@ -415,6 +431,9 @@ def train(args):
             if accelerator.is_main_process:
                 # checking for saving is in util
                 src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
+                if args.enable_ema and not args.ema_save_only_ema_weights and ((epoch + 1) % args.save_every_n_epochs == 0):
+                    temp_name = args.output_name
+                    args.output_name = args.output_name + "-non-EMA"
                 train_util.save_sd_model_on_epoch_end_or_stepwise(
                     args,
                     True,
@@ -430,6 +449,25 @@ def train(args):
                     accelerator.unwrap_model(unet),
                     vae,
                 )
+                if args.enable_ema and ((epoch + 1) % args.save_every_n_epochs == 0):
+                    args.output_name = temp_name if temp_name else args.output_name
+                    with ema.ema_parameters(trainable_params):
+                        print("Saving EMA:")
+                        train_util.save_sd_model_on_epoch_end_or_stepwise(
+                            args,
+                            True,
+                            accelerator,
+                            src_path,
+                            save_stable_diffusion_format,
+                            use_safetensors,
+                            save_dtype,
+                            epoch,
+                            num_train_epochs,
+                            global_step,
+                            accelerator.unwrap_model(text_encoder),
+                            accelerator.unwrap_model(unet),
+                            vae,
+                        )
 
         train_util.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
@@ -437,6 +475,8 @@ def train(args):
     if is_main_process:
         unet = accelerator.unwrap_model(unet)
         text_encoder = accelerator.unwrap_model(text_encoder)
+        if args.enable_ema:
+            ema = accelerator.unwrap_model(ema)
 
     accelerator.end_training()
 
@@ -447,6 +487,14 @@ def train(args):
 
     if is_main_process:
         src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
+        if args.enable_ema and not args.ema_save_only_ema_weights:
+            temp_name = args.output_name
+            args.output_name = args.output_name + "-non-EMA"
+            train_util.save_sd_model_on_train_end(args, src_path, save_stable_diffusion_format, use_safetensors, save_dtype, epoch, global_step, text_encoder, unet, vae)
+            args.output_name = temp_name
+        if args.enable_ema:
+            print("Saving EMA:")
+            ema.copy_to(trainable_params)
         train_util.save_sd_model_on_train_end(
             args, src_path, save_stable_diffusion_format, use_safetensors, save_dtype, epoch, global_step, text_encoder, unet, vae
         )

--- a/train_db.py
+++ b/train_db.py
@@ -208,9 +208,9 @@ def train(args):
         text_encoder.to(weight_dtype)
 
     if args.enable_ema:
-        ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
+        #ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
         ema = EMAModel(trainable_params, decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
-        ema.to(accelerator.device, dtype=ema_dtype)
+        ema.to(accelerator.device, dtype=weight_dtype)
     # acceleratorがなんかよろしくやってくれるらしい
     if train_text_encoder:
         if args.enable_ema:
@@ -362,7 +362,7 @@ def train(args):
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
                 if args.enable_ema:
-                    with torch.no_grad():
+                    with torch.no_grad(), accelerator.autocast():
                         ema.step(trainable_params)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/train_network.py
+++ b/train_network.py
@@ -401,7 +401,7 @@ class NetworkTrainer:
         if train_unet and train_text_encoder:
             if len(text_encoders) > 1:
                 unet, t_enc1, t_enc2, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                unet, text_encoders[0], text_encoders[1], network, optimizer, train_dataloader, lr_scheduler
+                    unet, text_encoders[0], text_encoders[1], network, optimizer, train_dataloader, lr_scheduler
                 )
                 text_encoder = text_encoders = [t_enc1, t_enc2]
                 del t_enc1, t_enc2
@@ -412,7 +412,7 @@ class NetworkTrainer:
                 text_encoders = [text_encoder]
         elif train_unet:
             unet, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-            unet, network, optimizer, train_dataloader, lr_scheduler
+                unet, network, optimizer, train_dataloader, lr_scheduler
             )
             for t_enc in text_encoders:
                 t_enc.to(accelerator.device, dtype=weight_dtype)
@@ -894,9 +894,9 @@ class NetworkTrainer:
 
                 if args.logging_dir is not None:
                     logs = self.generate_step_logs(args, current_loss, avr_loss, lr_scheduler, keys_scaled, mean_norm, maximum_norm)
-                    if args.enable_ema:
-                        logs["loss/ema_decay"] = ema.get_decay(global_step)
-                        # logs["lr/lr*(1-ema_decay)"] = float(lr_scheduler.get_last_lr()[0]) * (1.0 - ema.get_decay(global_step))
+                    #if args.enable_ema:
+                    #    logs["loss/ema_decay"] = ema.get_decay(global_step)
+                    #    # logs["lr/lr*(1-ema_decay)"] = float(lr_scheduler.get_last_lr()[0]) * (1.0 - ema.get_decay(global_step))
                     accelerator.log(logs, step=global_step)
 
                 if global_step >= args.max_train_steps:

--- a/train_network.py
+++ b/train_network.py
@@ -386,9 +386,9 @@ class NetworkTrainer:
             t_enc.requires_grad_(False)
 
         if args.enable_ema:
-            #ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float32
+            ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float
             ema = EMAModel(network.parameters(), decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
-            ema.to(accelerator.device, dtype=weight_dtype)
+            ema.to(accelerator.device, dtype=ema_dtype)
         # acceleratorがなんかよろしくやってくれるらしい
         # TODO めちゃくちゃ冗長なのでコードを整理する
         if train_unet and train_text_encoder:
@@ -846,7 +846,7 @@ class NetworkTrainer:
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
                     if args.enable_ema:
-                        with torch.no_grad():
+                        with torch.no_grad(), accelerator.autocast():
                             ema.step(network.parameters())
 
                 if args.scale_weight_norms:

--- a/train_network.py
+++ b/train_network.py
@@ -389,39 +389,32 @@ class NetworkTrainer:
             ema_dtype = weight_dtype if (args.full_bf16 or args.full_fp16) else torch.float
             ema = EMAModel(network.parameters(), decay=args.ema_decay, beta=args.ema_exp_beta, max_train_steps=args.max_train_steps)
             ema.to(accelerator.device, dtype=ema_dtype)
+        else:
+            ema = None
         # acceleratorがなんかよろしくやってくれるらしい
         # TODO めちゃくちゃ冗長なのでコードを整理する
         if train_unet and train_text_encoder:
             if len(text_encoders) > 1:
-                if args.enable_ema:
-                    unet, t_enc1, t_enc2, network, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                    unet, text_encoders[0], text_encoders[1], network, ema, optimizer, train_dataloader, lr_scheduler
-                    )
-                else:
-                    unet, t_enc1, t_enc2, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                        unet, text_encoders[0], text_encoders[1], network, optimizer, train_dataloader, lr_scheduler
-                    )
+
+                unet, t_enc1, t_enc2, network, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                unet, text_encoders[0], text_encoders[1], network, ema, optimizer, train_dataloader, lr_scheduler
+                )
+
                 text_encoder = text_encoders = [t_enc1, t_enc2]
                 del t_enc1, t_enc2
             else:
-                if args.enable_ema:
-                    unet, text_encoder, network, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                        unet, text_encoder, network, ema, optimizer, train_dataloader, lr_scheduler
-                    )
-                else:
-                    unet, text_encoder, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                        unet, text_encoder, network, optimizer, train_dataloader, lr_scheduler
-                    )
+
+                unet, text_encoder, network, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                    unet, text_encoder, network, ema, optimizer, train_dataloader, lr_scheduler
+                )
+
                 text_encoders = [text_encoder]
         elif train_unet:
-            if args.enable_ema:
+
                 unet, network, ema, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
                     unet, network, ema, optimizer, train_dataloader, lr_scheduler
                 )
-            else:
-                unet, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                    unet, network, optimizer, train_dataloader, lr_scheduler
-                )
+
         elif train_text_encoder:
             if len(text_encoders) > 1:
                 t_enc1, t_enc2, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -409,6 +409,8 @@ class TextualInversionTrainer:
         # lr schedulerを用意する
         lr_scheduler = train_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
 
+        if args.enable_ema:
+            print("--enable_ema not supported in this script yet. Training without EMA. / --enable_ema このスクリプトではサポートされていません。トレーニングはEMAなしで行われる ")
         # acceleratorがなんかよろしくやってくれるらしい
         if len(text_encoders) == 1:
             text_encoder_or_list, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(


### PR DESCRIPTION
Add EMA support. Usually it is used like this:
- At the start of training, the model parameters are copied to the EMA parameters.
- At each gradient update step, the EMA parameters are updated using the following formula: ema_param = ema_param * decay + param * (1 - decay)
- At the end of training, the model parameters are replaced by the EMA parameters.

In this implementation by default both EMA and non-EMA weights are saved (model is saved in 2 files). Usually you only need EMA weights if you using EMA.
Usually EMA is used when training large models, but I tried it on short finetuning and Lora training, and it seems to work. though difference between EMA and normal weights is small.

