### PR TITLE
Sync steps to prevent unexpected crash

### DIFF
--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -591,6 +591,7 @@ def train(args):
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
+            accelerator.wait_for_everyone()
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:
                 progress_bar.update(1)
@@ -607,10 +608,10 @@ def train(args):
                     [text_encoder1, text_encoder2],
                     unet,
                 )
+                accelerator.wait_for_everyone()
 
                 # 指定ステップごとにモデルを保存
                 if args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0:
-                    accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
                         sdxl_train_util.save_sd_model_on_epoch_end_or_stepwise(
@@ -631,6 +632,7 @@ def train(args):
                             logit_scale,
                             ckpt_info,
                         )
+                    accelerator.wait_for_everyone()
 
             current_loss = loss.detach().item()  # 平均なのでbatch sizeは関係ないはず
             if args.logging_dir is not None:
@@ -677,6 +679,7 @@ def train(args):
                     logit_scale,
                     ckpt_info,
                 )
+            accelerator.wait_for_everyone()
 
         sdxl_train_util.sample_images(
             accelerator,
@@ -689,6 +692,7 @@ def train(args):
             [text_encoder1, text_encoder2],
             unet,
         )
+        accelerator.wait_for_everyone()
 
     is_main_process = accelerator.is_main_process
     # if is_main_process:


### PR DESCRIPTION
I've found a bug that occurs while finetuning SD XL with multi-GPU configuration.

### Bug description
The steps across different accelerator processes are not synchronized. It happened when I configured `--sample_every_n_steps`. For example, the progress bar shows it's in the 950th step, but somehow one of the accelerator processes says it has already built a pipeline for generating the sample image for the 1000th step, yet another process says it's about to generate the sample image for the 900th step. If I were to let it run further, the discrepancy in steps across different processes would get even more significant and the script would eventually crash, throwing an NCCL DDP timeout error.

I've also tried to configure `--ddp_timeout=999999` in the training argument. It didn't throw a timeout error this time and finished training, but the script stalled just before it could save the final model checkpoint.

### What I did
I've added several `accelerator.wait_for_everyone()` to ensure that all accelerator processes synchronize step counts, without slowing down the overall training process. From my empirical findings, the output sample images I got from `--sample_every_n_steps` improved in quality after this fix (random seed controlled).

The above scenarios happened for `sdxl_train.py`, but I suspect it could happen to other training scripts. This pull request only tackled `sdxl_train.py`, so you might want to test other training scripts as well.