### PR TITLE
Add LR scheduler metadata for non-standard LR schedulers

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -504,7 +504,7 @@ class NetworkTrainer:
             "ss_max_train_steps": args.max_train_steps,
             "ss_lr_warmup_steps": args.lr_warmup_steps,
             "ss_lr_scheduler": (args.lr_scheduler_type or args.lr_scheduler)
-                + (f"{args.lr_scheduler_args}" if len(args.lr_scheduler_args) > 0 else ""),
+                + (f"({args.lr_scheduler_args})" if len(args.lr_scheduler_args) > 0 else ""),
             "ss_network_module": args.network_module,
             "ss_network_dim": args.network_dim,  # None means default because another network than LoRA may have another default dim
             "ss_network_alpha": args.network_alpha,  # some networks may not have alpha

--- a/train_network.py
+++ b/train_network.py
@@ -503,7 +503,8 @@ class NetworkTrainer:
             "ss_gradient_accumulation_steps": args.gradient_accumulation_steps,
             "ss_max_train_steps": args.max_train_steps,
             "ss_lr_warmup_steps": args.lr_warmup_steps,
-            "ss_lr_scheduler": args.lr_scheduler,
+            "ss_lr_scheduler": (args.lr_scheduler_type or args.lr_scheduler)
+                + (f"{args.lr_scheduler_args}" if len(args.lr_scheduler_args) > 0 else ""),
             "ss_network_module": args.network_module,
             "ss_network_dim": args.network_dim,  # None means default because another network than LoRA may have another default dim
             "ss_network_alpha": args.network_alpha,  # some networks may not have alpha


### PR DESCRIPTION
Tried to emulate how the optimizer_args looked but left with a more raw representation until we export the args from `train_util.get_scheduler_fix`

```
OneCycleLR(['max_lr=[5e-4,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3,1e-3]', 'steps_per_epoch=10', 'epochs=10', 'base_momentum=0.85', 'max_momentum=0.95'])
```