### PR TITLE
Enable distributed sample image generation on multi-GPU enviroment

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3380,7 +3380,9 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
 
     if not args.resume_from_huggingface:
         print(f"resume training from local state: {args.resume}")
+        print(check_vram_usage(f"Before loading state from {args.resume}")
         accelerator.load_state(args.resume)
+        print(check_vram_usage(f"After loading state from {args.resume}")
         return
 
     print(f"resume training from huggingface state: {args.resume}")
@@ -3422,7 +3424,9 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
     if len(results) == 0:
         raise ValueError("No files found in the specified repo id/path/revision / 指定されたリポジトリID/パス/リビジョンにファイルが見つかりませんでした")
     dirname = os.path.dirname(results[0])
+    print(check_vram_usage(f"Before loading huggingface state from {args.resume}")
     accelerator.load_state(dirname)
+    print(check_vram_usage(f"After loading huggingface state from {args.resume}")
 
 
 def get_optimizer(args, trainable_params):

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4729,7 +4729,8 @@ def sample_images_common(
         prompts = temp_prompts
         temp_prompts = []
         num_of_processes = distributed_state.num_processes
-        for i in range(num_of_processes) temp_prompts.append([])
+        for i in range(num_of_processes):
+            temp_prompts.append([])
         for i in range(len(prompts)) temp_prompts.[i%num_of_processes] = prompts[i]
         prompts=temp_prompts
         del temp_prompts

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4708,33 +4708,32 @@ def sample_images_common(
     print(check_vram_usage("After create pipeline"))
     save_dir = args.output_dir + "/sample"
     os.makedirs(save_dir, exist_ok=True)
-    if accelerator.is_main_process:
-        temp_prompts = []
-        for i, prompt_dict in enumerate(prompts):
-            if isinstance(prompt_dict, str):
-                prompt_dict = line_to_prompt_dict(prompt_dict)
-            assert isinstance(prompt_dict, dict)
-            temp_dict: dict = {}
-            temp_dict["negative_prompt"] = prompt_dict.get("negative_prompt")
-            temp_dict["sample_steps"] = prompt_dict.get("sample_steps", 30)
-            temp_dict["width"] = prompt_dict.get("width", 512)
-            temp_dict["height"] = prompt_dict.get("height", 512)
-            temp_dict["scale"] = prompt_dict.get("scale", 7.5)
-            temp_dict["seed"] = prompt_dict.get("seed")
-            temp_dict["controlnet_image"] = prompt_dict.get("controlnet_image")
-            temp_dict["prompt"]: str = prompt_dict.get("prompt", "")
-            temp_dict["sample_sampler"]: str = prompt_dict.get("sample_sampler", args.sample_sampler)
-            temp_dict["enum"] = i
-            temp_prompts.append(temp_dict)
-        prompts = temp_prompts
-        temp_prompts = []
-        num_of_processes = distributed_state.num_processes
-        for i in range(num_of_processes):
-            temp_prompts.append([])
-        for i in range(len(prompts)):
-            temp_prompts[i%num_of_processes].append(prompts[i])
-        prompts=temp_prompts
-        del temp_prompts
+    temp_prompts = []
+    for i, prompt_dict in enumerate(prompts):
+        if isinstance(prompt_dict, str):
+            prompt_dict = line_to_prompt_dict(prompt_dict)
+        assert isinstance(prompt_dict, dict)
+        temp_dict: dict = {}
+        temp_dict["negative_prompt"] = prompt_dict.get("negative_prompt")
+        temp_dict["sample_steps"] = prompt_dict.get("sample_steps", 30)
+        temp_dict["width"] = prompt_dict.get("width", 512)
+        temp_dict["height"] = prompt_dict.get("height", 512)
+        temp_dict["scale"] = prompt_dict.get("scale", 7.5)
+        temp_dict["seed"] = prompt_dict.get("seed")
+        temp_dict["controlnet_image"] = prompt_dict.get("controlnet_image")
+        temp_dict["prompt"]: str = prompt_dict.get("prompt", "")
+        temp_dict["sample_sampler"]: str = prompt_dict.get("sample_sampler", args.sample_sampler)
+        temp_dict["enum"] = i
+        temp_prompts.append(temp_dict)
+    prompts = temp_prompts
+    temp_prompts = []
+    num_of_processes = distributed_state.num_processes
+    for i in range(num_of_processes):
+        temp_prompts.append([])
+    for i in range(len(prompts)):
+        temp_prompts[i%num_of_processes].append(prompts[i])
+    prompts=temp_prompts
+    del temp_prompts
     print(prompts)
     
     rng_state = torch.get_rng_state()

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4732,7 +4732,7 @@ def sample_images_common(
         for i in range(num_of_processes):
             temp_prompts.append([])
         for i in range(len(prompts)):
-            temp_prompts.[i%num_of_processes] = prompts[i]
+            temp_prompts[i%num_of_processes].append(prompts[i])
         prompts=temp_prompts
         del temp_prompts
     print(prompts)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4744,8 +4744,8 @@ def sample_images_common(
                 for prompt_dict in prompt_dict_lists:
                     print(prompt_dict)
             for prompt_dict in prompt_dict_lists:
-                if not accelerator.is_main_process:
-                    continue
+#                if not accelerator.is_main_process:
+#                    continue
 
                 if isinstance(prompt_dict, str):
                     prompt_dict = line_to_prompt_dict(prompt_dict)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4731,7 +4731,8 @@ def sample_images_common(
         num_of_processes = distributed_state.num_processes
         for i in range(num_of_processes):
             temp_prompts.append([])
-        for i in range(len(prompts)) temp_prompts.[i%num_of_processes] = prompts[i]
+        for i in range(len(prompts)):
+            temp_prompts.[i%num_of_processes] = prompts[i]
         prompts=temp_prompts
         del temp_prompts
     print(prompts)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4809,7 +4809,7 @@ def sample_images_common(
                 seed_suffix = "" if seed is None else f"_{seed}"
                 i: int = prompt_dict["enum"]
                 img_filename = (
-                    f"{'' if args.output_name is None else args.output_name + '_'}{num_suffix}_{i:02d}_{ts_str}{'' if seed is None else '_' + seed_suffix}.png"
+                    f"{'' if args.output_name is None else args.output_name + '_'}{ts_str}_{num_suffix}_{i:02d}{seed_suffix}.png"
                 )
 
                 image.save(os.path.join(save_dir, img_filename))

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4698,11 +4698,26 @@ def sample_images_common(
     print(check_vram_usage("After create pipeline"))
     save_dir = args.output_dir + "/sample"
     os.makedirs(save_dir, exist_ok=True)
+    print(prompts)
+    temp_prompts = []
     for i, prompt_dict in enumerate(prompts):
         if isinstance(prompt_dict, str):
             prompt_dict = line_to_prompt_dict(prompt_dict)
         assert isinstance(prompt_dict, dict)
-        prompt_dict["enum"] = i
+        temp_dict["negative_prompt"] = prompt_dict.get("negative_prompt")
+        temp_dict["sample_steps"] = prompt_dict.get("sample_steps", 30)
+        temp_dict["width"] = prompt_dict.get("width", 512)
+        temp_dict["height"] = prompt_dict.get("height", 512)
+        temp_dict["scale"] = prompt_dict.get("scale", 7.5)
+        temp_dict["seed"] = prompt_dict.get("seed")
+        temp_dict["controlnet_image"] = prompt_dict.get("controlnet_image")
+        temp_dict["prompt"]: str = prompt_dict.get("prompt", "")
+        temp_dict["sample_sampler"]: str = prompt_dict.get("sample_sampler", args.sample_sampler)
+        temp_dict["enum"] = i
+        temp_prompts.append(temp_dict)
+
+    prompts = temp_prompts
+    del temp_prompts
 
     print("Debug output of prompts value:")
     print(prompts)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4708,26 +4708,32 @@ def sample_images_common(
     print(check_vram_usage("After create pipeline"))
     save_dir = args.output_dir + "/sample"
     os.makedirs(save_dir, exist_ok=True)
-    temp_prompts = []
-    for i, prompt_dict in enumerate(prompts):
-        if isinstance(prompt_dict, str):
-            prompt_dict = line_to_prompt_dict(prompt_dict)
-        assert isinstance(prompt_dict, dict)
-        temp_dict: dict = {}
-        temp_dict["negative_prompt"] = prompt_dict.get("negative_prompt")
-        temp_dict["sample_steps"] = prompt_dict.get("sample_steps", 30)
-        temp_dict["width"] = prompt_dict.get("width", 512)
-        temp_dict["height"] = prompt_dict.get("height", 512)
-        temp_dict["scale"] = prompt_dict.get("scale", 7.5)
-        temp_dict["seed"] = prompt_dict.get("seed")
-        temp_dict["controlnet_image"] = prompt_dict.get("controlnet_image")
-        temp_dict["prompt"]: str = prompt_dict.get("prompt", "")
-        temp_dict["sample_sampler"]: str = prompt_dict.get("sample_sampler", args.sample_sampler)
-        temp_dict["enum"] = i
-        temp_prompts.append(temp_dict)
-
-    prompts = temp_prompts
-    del temp_prompts
+    if accelerator.is_main_process:
+        temp_prompts = []
+        for i, prompt_dict in enumerate(prompts):
+            if isinstance(prompt_dict, str):
+                prompt_dict = line_to_prompt_dict(prompt_dict)
+            assert isinstance(prompt_dict, dict)
+            temp_dict: dict = {}
+            temp_dict["negative_prompt"] = prompt_dict.get("negative_prompt")
+            temp_dict["sample_steps"] = prompt_dict.get("sample_steps", 30)
+            temp_dict["width"] = prompt_dict.get("width", 512)
+            temp_dict["height"] = prompt_dict.get("height", 512)
+            temp_dict["scale"] = prompt_dict.get("scale", 7.5)
+            temp_dict["seed"] = prompt_dict.get("seed")
+            temp_dict["controlnet_image"] = prompt_dict.get("controlnet_image")
+            temp_dict["prompt"]: str = prompt_dict.get("prompt", "")
+            temp_dict["sample_sampler"]: str = prompt_dict.get("sample_sampler", args.sample_sampler)
+            temp_dict["enum"] = i
+            temp_prompts.append(temp_dict)
+        prompts = temp_prompts
+        temp_prompts = []
+        num_of_processes = distributed_state.num_processes
+        for i in range(num_of_processes) temp_prompts.append([])
+        for i in range(len(prompts)) temp_prompts.[i%num_of_processes] = prompts[i]
+        prompts=temp_prompts
+        del temp_prompts
+    print(prompts)
     
     rng_state = torch.get_rng_state()
     cuda_rng_state = torch.cuda.get_rng_state() if torch.cuda.is_available() else None
@@ -4737,13 +4743,13 @@ def sample_images_common(
         with distributed_state.split_between_processes(prompts) as prompt_dict_lists:
             if accelerator.is_main_process:
                 print(f"Running on main Accelerator on {torch.cuda.current_device()}")
-                for prompt_dict in prompt_dict_lists:
+                for prompt_dict in prompt_dict_lists[0]:
                     print(prompt_dict)
             else:
                 print(f"Running on sub Accelerator on {torch.cuda.current_device()}")
-                for prompt_dict in prompt_dict_lists:
+                for prompt_dict in prompt_dict_lists[0]:
                     print(prompt_dict)
-            for prompt_dict in prompt_dict_lists:
+            for prompt_dict in prompt_dict_lists[0]:
 #                if not accelerator.is_main_process:
 #                    continue
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4626,8 +4626,7 @@ def sample_images_common(
     """
     StableDiffusionLongPromptWeightingPipelineの改造版を使うようにしたので、clip skipおよびプロンプトの重みづけに対応した
     """
-    print(check_vram_usage("Start of Image Sample Generation"))
-    distributed_state = PartialState() #testing implementation of multi gpu distributed inference
+
     if steps == 0:
         if not args.sample_at_first:
             return
@@ -4641,7 +4640,8 @@ def sample_images_common(
         else:
             if steps % args.sample_every_n_steps != 0 or epoch is not None:  # steps is not divisible or end of epoch
                 return
-
+    print(check_vram_usage("Start of Image Sample Generation"))
+    distributed_state = PartialState() #testing implementation of multi gpu distributed inference
     print(f"\ngenerating sample images at step / サンプル画像生成 ステップ: {steps}")
     if not os.path.isfile(args.sample_prompts):
         print(f"No prompt file / プロンプトファイルがありません: {args.sample_prompts}")

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4607,7 +4607,7 @@ def line_to_prompt_dict(line: str) -> dict:
     return prompt_dict
 
 def check_vram_usage(at_called_point):
-    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n{torch.cuda.memory_summary()}\n"
+    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n{torch.cuda.memory_summary(None, True)}\n"
 
 def sample_images_common(
     pipe_class,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4808,7 +4808,7 @@ def sample_images_common(
     for i in range(torch.cuda.device_count()):
         with torch.cuda.device(f'cuda:{i}'):
             torch.cuda.empty_cache()
-            print(check_vram_usage("After empty cache on cuda:{i}")
+            print(check_vram_usage("After empty cache on cuda:{i}"))
     
     torch.set_rng_state(rng_state)
     if cuda_rng_state is not None:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3380,9 +3380,9 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
 
     if not args.resume_from_huggingface:
         print(f"resume training from local state: {args.resume}")
-        print(check_vram_usage(f"Before loading state from {args.resume}")
+        print(check_vram_usage(f"Before loading state from {args.resume}"))
         accelerator.load_state(args.resume)
-        print(check_vram_usage(f"After loading state from {args.resume}")
+        print(check_vram_usage(f"After loading state from {args.resume}"))
         return
 
     print(f"resume training from huggingface state: {args.resume}")
@@ -3424,9 +3424,9 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
     if len(results) == 0:
         raise ValueError("No files found in the specified repo id/path/revision / 指定されたリポジトリID/パス/リビジョンにファイルが見つかりませんでした")
     dirname = os.path.dirname(results[0])
-    print(check_vram_usage(f"Before loading huggingface state from {args.resume}")
+    print(check_vram_usage(f"Before loading huggingface state from {args.resume}"))
     accelerator.load_state(dirname)
-    print(check_vram_usage(f"After loading huggingface state from {args.resume}")
+    print(check_vram_usage(f"After loading huggingface state from {args.resume}"))
 
 
 def get_optimizer(args, trainable_params):

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4736,7 +4736,8 @@ def sample_images_common(
             if isinstance(prompt_dict, str):
                 prompt_dict = line_to_prompt_dict(prompt_dict)
 
-            assert isinstance(prompt_dict, dict)
+#            assert isinstance(prompt_dict, dict)
+            print(prompt_dict)
             negative_prompt = prompt_dict.get("negative_prompt")
             sample_steps = prompt_dict.get("sample_steps", 30)
             width = prompt_dict.get("width", 512)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4702,7 +4702,6 @@ def sample_images_common(
     print(check_vram_usage("After create pipeline"))
     save_dir = args.output_dir + "/sample"
     os.makedirs(save_dir, exist_ok=True)
-    print(prompts)
     temp_prompts = []
     for i, prompt_dict in enumerate(prompts):
         if isinstance(prompt_dict, str):
@@ -4723,9 +4722,6 @@ def sample_images_common(
 
     prompts = temp_prompts
     del temp_prompts
-
-    print("Debug output of prompts value:")
-    print(prompts)
     
     rng_state = torch.get_rng_state()
     cuda_rng_state = torch.cuda.get_rng_state() if torch.cuda.is_available() else None
@@ -4741,7 +4737,6 @@ def sample_images_common(
                     prompt_dict = line_to_prompt_dict(prompt_dict)
 
                 assert isinstance(prompt_dict, dict)
-                print(prompt_dict)
                 negative_prompt = prompt_dict.get("negative_prompt")
                 sample_steps = prompt_dict.get("sample_steps", 30)
                 width = prompt_dict.get("width", 512)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4713,8 +4713,9 @@ def sample_images_common(
     with torch.no_grad():
         # with accelerator.autocast():
         with distributed_state.split_between_processes(prompts) as prompt_dict:
-            if not accelerator.is_main_process:
-                continue
+            
+#            if not accelerator.is_main_process:
+#                continue
 
             if isinstance(prompt_dict, str):
                 prompt_dict = line_to_prompt_dict(prompt_dict)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4781,8 +4781,9 @@ def sample_images_common(
             ts_str = time.strftime("%Y%m%d%H%M%S", time.localtime())
             num_suffix = f"e{epoch:06d}" if epoch is not None else f"{steps:06d}"
             seed_suffix = "" if seed is None else f"_{seed}"
+            i: int = prompt_dict["enum"]
             img_filename = (
-                f"{'' if args.output_name is None else args.output_name + '_'}{ts_str}_{num_suffix}_{prompt_dict["enum"]:02d}{seed_suffix}.png"
+                f"{'' if args.output_name is None else args.output_name + '_'}{ts_str}_{num_suffix}_{i:02d}{seed_suffix}.png"
             )
 
             image.save(os.path.join(save_dir, img_filename))

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4825,7 +4825,7 @@ def sample_images_common(
     for i in range(torch.cuda.device_count()):
         with torch.cuda.device(f'cuda:{i}'):
             torch.cuda.empty_cache()
-            print(check_vram_usage("After empty cache on cuda:{i}"))
+            print(check_vram_usage(f"After empty cache on cuda:{i}"))
     
     torch.set_rng_state(rng_state)
     if cuda_rng_state is not None:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4607,7 +4607,7 @@ def line_to_prompt_dict(line: str) -> dict:
     return prompt_dict
 
 def check_vram_usage(at_called_point):
-    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n"
+    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n{torch.cuda.memory_summary()}\n"
 
 def sample_images_common(
     pipe_class,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4607,7 +4607,7 @@ def line_to_prompt_dict(line: str) -> dict:
     return prompt_dict
 
 def check_vram_usage(at_called_point):
-    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n{torch.cuda.memory_summary(None, True)}\n"
+    return f"\nChecking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n{torch.cuda.memory_summary(None, True)}\n"
 
 def sample_images_common(
     pipe_class,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4820,7 +4820,7 @@ def sample_images_common(
                 seed_suffix = "" if seed is None else f"_{seed}"
                 i: int = prompt_dict["enum"]
                 img_filename = (
-                    f"{'' if args.output_name is None else args.output_name + '_'}{num_suffix}_{i:02d}{ts_str}{'' if seed is None else '_' + seed_suffix}.png"
+                    f"{'' if args.output_name is None else args.output_name + '_'}{num_suffix}_{i:02d}_{ts_str}{'' if seed is None else '_' + seed_suffix}.png"
                 )
 
                 image.save(os.path.join(save_dir, img_filename))

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -19,7 +19,7 @@ from typing import (
     Tuple,
     Union,
 )
-from accelerate import Accelerator, InitProcessGroupKwargs, DistributedDataParallelKwargs
+from accelerate import Accelerator, InitProcessGroupKwargs, DistributedDataParallelKwargs, PartialState
 import gc
 import glob
 import math

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4814,7 +4814,7 @@ def sample_images_common(
                 seed_suffix = "" if seed is None else f"_{seed}"
                 i: int = prompt_dict["enum"]
                 img_filename = (
-                    f"{'' if args.output_name is None else args.output_name + '_'}{ts_str}_{num_suffix}_{i:02d}{seed_suffix}.png"
+                    f"{'' if args.output_name is None else args.output_name + '_'}{num_suffix}_{i:02d}{ts_str}{'' if seed is None else '_' + seed_suffix}.png"
                 )
 
                 image.save(os.path.join(save_dir, img_filename))

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4704,6 +4704,7 @@ def sample_images_common(
         if isinstance(prompt_dict, str):
             prompt_dict = line_to_prompt_dict(prompt_dict)
         assert isinstance(prompt_dict, dict)
+        temp_dict: dict = {}
         temp_dict["negative_prompt"] = prompt_dict.get("negative_prompt")
         temp_dict["sample_steps"] = prompt_dict.get("sample_steps", 30)
         temp_dict["width"] = prompt_dict.get("width", 512)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4607,7 +4607,7 @@ def line_to_prompt_dict(line: str) -> dict:
     return prompt_dict
 
 def check_vram_usage(at_called_point):
-    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated(0)/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved(0)/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved(0)/1024/1024/1024)}\n"
+    return f"Checking VRAM usage at: {at_called_point} on CUDA Device {torch.cuda.current_device()}\ntorch.cuda.memory_allocated: {(torch.cuda.memory_allocated()/1024/1024/1024)}\ntorch.cuda.memory_reserved: {(torch.cuda.memory_reserved()/1024/1024/1024)}\ntorch.cuda.max_memory_reserved: {(torch.cuda.max_memory_reserved()/1024/1024/1024)}\n"
 
 def sample_images_common(
     pipe_class,

--- a/train_network.py
+++ b/train_network.py
@@ -724,6 +724,7 @@ class NetworkTrainer:
             if os.path.exists(old_ckpt_file):
                 accelerator.print(f"removing old checkpoint: {old_ckpt_file}")
                 os.remove(old_ckpt_file)
+                
         # For --sample_at_first
         self.sample_images(accelerator, args, 0, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 

--- a/train_network.py
+++ b/train_network.py
@@ -235,9 +235,7 @@ class NetworkTrainer:
         vae_dtype = torch.float32 if args.no_half_vae else weight_dtype
 
         # モデルを読み込む
-        accelerator.print(train_util.check_vram_usage(f"Before load model on {torch.cuda.current_device()}"))
         model_version, text_encoder, vae, unet = self.load_target_model(args, weight_dtype, accelerator)
-        accelerator.print(train_util.check_vram_usage(f"After load model on {torch.cuda.current_device()}"))
 
         # text_encoder is List[CLIPTextModel] or CLIPTextModel
         text_encoders = text_encoder if isinstance(text_encoder, list) else [text_encoder]
@@ -341,7 +339,6 @@ class NetworkTrainer:
 
         # 学習に必要なクラスを準備する
         accelerator.print("prepare optimizer, data loader etc.")
-        accelerator.print(train_util.check_vram_usage(f"At start of preparations on {torch.cuda.current_device()}"))
 
         # 後方互換性を確保するよ
         try:
@@ -463,7 +460,6 @@ class NetworkTrainer:
         total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
 
         accelerator.print("running training / 学習開始")
-        accelerator.print(train_util.check_vram_usage("At start of training"))
         accelerator.print(f"  num train images * repeats / 学習画像の数×繰り返し回数: {train_dataset_group.num_train_images}")
         accelerator.print(f"  num reg images / 正則化画像の数: {train_dataset_group.num_reg_images}")
         accelerator.print(f"  num batches per epoch / 1epochのバッチ数: {len(train_dataloader)}")
@@ -732,14 +728,12 @@ class NetworkTrainer:
             if os.path.exists(old_ckpt_file):
                 accelerator.print(f"removing old checkpoint: {old_ckpt_file}")
                 os.remove(old_ckpt_file)
-        accelerator.print(train_util.check_vram_usage("Before sample at first"))
         # For --sample_at_first
         self.sample_images(accelerator, args, 0, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
         # training loop
         for epoch in range(num_train_epochs):
             accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")
-            accelerator.print(train_util.check_vram_usage(f"at start of epoch {epoch+1}/{num_train_epochs}"))
             current_epoch.value = epoch + 1
 
             metadata["ss_epoch"] = str(epoch + 1)

--- a/train_network.py
+++ b/train_network.py
@@ -225,10 +225,6 @@ class NetworkTrainer:
         print("preparing accelerator")
         accelerator = train_util.prepare_accelerator(args)
         is_main_process = accelerator.is_main_process
-        if accelerator.is_main_process:
-            accelerator.print(f"Running on main Accelerator on {torch.cuda.current_device()}")
-        else:
-           accelerator. print(f"Running on sub Accelerator on {torch.cuda.current_device()}")
 
         # mixed precisionに対応した型を用意しておき適宜castする
         weight_dtype, save_dtype = train_util.prepare_dtype(args)

--- a/train_network.py
+++ b/train_network.py
@@ -724,7 +724,7 @@ class NetworkTrainer:
             if os.path.exists(old_ckpt_file):
                 accelerator.print(f"removing old checkpoint: {old_ckpt_file}")
                 os.remove(old_ckpt_file)
-                
+
         # For --sample_at_first
         self.sample_images(accelerator, args, 0, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 

--- a/train_network.py
+++ b/train_network.py
@@ -456,6 +456,7 @@ class NetworkTrainer:
         total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
 
         accelerator.print("running training / 学習開始")
+        accelerator.print(train_util.check_vram_usage("At start of training"))
         accelerator.print(f"  num train images * repeats / 学習画像の数×繰り返し回数: {train_dataset_group.num_train_images}")
         accelerator.print(f"  num reg images / 正則化画像の数: {train_dataset_group.num_reg_images}")
         accelerator.print(f"  num batches per epoch / 1epochのバッチ数: {len(train_dataloader)}")
@@ -724,13 +725,14 @@ class NetworkTrainer:
             if os.path.exists(old_ckpt_file):
                 accelerator.print(f"removing old checkpoint: {old_ckpt_file}")
                 os.remove(old_ckpt_file)
-
+        accelerator.print(train_util.check_vram_usage("Before sample at first"))
         # For --sample_at_first
         self.sample_images(accelerator, args, 0, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
         # training loop
         for epoch in range(num_train_epochs):
             accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")
+            accelerator.print(train_util.check_vram_usage(f"at start of epoch {epoch+1}/{num_train_epochs}"))
             current_epoch.value = epoch + 1
 
             metadata["ss_epoch"] = str(epoch + 1)


### PR DESCRIPTION
Modified the sample_images_common function to make use of Accelerator PartialState to feed the list of sample images prompt to all available GPUs.

Tested working fine in single GPU Google Colab enviroment and dual GPU Kaggle enviroment.

Possible side effect of using mutliple GPUs to generate sample images is that the file creation time may not sync with the order of the prompt from the original prompt file. Attempted some mitigation by spliting prompts to passed to each GPU process in the in the order that the GPU process is called. However, if the sample image prompts have different samplers and/or number of steps, this would likely break the workaround as generation times would be out of sync.

Might be able to artificially force syncronization by making the sample image process wait for all other processes to complete the image generation step before continuing to the next sample image by using `accelerator.wait_for_everyone()` but I imagine efficient use of GPU time would be more important than perfectly sorted sample images based on image creation time.