### PR TITLE
Fix multi-gpu SDXL training

### DIFF
--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -398,6 +398,9 @@ def train(args):
     if train_unet:
         unet = accelerator.prepare(unet)
     if train_text_encoder1:
+        # freeze last layer and final_layer_norm in te1 since we use the output of the penultimate layer
+        text_encoder1.text_model.encoder.layers[-1].requires_grad_(False)
+        text_encoder1.text_model.final_layer_norm.requires_grad_(False)
         text_encoder1 = accelerator.prepare(text_encoder1)
     if train_text_encoder2:
         text_encoder2 = accelerator.prepare(text_encoder2)


### PR DESCRIPTION
- Fix : #994 
- Fix: #997 

- Add `--gradient_as_bucket_view` to reduce VRAM usage in DDP training
- Add `--static_graph` to solve conflict between DDP and gradients checkpoints 
- Freeze the last layer of text_encoder1 in `sdxl_train.py` since it doesn't participate in loss calculation, used to prevent RuntimeError in DDP training

These are related to text_encoders training, so I tested them by training text_encoders on 2 GPUs due to the limited VRAM.