### PR TITLE
Fix Sequence for Loading Weights (LyCORIS) in Training

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -314,12 +314,13 @@ class NetworkTrainer:
 
         train_unet = not args.network_train_text_encoder_only
         train_text_encoder = self.is_train_text_encoder(args)
-        network.apply_to(text_encoder, unet, train_text_encoder, train_unet)
-
+        
         if args.network_weights is not None:
             info = network.load_weights(args.network_weights)
             accelerator.print(f"load network weights from {args.network_weights}: {info}")
 
+        network.apply_to(text_encoder, unet, train_text_encoder, train_unet)
+        
         if args.gradient_checkpointing:
             unet.enable_gradient_checkpointing()
             for t_enc in text_encoders:


### PR DESCRIPTION
Hello! It's me again. 😁

I suggested moving the call to `apply_to` after `load_weights` to ensure that if the `--network_weights` option is used, the pre-trained weights are actually loaded and applied, as the previous order prevented this from happening.

### Logs

**Before**
```
load network weights from C:/stable-diffusion-webui/models/Stable-diffusion/abluble.safetensors: None
CrossAttnDownBlock2D False -> True
CrossAttnDownBlock2D False -> True
CrossAttnDownBlock2D False -> True
DownBlock2D False -> True
UNetMidBlock2DCrossAttn False -> True
UpBlock2D False -> True
CrossAttnUpBlock2D False -> True
CrossAttnUpBlock2D False -> True
CrossAttnUpBlock2D False -> True
prepare optimizer, data loader etc.
```
**After**
```
load network weights from C:/stable-diffusion-webui/models/Stable-diffusion/abluble.safetensors: None
enable LyCORIS for text encoder
enable LyCORIS for U-Net
weights are loaded: <All keys matched successfully>     <---------- Here, the difference
CrossAttnDownBlock2D False -> True
CrossAttnDownBlock2D False -> True
CrossAttnDownBlock2D False -> True
DownBlock2D False -> True
UNetMidBlock2DCrossAttn False -> True
UpBlock2D False -> True
CrossAttnUpBlock2D False -> True
CrossAttnUpBlock2D False -> True
CrossAttnUpBlock2D False -> True
prepare optimizer, data loader etc.
```

