### PR TITLE
Soft min SNR gamma

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -27,6 +27,7 @@ from library.config_util import (
 import library.custom_train_functions as custom_train_functions
 from library.custom_train_functions import (
     apply_snr_weight,
+    apply_soft_snr_weight,
     get_weighted_text_embeddings,
     prepare_scheduler_for_custom_training,
     scale_v_prediction_loss_like_noise_prediction,
@@ -353,6 +354,8 @@ def train(args):
 
                     if args.min_snr_gamma:
                         loss = apply_snr_weight(loss, timesteps, noise_scheduler, args.min_snr_gamma, args.v_parameterization)
+                    if args.soft_min_snr_gamma:
+                        loss = apply_soft_snr_weight(loss, timesteps, noise_scheduler, args.soft_min_snr_gamma, args.v_parameterization)
                     if args.scale_v_pred_loss_like_noise_pred:
                         loss = scale_v_prediction_loss_like_noise_prediction(loss, timesteps, noise_scheduler)
                     if args.debiased_estimation_loss:

--- a/library/custom_train_functions.py
+++ b/library/custom_train_functions.py
@@ -70,19 +70,7 @@ def apply_snr_weight(loss, timesteps, noise_scheduler, gamma, v_prediction=False
 
 def apply_soft_snr_weight(loss, timesteps, noise_scheduler, gamma, v_prediction=False):
     snr = torch.stack([noise_scheduler.all_snr[t] for t in timesteps])
-    # min_snr_gamma = torch.minimum(snr, torch.full_like(snr, gamma))
-    soft_min_snr_gamma_weight = 1 / (torch.pow(snr, 2) + (1 / float(gamma)))
-    with open("snr.txt", "a") as myfile:
-        myfile.write(f"{snr.item()},{gamma}\n")
-
-    # with open("snrmin.txt", "a") as myfile:
-    #     myfile.write(f"{min_snr_gamma.item()},{soft_min_snr_gamma.item()}\n")
-    # print("soft_min_snr_gamma", soft_min_snr_gamma, 1 / (snr + (1 / float(gamma))))
-    # print("min_snr_gamma", min_snr_gamma)
-    # if v_prediction:
-    #     snr_weight = torch.div(soft_min_snr_gamma, snr+1).float().to(loss.device)
-    # else:
-    #     snr_weight = torch.div(soft_min_snr_gamma, snr).float().to(loss.device)
+    soft_min_snr_gamma_weight = 1 / (torch.pow(snr if v_prediction is False else snr + 1, 2) + (1 / float(gamma)))
     loss = loss * soft_min_snr_gamma_weight
     return loss
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4809,7 +4809,7 @@ def sample_images_common(
                 except ImportError:  # 事前に一度確認するのでここはエラー出ないはず
                     raise ImportError("No wandb / wandb がインストールされていないようです")
 
-                wandb_tracker.log({f"sample_{i}": wandb.Image(image)}, step=steps)
+                wandb_tracker.log({f"sample_{i}": wandb.Image(image)})
             except:  # wandb 無効時
                 pass
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4809,7 +4809,7 @@ def sample_images_common(
                 except ImportError:  # 事前に一度確認するのでここはエラー出ないはず
                     raise ImportError("No wandb / wandb がインストールされていないようです")
 
-                wandb_tracker.log({f"sample_{i}": wandb.Image(image)})
+                wandb_tracker.log({f"sample_{i}": wandb.Image(image)}, step=steps)
             except:  # wandb 無効時
                 pass
 

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -32,6 +32,7 @@ import library.huggingface_util as huggingface_util
 import library.custom_train_functions as custom_train_functions
 from library.custom_train_functions import (
     apply_snr_weight,
+    apply_soft_snr_weight,
     pyramid_noise_like,
     apply_noise_offset,
 )
@@ -457,6 +458,8 @@ def train(args):
 
                 if args.min_snr_gamma:
                     loss = apply_snr_weight(loss, timesteps, noise_scheduler, args.min_snr_gamma, args.v_parameterization)
+                if args.soft_min_snr_gamma:
+                    loss = apply_soft_snr_weight(loss, timesteps, noise_scheduler, args.soft_min_snr_gamma, args.v_parameterization)
 
                 loss = loss.mean()  # 平均なのでbatch_sizeで割る必要なし
 

--- a/train_db.py
+++ b/train_db.py
@@ -28,6 +28,7 @@ from library.config_util import (
 import library.custom_train_functions as custom_train_functions
 from library.custom_train_functions import (
     apply_snr_weight,
+    apply_soft_snr_weight,
     get_weighted_text_embeddings,
     prepare_scheduler_for_custom_training,
     pyramid_noise_like,
@@ -341,6 +342,8 @@ def train(args):
 
                 if args.min_snr_gamma:
                     loss = apply_snr_weight(loss, timesteps, noise_scheduler, args.min_snr_gamma, args.v_parameterization)
+                if args.soft_min_snr_gamma:
+                    loss = apply_soft_snr_weight(loss, timesteps, noise_scheduler, args.soft_min_snr_gamma, args.v_parameterization)
                 if args.scale_v_pred_loss_like_noise_pred:
                     loss = scale_v_prediction_loss_like_noise_prediction(loss, timesteps, noise_scheduler)
                 if args.debiased_estimation_loss:

--- a/train_network.py
+++ b/train_network.py
@@ -35,6 +35,7 @@ import library.huggingface_util as huggingface_util
 import library.custom_train_functions as custom_train_functions
 from library.custom_train_functions import (
     apply_snr_weight,
+    apply_soft_snr_weight,
     get_weighted_text_embeddings,
     prepare_scheduler_for_custom_training,
     scale_v_prediction_loss_like_noise_prediction,
@@ -522,6 +523,7 @@ class NetworkTrainer:
             "ss_face_crop_aug_range": args.face_crop_aug_range,
             "ss_prior_loss_weight": args.prior_loss_weight,
             "ss_min_snr_gamma": args.min_snr_gamma,
+            "ss_soft_min_snr_gamma": args.soft_min_snr_gamma,
             "ss_scale_weight_norms": args.scale_weight_norms,
             "ss_ip_noise_gamma": args.ip_noise_gamma,
             "ss_debiased_estimation": bool(args.debiased_estimation_loss),

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -27,6 +27,7 @@ from library.config_util import (
 import library.custom_train_functions as custom_train_functions
 from library.custom_train_functions import (
     apply_snr_weight,
+    apply_soft_snr_weight,
     prepare_scheduler_for_custom_training,
     scale_v_prediction_loss_like_noise_prediction,
     add_v_prediction_like_loss,
@@ -590,6 +591,8 @@ class TextualInversionTrainer:
 
                     if args.min_snr_gamma:
                         loss = apply_snr_weight(loss, timesteps, noise_scheduler, args.min_snr_gamma, args.v_parameterization)
+                    if args.soft_min_snr_gamma:
+                        loss = apply_soft_snr_weight(loss, timesteps, noise_scheduler, args.soft_min_snr_gamma, args.v_parameterization)
                     if args.scale_v_pred_loss_like_noise_pred:
                         loss = scale_v_prediction_loss_like_noise_prediction(loss, timesteps, noise_scheduler)
                     if args.v_pred_like_loss:


### PR DESCRIPTION
In "Scalable High-Resolution Pixel-Space Image Synthesis with Hourglass Diffusion Transformers" they came up with Soft min SNR gamma which smooths out the transition area. 

![Screenshot 2024-01-23 at 23-13-30 Scalable High-Resolution Pixel-Space Image Synthesis with Hourglass Diffusion Transformers - 2401 11605 pdf](https://github.com/kohya-ss/sd-scripts/assets/15027/e4a7cc99-bdc1-49b8-9073-271d70f0b656)
![Screenshot 2024-01-23 at 22-53-06 Scalable High-Resolution Pixel-Space Image Synthesis with Hourglass Diffusion Transformers - 2401 11605 pdf](https://github.com/kohya-ss/sd-scripts/assets/15027/68d1ce2c-3335-4ae0-84cd-e3512e04087a)

31 = soft_min_snr_gamma = 5
32 = min_snr_gamma =  5
![Screenshot 2024-01-24 at 00-01-36 Weights   Biases](https://github.com/kohya-ss/sd-scripts/assets/15027/b5be3afa-5600-432f-8a47-c0ee8762f134)

Note I think the math is correct but I could be wrong so if anyone wants to correct I can update it. 