### PR TITLE
Update Memory Efficient Attention

### DIFF
--- a/library/attention_processors.py
+++ b/library/attention_processors.py
@@ -3,39 +3,55 @@ from typing import Any
 from einops import rearrange
 import torch
 from diffusers.models.attention_processor import Attention
+from functools import partial
+from torch import nn
 
+
+# constants
+
+EPSILON = 1e-10
+
+# helper functions
+
+def exists(val):
+    return val is not None
+
+def default(val, d):
+    return val if exists(val) else d
 
 # flash attention forwards and backwards
 
-# https://arxiv.org/abs/2205.14135
-
-EPSILON = 1e-6
-
+# flash attention v1 - https://arxiv.org/abs/2205.14135
+# flash attention v2 - https://tridao.me/publications/flash2/flash2.pdf
 
 class FlashAttentionFunction(torch.autograd.function.Function):
     @staticmethod
     @torch.no_grad()
     def forward(ctx, q, k, v, mask, causal, q_bucket_size, k_bucket_size):
-        """Algorithm 2 in the paper"""
+        """ Algorithm 1 in the v2 paper """
 
         device = q.device
-        dtype = q.dtype
         max_neg_value = -torch.finfo(q.dtype).max
         qk_len_diff = max(k.shape[-2] - q.shape[-2], 0)
 
         o = torch.zeros_like(q)
-        all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
-        all_row_maxes = torch.full(
-            (*q.shape[:-1], 1), max_neg_value, dtype=dtype, device=device
-        )
+        all_row_sums = torch.zeros((*q.shape[:-1], 1), device=device)
+        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
 
         scale = q.shape[-1] ** -0.5
 
-        if mask is None:
-            mask = (None,) * math.ceil(q.shape[-2] / q_bucket_size)
+        num_row_tiles = math.ceil(q.shape[-2] / q_bucket_size)
+        num_col_tiles = math.ceil(k.shape[-2] / k_bucket_size)
+
+        if exists(mask) and mask.ndim == 2:
+            mask = rearrange(mask, 'b n -> b 1 1 n')
+
+        if not exists(mask):
+            col_masks = (None,) * num_col_tiles
+            mask = (col_masks,) * num_row_tiles 
         else:
-            mask = rearrange(mask, "b n -> b 1 1 n")
-            mask = mask.split(q_bucket_size, dim=-1)
+            mask = ((mask,) * num_row_tiles) if mask.shape[-2] == 1 else mask.split(q_bucket_size, dim=-2)
+            mask = tuple(((row_mask,) * num_col_tiles) if row_mask.shape[-1] == 1 else row_mask.split(k_bucket_size, dim=-1) for row_mask in mask)
 
         row_splits = zip(
             q.split(q_bucket_size, dim=-2),
@@ -51,68 +67,58 @@ class FlashAttentionFunction(torch.autograd.function.Function):
             col_splits = zip(
                 k.split(k_bucket_size, dim=-2),
                 v.split(k_bucket_size, dim=-2),
+                row_mask
             )
 
-            for k_ind, (kc, vc) in enumerate(col_splits):
+            for k_ind, (kc, vc, col_mask) in enumerate(col_splits):
                 k_start_index = k_ind * k_bucket_size
 
-                attn_weights = (
-                    torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
-                )
+                attn_weights = torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
 
-                if row_mask is not None:
-                    attn_weights.masked_fill_(~row_mask, max_neg_value)
+                if exists(col_mask):
+                    attn_weights.masked_fill_(~col_mask, max_neg_value)
 
                 if causal and q_start_index < (k_start_index + k_bucket_size - 1):
-                    causal_mask = torch.ones(
-                        (qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device
-                    ).triu(q_start_index - k_start_index + 1)
+                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
                 block_row_maxes = attn_weights.amax(dim=-1, keepdims=True)
-                attn_weights -= block_row_maxes
-                exp_weights = torch.exp(attn_weights)
-
-                if row_mask is not None:
-                    exp_weights.masked_fill_(~row_mask, 0.0)
-
-                block_row_sums = exp_weights.sum(dim=-1, keepdims=True).clamp(
-                    min=EPSILON
-                )
-
                 new_row_maxes = torch.maximum(block_row_maxes, row_maxes)
 
-                exp_values = torch.einsum(
-                    "... i j, ... j d -> ... i d", exp_weights, vc
-                )
+                exp_weights = torch.exp(attn_weights - new_row_maxes)
+
+                if exists(col_mask):
+                    exp_weights.masked_fill_(~col_mask, 0.)
+
+                block_row_sums = exp_weights.sum(dim=-1, keepdims=True).clamp(min=EPSILON)
+
+                exp_values = torch.einsum("... i j, ... j d -> ... i d", exp_weights, vc)
 
                 exp_row_max_diff = torch.exp(row_maxes - new_row_maxes)
-                exp_block_row_max_diff = torch.exp(block_row_maxes - new_row_maxes)
 
-                new_row_sums = (
-                    exp_row_max_diff * row_sums
-                    + exp_block_row_max_diff * block_row_sums
-                )
+                new_row_sums = exp_row_max_diff * row_sums + block_row_sums
 
-                oc.mul_((row_sums / new_row_sums) * exp_row_max_diff).add_(
-                    (exp_block_row_max_diff / new_row_sums) * exp_values
-                )
+                oc.mul_(exp_row_max_diff).add_(exp_values)
 
                 row_maxes.copy_(new_row_maxes)
                 row_sums.copy_(new_row_sums)
 
+            oc.div_(row_sums)
+
+        lse = all_row_sums.log() + all_row_maxes
+
         ctx.args = (causal, scale, mask, q_bucket_size, k_bucket_size)
-        ctx.save_for_backward(q, k, v, o, all_row_sums, all_row_maxes)
+        ctx.save_for_backward(q, k, v, o, lse)
 
         return o
 
     @staticmethod
     @torch.no_grad()
     def backward(ctx, do):
-        """Algorithm 4 in the paper"""
+        """ Algorithm 2 in the v2 paper """
 
         causal, scale, mask, q_bucket_size, k_bucket_size = ctx.args
-        q, k, v, o, l, m = ctx.saved_tensors
+        q, k, v, o, lse = ctx.saved_tensors
 
         device = q.device
 
@@ -128,12 +134,11 @@ class FlashAttentionFunction(torch.autograd.function.Function):
             o.split(q_bucket_size, dim=-2),
             do.split(q_bucket_size, dim=-2),
             mask,
-            l.split(q_bucket_size, dim=-2),
-            m.split(q_bucket_size, dim=-2),
-            dq.split(q_bucket_size, dim=-2),
+            lse.split(q_bucket_size, dim=-2),
+            dq.split(q_bucket_size, dim=-2)
         )
 
-        for ind, (qc, oc, doc, row_mask, lc, mc, dqc) in enumerate(row_splits):
+        for ind, (qc, oc, doc, row_mask, lsec, dqc) in enumerate(row_splits):
             q_start_index = ind * q_bucket_size - qk_len_diff
 
             col_splits = zip(
@@ -141,27 +146,22 @@ class FlashAttentionFunction(torch.autograd.function.Function):
                 v.split(k_bucket_size, dim=-2),
                 dk.split(k_bucket_size, dim=-2),
                 dv.split(k_bucket_size, dim=-2),
+                row_mask
             )
 
-            for k_ind, (kc, vc, dkc, dvc) in enumerate(col_splits):
+            for k_ind, (kc, vc, dkc, dvc, col_mask) in enumerate(col_splits):
                 k_start_index = k_ind * k_bucket_size
 
-                attn_weights = (
-                    torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
-                )
+                attn_weights = torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
 
                 if causal and q_start_index < (k_start_index + k_bucket_size - 1):
-                    causal_mask = torch.ones(
-                        (qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device
-                    ).triu(q_start_index - k_start_index + 1)
+                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                exp_attn_weights = torch.exp(attn_weights - mc)
+                p = torch.exp(attn_weights - lsec).half() # The half part isn't in the original code, but it complains without it
 
-                if row_mask is not None:
-                    exp_attn_weights.masked_fill_(~row_mask, 0.0)
-
-                p = exp_attn_weights / lc
+                if exists(col_mask):
+                    p.masked_fill_(~col_mask, 0.)
 
                 dv_chunk = torch.einsum("... i j, ... i d -> ... j d", p, doc)
                 dp = torch.einsum("... i d, ... j d -> ... i j", doc, vc)

--- a/library/attention_processors.py
+++ b/library/attention_processors.py
@@ -159,7 +159,7 @@ class FlashAttentionFunction(torch.autograd.function.Function):
                     causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                p = torch.exp(attn_weights - lsec)
+                p = torch.exp(attn_weights - lsec).half()
 
                 if exists(col_mask):
                     p.masked_fill_(~col_mask, 0.)

--- a/library/attention_processors.py
+++ b/library/attention_processors.py
@@ -37,7 +37,7 @@ class FlashAttentionFunction(torch.autograd.function.Function):
 
         o = torch.zeros_like(q)
         all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
-        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
+        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, dtype=dtype, device=device)
 
         scale = q.shape[-1] ** -0.5
 

--- a/library/attention_processors.py
+++ b/library/attention_processors.py
@@ -31,11 +31,12 @@ class FlashAttentionFunction(torch.autograd.function.Function):
         """ Algorithm 1 in the v2 paper """
 
         device = q.device
+        dtype = q.dtype
         max_neg_value = -torch.finfo(q.dtype).max
         qk_len_diff = max(k.shape[-2] - q.shape[-2], 0)
 
         o = torch.zeros_like(q)
-        all_row_sums = torch.zeros((*q.shape[:-1], 1), device=device)
+        all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
         all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
 
         scale = q.shape[-1] ** -0.5

--- a/library/attention_processors.py
+++ b/library/attention_processors.py
@@ -159,7 +159,7 @@ class FlashAttentionFunction(torch.autograd.function.Function):
                     causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                p = torch.exp(attn_weights - lsec).half() # The half part isn't in the original code, but it complains without it
+                p = torch.exp(attn_weights - lsec)
 
                 if exists(col_mask):
                     p.masked_fill_(~col_mask, 0.)

--- a/library/original_unet.py
+++ b/library/original_unet.py
@@ -168,7 +168,7 @@ class FlashAttentionFunction(torch.autograd.Function):
 
         o = torch.zeros_like(q)
         all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
-        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
+        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, dtype=dtype, device=device)
 
         scale = q.shape[-1] ** -0.5
 

--- a/library/original_unet.py
+++ b/library/original_unet.py
@@ -112,6 +112,7 @@ from typing import Dict, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.nn import functional as F
+from functools import partial
 from einops import rearrange
 
 BLOCK_OUT_CHANNELS: Tuple[int] = (320, 640, 1280, 1280)
@@ -139,46 +140,49 @@ UP_BLOCK_TYPES = ["UpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D", "Cros
 
 # constants
 
-EPSILON = 1e-6
+EPSILON = 1e-10
 
 # helper functions
-
 
 def exists(val):
     return val is not None
 
-
 def default(val, d):
     return val if exists(val) else d
 
-
 # flash attention forwards and backwards
 
-# https://arxiv.org/abs/2205.14135
-
+# flash attention v1 - https://arxiv.org/abs/2205.14135
+# flash attention v2 - https://tridao.me/publications/flash2/flash2.pdf
 
 class FlashAttentionFunction(torch.autograd.Function):
     @staticmethod
     @torch.no_grad()
     def forward(ctx, q, k, v, mask, causal, q_bucket_size, k_bucket_size):
-        """Algorithm 2 in the paper"""
+        """ Algorithm 1 in the v2 paper """
 
         device = q.device
-        dtype = q.dtype
         max_neg_value = -torch.finfo(q.dtype).max
         qk_len_diff = max(k.shape[-2] - q.shape[-2], 0)
 
         o = torch.zeros_like(q)
-        all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
-        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, dtype=dtype, device=device)
+        all_row_sums = torch.zeros((*q.shape[:-1], 1), device=device)
+        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
 
         scale = q.shape[-1] ** -0.5
 
+        num_row_tiles = math.ceil(q.shape[-2] / q_bucket_size)
+        num_col_tiles = math.ceil(k.shape[-2] / k_bucket_size)
+
+        if exists(mask) and mask.ndim == 2:
+            mask = rearrange(mask, 'b n -> b 1 1 n')
+
         if not exists(mask):
-            mask = (None,) * math.ceil(q.shape[-2] / q_bucket_size)
+            col_masks = (None,) * num_col_tiles
+            mask = (col_masks,) * num_row_tiles 
         else:
-            mask = rearrange(mask, "b n -> b 1 1 n")
-            mask = mask.split(q_bucket_size, dim=-1)
+            mask = ((mask,) * num_row_tiles) if mask.shape[-2] == 1 else mask.split(q_bucket_size, dim=-2)
+            mask = tuple(((row_mask,) * num_col_tiles) if row_mask.shape[-1] == 1 else row_mask.split(k_bucket_size, dim=-1) for row_mask in mask)
 
         row_splits = zip(
             q.split(q_bucket_size, dim=-2),
@@ -194,57 +198,58 @@ class FlashAttentionFunction(torch.autograd.Function):
             col_splits = zip(
                 k.split(k_bucket_size, dim=-2),
                 v.split(k_bucket_size, dim=-2),
+                row_mask
             )
 
-            for k_ind, (kc, vc) in enumerate(col_splits):
+            for k_ind, (kc, vc, col_mask) in enumerate(col_splits):
                 k_start_index = k_ind * k_bucket_size
 
                 attn_weights = torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
 
-                if exists(row_mask):
-                    attn_weights.masked_fill_(~row_mask, max_neg_value)
+                if exists(col_mask):
+                    attn_weights.masked_fill_(~col_mask, max_neg_value)
 
                 if causal and q_start_index < (k_start_index + k_bucket_size - 1):
-                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(
-                        q_start_index - k_start_index + 1
-                    )
+                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
                 block_row_maxes = attn_weights.amax(dim=-1, keepdims=True)
-                attn_weights -= block_row_maxes
-                exp_weights = torch.exp(attn_weights)
+                new_row_maxes = torch.maximum(block_row_maxes, row_maxes)
 
-                if exists(row_mask):
-                    exp_weights.masked_fill_(~row_mask, 0.0)
+                exp_weights = torch.exp(attn_weights - new_row_maxes)
+
+                if exists(col_mask):
+                    exp_weights.masked_fill_(~col_mask, 0.)
 
                 block_row_sums = exp_weights.sum(dim=-1, keepdims=True).clamp(min=EPSILON)
-
-                new_row_maxes = torch.maximum(block_row_maxes, row_maxes)
 
                 exp_values = torch.einsum("... i j, ... j d -> ... i d", exp_weights, vc)
 
                 exp_row_max_diff = torch.exp(row_maxes - new_row_maxes)
-                exp_block_row_max_diff = torch.exp(block_row_maxes - new_row_maxes)
 
-                new_row_sums = exp_row_max_diff * row_sums + exp_block_row_max_diff * block_row_sums
+                new_row_sums = exp_row_max_diff * row_sums + block_row_sums
 
-                oc.mul_((row_sums / new_row_sums) * exp_row_max_diff).add_((exp_block_row_max_diff / new_row_sums) * exp_values)
+                oc.mul_(exp_row_max_diff).add_(exp_values)
 
                 row_maxes.copy_(new_row_maxes)
                 row_sums.copy_(new_row_sums)
 
+            oc.div_(row_sums)
+
+        lse = all_row_sums.log() + all_row_maxes
+
         ctx.args = (causal, scale, mask, q_bucket_size, k_bucket_size)
-        ctx.save_for_backward(q, k, v, o, all_row_sums, all_row_maxes)
+        ctx.save_for_backward(q, k, v, o, lse)
 
         return o
 
     @staticmethod
     @torch.no_grad()
     def backward(ctx, do):
-        """Algorithm 4 in the paper"""
+        """ Algorithm 2 in the v2 paper """
 
         causal, scale, mask, q_bucket_size, k_bucket_size = ctx.args
-        q, k, v, o, l, m = ctx.saved_tensors
+        q, k, v, o, lse = ctx.saved_tensors
 
         device = q.device
 
@@ -260,12 +265,11 @@ class FlashAttentionFunction(torch.autograd.Function):
             o.split(q_bucket_size, dim=-2),
             do.split(q_bucket_size, dim=-2),
             mask,
-            l.split(q_bucket_size, dim=-2),
-            m.split(q_bucket_size, dim=-2),
-            dq.split(q_bucket_size, dim=-2),
+            lse.split(q_bucket_size, dim =-2),
+            dq.split(q_bucket_size, dim =-2)
         )
 
-        for ind, (qc, oc, doc, row_mask, lc, mc, dqc) in enumerate(row_splits):
+        for ind, (qc, oc, doc, row_mask, lsec, dqc) in enumerate(row_splits):
             q_start_index = ind * q_bucket_size - qk_len_diff
 
             col_splits = zip(
@@ -273,25 +277,22 @@ class FlashAttentionFunction(torch.autograd.Function):
                 v.split(k_bucket_size, dim=-2),
                 dk.split(k_bucket_size, dim=-2),
                 dv.split(k_bucket_size, dim=-2),
+                row_mask
             )
 
-            for k_ind, (kc, vc, dkc, dvc) in enumerate(col_splits):
+            for k_ind, (kc, vc, dkc, dvc, col_mask) in enumerate(col_splits):
                 k_start_index = k_ind * k_bucket_size
 
                 attn_weights = torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
 
                 if causal and q_start_index < (k_start_index + k_bucket_size - 1):
-                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(
-                        q_start_index - k_start_index + 1
-                    )
+                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                exp_attn_weights = torch.exp(attn_weights - mc)
+                p = torch.exp(attn_weights - lsec).half() # The half part isn't in the original code, but it complains without it
 
-                if exists(row_mask):
-                    exp_attn_weights.masked_fill_(~row_mask, 0.0)
-
-                p = exp_attn_weights / lc
+                if exists(col_mask):
+                    p.masked_fill_(~col_mask, 0.)
 
                 dv_chunk = torch.einsum("... i j, ... i d -> ... j d", p, doc)
                 dp = torch.einsum("... i d, ... j d -> ... i j", doc, vc)

--- a/library/original_unet.py
+++ b/library/original_unet.py
@@ -290,7 +290,7 @@ class FlashAttentionFunction(torch.autograd.Function):
                     causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                p = torch.exp(attn_weights - lsec)
+                p = torch.exp(attn_weights - lsec).half()
 
                 if exists(col_mask):
                     p.masked_fill_(~col_mask, 0.)

--- a/library/original_unet.py
+++ b/library/original_unet.py
@@ -290,7 +290,7 @@ class FlashAttentionFunction(torch.autograd.Function):
                     causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                p = torch.exp(attn_weights - lsec).half() # The half part isn't in the original code, but it complains without it
+                p = torch.exp(attn_weights - lsec)
 
                 if exists(col_mask):
                     p.masked_fill_(~col_mask, 0.)

--- a/library/original_unet.py
+++ b/library/original_unet.py
@@ -162,11 +162,12 @@ class FlashAttentionFunction(torch.autograd.Function):
         """ Algorithm 1 in the v2 paper """
 
         device = q.device
+        dtype = q.dtype
         max_neg_value = -torch.finfo(q.dtype).max
         qk_len_diff = max(k.shape[-2] - q.shape[-2], 0)
 
         o = torch.zeros_like(q)
-        all_row_sums = torch.zeros((*q.shape[:-1], 1), device=device)
+        all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
         all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
 
         scale = q.shape[-1] ** -0.5

--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -200,7 +200,7 @@ class FlashAttentionFunction(torch.autograd.function.Function):
                     causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                p = torch.exp(attn_weights - lsec)
+                p = torch.exp(attn_weights - lsec).half()
 
                 if exists(col_mask):
                     p.masked_fill_(~col_mask, 0.)

--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -72,11 +72,12 @@ class FlashAttentionFunction(torch.autograd.function.Function):
         """ Algorithm 1 in the v2 paper """
 
         device = q.device
+        dtype = q.dtype
         max_neg_value = -torch.finfo(q.dtype).max
         qk_len_diff = max(k.shape[-2] - q.shape[-2], 0)
 
         o = torch.zeros_like(q)
-        all_row_sums = torch.zeros((*q.shape[:-1], 1), device=device)
+        all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
         all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
 
         scale = q.shape[-1] ** -0.5

--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -30,6 +30,7 @@ import torch.utils.checkpoint
 from torch import nn
 from torch.nn import functional as F
 from einops import rearrange
+from functools import partial
 
 
 IN_CHANNELS: int = 4
@@ -49,46 +50,49 @@ USE_REENTRANT = True
 
 # constants
 
-EPSILON = 1e-6
+EPSILON = 1e-10
 
 # helper functions
-
 
 def exists(val):
     return val is not None
 
-
 def default(val, d):
     return val if exists(val) else d
 
-
 # flash attention forwards and backwards
 
-# https://arxiv.org/abs/2205.14135
+# flash attention v1 - https://arxiv.org/abs/2205.14135
+# flash attention v2 - https://tridao.me/publications/flash2/flash2.pdf
 
-
-class FlashAttentionFunction(torch.autograd.Function):
+class FlashAttentionFunction(torch.autograd.function.Function):
     @staticmethod
     @torch.no_grad()
     def forward(ctx, q, k, v, mask, causal, q_bucket_size, k_bucket_size):
-        """Algorithm 2 in the paper"""
+        """ Algorithm 1 in the v2 paper """
 
         device = q.device
-        dtype = q.dtype
         max_neg_value = -torch.finfo(q.dtype).max
         qk_len_diff = max(k.shape[-2] - q.shape[-2], 0)
 
         o = torch.zeros_like(q)
-        all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
-        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, dtype=dtype, device=device)
+        all_row_sums = torch.zeros((*q.shape[:-1], 1), device=device)
+        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
 
         scale = q.shape[-1] ** -0.5
 
+        num_row_tiles = math.ceil(q.shape[-2] / q_bucket_size)
+        num_col_tiles = math.ceil(k.shape[-2] / k_bucket_size)
+
+        if exists(mask) and mask.ndim == 2:
+            mask = rearrange(mask, 'b n -> b 1 1 n')
+
         if not exists(mask):
-            mask = (None,) * math.ceil(q.shape[-2] / q_bucket_size)
+            col_masks = (None,) * num_col_tiles
+            mask = (col_masks,) * num_row_tiles 
         else:
-            mask = rearrange(mask, "b n -> b 1 1 n")
-            mask = mask.split(q_bucket_size, dim=-1)
+            mask = ((mask,) * num_row_tiles) if mask.shape[-2] == 1 else mask.split(q_bucket_size, dim=-2)
+            mask = tuple(((row_mask,) * num_col_tiles) if row_mask.shape[-1] == 1 else row_mask.split(k_bucket_size, dim=-1) for row_mask in mask)
 
         row_splits = zip(
             q.split(q_bucket_size, dim=-2),
@@ -104,57 +108,58 @@ class FlashAttentionFunction(torch.autograd.Function):
             col_splits = zip(
                 k.split(k_bucket_size, dim=-2),
                 v.split(k_bucket_size, dim=-2),
+                row_mask
             )
 
-            for k_ind, (kc, vc) in enumerate(col_splits):
+            for k_ind, (kc, vc, col_mask) in enumerate(col_splits):
                 k_start_index = k_ind * k_bucket_size
 
                 attn_weights = torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
 
-                if exists(row_mask):
-                    attn_weights.masked_fill_(~row_mask, max_neg_value)
+                if exists(col_mask):
+                    attn_weights.masked_fill_(~col_mask, max_neg_value)
 
                 if causal and q_start_index < (k_start_index + k_bucket_size - 1):
-                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(
-                        q_start_index - k_start_index + 1
-                    )
+                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
                 block_row_maxes = attn_weights.amax(dim=-1, keepdims=True)
-                attn_weights -= block_row_maxes
-                exp_weights = torch.exp(attn_weights)
+                new_row_maxes = torch.maximum(block_row_maxes, row_maxes)
 
-                if exists(row_mask):
-                    exp_weights.masked_fill_(~row_mask, 0.0)
+                exp_weights = torch.exp(attn_weights - new_row_maxes)
+
+                if exists(col_mask):
+                    exp_weights.masked_fill_(~col_mask, 0.)
 
                 block_row_sums = exp_weights.sum(dim=-1, keepdims=True).clamp(min=EPSILON)
-
-                new_row_maxes = torch.maximum(block_row_maxes, row_maxes)
 
                 exp_values = torch.einsum("... i j, ... j d -> ... i d", exp_weights, vc)
 
                 exp_row_max_diff = torch.exp(row_maxes - new_row_maxes)
-                exp_block_row_max_diff = torch.exp(block_row_maxes - new_row_maxes)
 
-                new_row_sums = exp_row_max_diff * row_sums + exp_block_row_max_diff * block_row_sums
+                new_row_sums = exp_row_max_diff * row_sums + block_row_sums
 
-                oc.mul_((row_sums / new_row_sums) * exp_row_max_diff).add_((exp_block_row_max_diff / new_row_sums) * exp_values)
+                oc.mul_(exp_row_max_diff).add_(exp_values)
 
                 row_maxes.copy_(new_row_maxes)
                 row_sums.copy_(new_row_sums)
 
+            oc.div_(row_sums)
+
+        lse = all_row_sums.log() + all_row_maxes
+
         ctx.args = (causal, scale, mask, q_bucket_size, k_bucket_size)
-        ctx.save_for_backward(q, k, v, o, all_row_sums, all_row_maxes)
+        ctx.save_for_backward(q, k, v, o, lse)
 
         return o
 
     @staticmethod
     @torch.no_grad()
     def backward(ctx, do):
-        """Algorithm 4 in the paper"""
+        """ Algorithm 2 in the v2 paper """
 
         causal, scale, mask, q_bucket_size, k_bucket_size = ctx.args
-        q, k, v, o, l, m = ctx.saved_tensors
+        q, k, v, o, lse = ctx.saved_tensors
 
         device = q.device
 
@@ -170,12 +175,11 @@ class FlashAttentionFunction(torch.autograd.Function):
             o.split(q_bucket_size, dim=-2),
             do.split(q_bucket_size, dim=-2),
             mask,
-            l.split(q_bucket_size, dim=-2),
-            m.split(q_bucket_size, dim=-2),
-            dq.split(q_bucket_size, dim=-2),
+            lse.split(q_bucket_size, dim=-2),
+            dq.split(q_bucket_size, dim=-2)
         )
 
-        for ind, (qc, oc, doc, row_mask, lc, mc, dqc) in enumerate(row_splits):
+        for ind, (qc, oc, doc, row_mask, lsec, dqc) in enumerate(row_splits):
             q_start_index = ind * q_bucket_size - qk_len_diff
 
             col_splits = zip(
@@ -183,25 +187,22 @@ class FlashAttentionFunction(torch.autograd.Function):
                 v.split(k_bucket_size, dim=-2),
                 dk.split(k_bucket_size, dim=-2),
                 dv.split(k_bucket_size, dim=-2),
+                row_mask
             )
 
-            for k_ind, (kc, vc, dkc, dvc) in enumerate(col_splits):
+            for k_ind, (kc, vc, dkc, dvc, col_mask) in enumerate(col_splits):
                 k_start_index = k_ind * k_bucket_size
 
                 attn_weights = torch.einsum("... i d, ... j d -> ... i j", qc, kc) * scale
 
                 if causal and q_start_index < (k_start_index + k_bucket_size - 1):
-                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(
-                        q_start_index - k_start_index + 1
-                    )
+                    causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                exp_attn_weights = torch.exp(attn_weights - mc)
+                p = torch.exp(attn_weights - lsec).half() # The half part isn't in the original code, but it complains without it
 
-                if exists(row_mask):
-                    exp_attn_weights.masked_fill_(~row_mask, 0.0)
-
-                p = exp_attn_weights / lc
+                if exists(col_mask):
+                    p.masked_fill_(~col_mask, 0.)
 
                 dv_chunk = torch.einsum("... i j, ... i d -> ... j d", p, doc)
                 dp = torch.einsum("... i d, ... j d -> ... i j", doc, vc)

--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -200,7 +200,7 @@ class FlashAttentionFunction(torch.autograd.function.Function):
                     causal_mask = torch.ones((qc.shape[-2], kc.shape[-2]), dtype=torch.bool, device=device).triu(q_start_index - k_start_index + 1)
                     attn_weights.masked_fill_(causal_mask, max_neg_value)
 
-                p = torch.exp(attn_weights - lsec).half() # The half part isn't in the original code, but it complains without it
+                p = torch.exp(attn_weights - lsec)
 
                 if exists(col_mask):
                     p.masked_fill_(~col_mask, 0.)

--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -78,7 +78,7 @@ class FlashAttentionFunction(torch.autograd.function.Function):
 
         o = torch.zeros_like(q)
         all_row_sums = torch.zeros((*q.shape[:-1], 1), dtype=dtype, device=device)
-        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, device=device)
+        all_row_maxes = torch.full((*q.shape[:-1], 1), max_neg_value, dtype=dtype, device=device)
 
         scale = q.shape[-1] ** -0.5
 


### PR DESCRIPTION
Replaces the memory efficient attention from [here](https://github.com/lucidrains/memory-efficient-attention-pytorch) with the v2 version they updated to a few months ago. I can't tell if this is flash attention v2, or just v1 with some changes related to v2.

I had to add a `.half()` to p or else it would complain about being a float. Not sure how that changes things.

I don't really know what this stuff is all doing, but I noticed there was updated code and it wasn't much different so I tried copying it over. Hopefully someone can look over this with more expertise to confirm if it needs changes.

I also made some minor changes to reduce the github differences to make it easier to see changes.

I haven't tested speed or memory changes, but it does seem to train as expected.

edit: I don't see a memory or speed change. idrk.