### PR TITLE
Added cli argument for wandb session name

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2936,6 +2936,12 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         help="name of tracker to use for logging, default is script-specific default name / ログ出力に使用するtrackerの名前、省略時はスクリプトごとのデフォルト名",
     )
     parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help="The name of the specific wandb session / wandb ログに表示される特定の実行の名前",
+    )
+    parser.add_argument(
         "--log_tracker_config",
         type=str,
         default=None,

--- a/train_network.py
+++ b/train_network.py
@@ -684,6 +684,8 @@ class NetworkTrainer:
 
         if accelerator.is_main_process:
             init_kwargs = {}
+            if args.wandb_run_name:
+                init_kwargs['wandb'] = {'name': args.wandb_run_name}
             if args.log_tracker_config is not None:
                 init_kwargs = toml.load(args.log_tracker_config)
             accelerator.init_trackers(


### PR DESCRIPTION
Adds a command line argument that allows users to specify the wandb session name of their run.
Without this feature session names are not indicative.
While it is possible to fetch logger kwargs from a configuration toml this is cumbersome when sessions names are created in run time, which is very often the case.

This PR was first opened to the kohya_ss repo and now reopend in the sd_scripts repo as required.
https://github.com/bmaltais/kohya_ss/pull/1825
