### PR TITLE
Add Karras post-hoc EMA

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -32,7 +32,10 @@ from library.custom_train_functions import (
     scale_v_prediction_loss_like_noise_prediction,
     apply_debiased_estimation,
 )
-
+from library.train_util import (
+    EMA,
+    check_and_update_ema,
+)
 
 def train(args):
     train_util.verify_training_args(args)
@@ -240,6 +243,10 @@ def train(args):
         unet.to(weight_dtype)
         text_encoder.to(weight_dtype)
 
+    if args.enable_ema:      # u-net only
+        raise NotImplementedError
+        emas = train_util.setup_emas(args, unet)
+
     # acceleratorがなんかよろしくやってくれるらしい
     if args.train_text_encoder:
         unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
@@ -372,6 +379,7 @@ def train(args):
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3125,18 +3125,18 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--ema_beta",
         type=float,
         default=0.9999,
-        help="Max ema decay ",
+        help="Max ema decay. Only for traditional EMA ",
     )
     parser.add_argument(
         "--ema_karras_beta",
         action="store_true", 
-        help="use the karras time dependent beta "
+        help="use the karras time dependent beta. Only for traditional EMA "
     )
     parser.add_argument(
         "--ema_warmup_power",
         type=float,
         default=2/3,
-        help="If gamma=1 and power=1, implements a simple average. gamma=1, power=2/3 are \
+        help="Only for traditional EMA. If gamma=1 and power=1, implements a simple average. gamma=1, power=2/3 are \
         good values for models you plan to train for a million or more steps (reaches decay \
         factor 0.999 at 31.6K steps, 0.9999 at 1M steps), gamma=1, power=3/4 for models \
         you plan to train for less (reaches decay factor 0.999 at 10K steps, 0.9999 at \
@@ -3146,7 +3146,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--ema_update_after_step",
         type=int,
         default=100,
-        help="EMA warmup steps ",
+        help="EMA warmup steps. Only for traditional EMA. ",
     )
     parser.add_argument(
         "--ema_update_every",

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -68,6 +68,10 @@ import library.sai_model_spec as sai_model_spec
 # from library.attention_processors import FlashAttnProcessor
 # from library.hypernetwork import replace_attentions_for_hypernetwork
 from library.original_unet import UNet2DConditionModel
+from copy import deepcopy
+from functools import partial
+from beartype import beartype
+from beartype.typing import Set, Optional
 
 # Tokenizer: checkpointから読み込むのではなくあらかじめ提供されているものを使う
 TOKENIZER_PATH = "openai/clip-vit-large-patch14"
@@ -3086,6 +3090,78 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--output_config", action="store_true", help="output command line args to given .toml file / 引数を.tomlファイルに出力する"
     )
 
+    parser.add_argument(
+        "--enable_ema",
+        action="store_true", 
+        help="Enable EMA "
+    )
+    parser.add_argument(
+        "--ema_type", 
+        type=str,
+        default="post-hoc", 
+        choices=["traditional","post-hoc"],
+        help="'traditional' = traditional EMA \
+        'post-hoc' = karras EMA. Save multiple snaphots. Reconstruct any profile after training ",
+    )
+    parser.add_argument(
+        "--ema_k_sigma_rel_1",
+        type=float,
+        default=0.05,
+        help="Averaging length for karras EMA profile.  0 < sigma_rel < 0.28 ",
+    )
+    parser.add_argument(
+        "--ema_k_sigma_rel_2",
+        type=float,
+        default=0.1,
+        help="Averaging length for karras EMA profile.  0 < sigma_rel < 0.28 ",
+    )
+    parser.add_argument(
+        "--ema_k_num_snapshots",
+        type=int,
+        default=8,
+        help="Number of saved snapshots for post-hoc ema ",
+    )
+    parser.add_argument(
+        "--ema_beta",
+        type=float,
+        default=0.9999,
+        help="Max ema decay ",
+    )
+    parser.add_argument(
+        "--ema_karras_beta",
+        action="store_true", 
+        help="use the karras time dependent beta "
+    )
+    parser.add_argument(
+        "--ema_warmup_power",
+        type=float,
+        default=2/3,
+        help="If gamma=1 and power=1, implements a simple average. gamma=1, power=2/3 are \
+        good values for models you plan to train for a million or more steps (reaches decay \
+        factor 0.999 at 31.6K steps, 0.9999 at 1M steps), gamma=1, power=3/4 for models \
+        you plan to train for less (reaches decay factor 0.999 at 10K steps, 0.9999 at \
+        215.4k steps). ",
+    )
+    parser.add_argument(
+        "--ema_update_after_step",
+        type=int,
+        default=100,
+        help="EMA warmup steps ",
+    )
+    parser.add_argument(
+        "--ema_update_every",
+        type=int,
+        default=10,
+        help="Update EMA every x steps ",
+    )
+    parser.add_argument(
+        "--ema_device",
+        type=str,
+        default="cpu", 
+        help=" "
+    )
+
+
     # SAI Model spec
     parser.add_argument(
         "--metadata_title",
@@ -4890,3 +4966,304 @@ class LossRecorder:
     @property
     def moving_average(self) -> float:
         return self.loss_total / len(self.loss_list)
+
+
+# region EMA
+
+
+# based on https://arxiv.org/abs/2312.02696 , https://github.com/cloneofsimo/karras-power-ema-tutorial and  https://github.com/lucidrains/ema-pytorch/blob/main/ema_pytorch/ema_pytorch.py  
+
+#ema_gamma1 = 16.97    #  sigma_rel=0.05
+#ema_gamma2 = 6.94     #  sigma_rel=0.1
+
+def sigma_rel_to_gamma(sigma_rel):
+    t = sigma_rel ** -2
+    gamma = np.roots([1, 7, 16 - t, 12 - t]).real.max()
+    return gamma
+
+def p_dot_p(t_a, gamma_a, t_b, gamma_b):
+    t_ratio = t_a / t_b
+    t_exp = np.where(t_a < t_b, gamma_b, -gamma_a)
+    t_max = np.maximum(t_a, t_b)
+    num = (gamma_a + 1) * (gamma_b + 1) * t_ratio**t_exp
+    den = (gamma_a + gamma_b + 1) * t_max
+    return num / den
+
+def solve_weights(t_i, gamma_i, t_r, gamma_r):
+    rv = lambda x: np.float64(x).reshape(-1, 1)
+    cv = lambda x: np.float64(x).reshape(1, -1)
+    A = p_dot_p(rv(t_i), rv(gamma_i), cv(t_i), cv(gamma_i))
+    B = p_dot_p(rv(t_i), rv(gamma_i), cv(t_r), cv(gamma_r))
+    X = np.linalg.solve(A, B)
+    return X
+
+def exists(val):
+    return val is not None
+
+def get_module_device(m: torch.nn.Module):
+    return next(m.parameters()).device
+
+def inplace_copy(src: torch.Tensor, tgt: torch.Tensor, *, auto_move_device = False):
+    if auto_move_device:
+        tgt = tgt.to(src.device)
+
+    src.copy_(tgt)
+
+def inplace_lerp(src: torch.Tensor, tgt: torch.Tensor, weight, *, auto_move_device = False):
+    if auto_move_device:
+        tgt = tgt.to(src.device)
+
+    src.lerp_(tgt, weight)
+
+def check_and_update_ema(args, ema, checkpoint_index=0):
+    #if args.ema_type == "post-hoc" and ((ema.step + 1) % ema.post_hoc_snapshot_every) == 0 and ema.step != 0:
+    #    #save snapshot
+    #    snapshot_dir = os.path.join(args.output_dir, args.output_name + "_ema_snapshots")
+    #    os.makedirs(snapshot_dir, exist_ok=True)
+    #    #snap_num = math.floor(ema.step / ema.post_hoc_snapshot_every)
+    #    snapshot_name = os.path.join(snapshot_dir, "snapshot_{}_{:09d}_{:04f}".format(checkpoint_index, ema.step, ema.post_hoc_gamma))
+    #    print("saving snapshot")
+    #    # TODO add metadata
+    #    safetensors.torch.save_file(ema.state_dict(), snapshot_name + ".safetensors")
+    ema.update()
+
+
+class EMA(torch.nn.Module):
+    """
+    Implements exponential moving average shadowing for your model.
+
+    Utilizes an inverse decay schedule to manage longer term training runs.
+    By adjusting the power, you can control how fast EMA will ramp up to your specified beta.
+
+    @crowsonkb's notes on EMA Warmup:
+
+    If gamma=1 and power=1, implements a simple average. gamma=1, power=2/3 are
+    good values for models you plan to train for a million or more steps (reaches decay
+    factor 0.999 at 31.6K steps, 0.9999 at 1M steps), gamma=1, power=3/4 for models
+    you plan to train for less (reaches decay factor 0.999 at 10K steps, 0.9999 at
+    215.4k steps).
+
+    Args:
+        inv_gamma (float): Inverse multiplicative factor of EMA warmup. Default: 1.
+        power (float): Exponential factor of EMA warmup. Default: 2/3.
+        min_value (float): The minimum EMA decay rate. Default: 0.
+    """
+
+    @beartype
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        ema_model: Optional[torch.nn.Module] = None,           # if your model has lazylinears or other types of non-deepcopyable modules, you can pass in your own ema model
+        beta = 0.9999,
+        karras_beta = False,                          # if True, uses the karras time dependent beta
+        update_after_step = 100,
+        update_every = 10,
+        inv_gamma = 1.0,
+        power = 2 / 3,
+        min_value = 0.0,
+        param_or_buffer_names_no_ema: Set[str] = set(),
+        ignore_names: Set[str] = set(),
+        ignore_startswith_names: Set[str] = set(),
+        include_online_model = True,                  # set this to False if you do not wish for the online model to be saved along with the ema model (managed externally)
+        allow_different_devices = False,               # if the EMA model is on a different device (say CPU), automatically move the tensor
+        post_hoc = False,
+        post_hoc_gamma = 16.97,
+        post_hoc_snapshot_every = 1000,
+        sigma_rel = None,
+    ):
+        super().__init__()
+        self._beta = beta
+        self.karras_beta = karras_beta
+
+        self.post_hoc = post_hoc
+        self.post_hoc_gamma = post_hoc_gamma
+        self.post_hoc_snapshot_every = post_hoc_snapshot_every
+
+        self.is_frozen = beta == 1.
+
+        # whether to include the online model within the module tree, so that state_dict also saves it
+
+        self.include_online_model = include_online_model
+
+        if include_online_model:
+            self.online_model = model
+        else:
+            self.online_model = [model] # hack
+
+        # ema model
+
+        self.ema_model = ema_model
+
+        if not exists(self.ema_model):
+            try:
+                self.ema_model = deepcopy(model)
+            except Exception as e:
+                print(f'Error: While trying to deepcopy model: {e}')
+                print('Your model was not copyable. Please make sure you are not using any LazyLinear')
+                exit()
+
+        self.ema_model.requires_grad_(False)
+
+        # parameter and buffer names
+
+        self.parameter_names = {name for name, param in self.ema_model.named_parameters() if param.dtype in [torch.float, torch.float16, torch.bfloat16]}
+        self.buffer_names = {name for name, buffer in self.ema_model.named_buffers() if buffer.dtype in [torch.float, torch.float16, torch.bfloat16]}
+
+        # tensor update functions
+
+        self.inplace_copy = partial(inplace_copy, auto_move_device = allow_different_devices)
+        self.inplace_lerp = partial(inplace_lerp, auto_move_device = allow_different_devices)
+
+        # updating hyperparameters
+
+        self.update_every = update_every
+        self.update_after_step = update_after_step
+
+        self.inv_gamma = inv_gamma
+        self.power = power
+        self.min_value = min_value
+
+        assert isinstance(param_or_buffer_names_no_ema, (set, list))
+        self.param_or_buffer_names_no_ema = param_or_buffer_names_no_ema # parameter or buffer
+
+        self.ignore_names = ignore_names
+        self.ignore_startswith_names = ignore_startswith_names
+
+        # whether to manage if EMA model is kept on a different device
+
+        self.allow_different_devices = allow_different_devices
+
+        # init and step states
+
+        self.register_buffer('initted', torch.tensor(False))
+        self.register_buffer('step', torch.tensor(0))
+
+        if sigma_rel:
+            self.post_hoc_gamma = sigma_rel_to_gamma(sigma_rel)
+
+        if post_hoc:
+            self.karras_beta = True
+            self.power = self.post_hoc_gamma
+            self.register_buffer('ema_gamma', torch.tensor(self.post_hoc_gamma))
+
+    @property
+    def model(self):
+        return self.online_model if self.include_online_model else self.online_model[0]
+    
+    @property
+    def beta(self):
+        if self.karras_beta:
+            return (1 - 1 / (self.step + 1)) ** (1 + self.power)
+
+        return self._beta
+
+    def eval(self):
+        return self.ema_model.eval()
+    
+    def restore_ema_model_device(self):
+        device = self.initted.device
+        self.ema_model.to(device)
+
+    def get_params_iter(self, model):
+        for name, param in model.named_parameters():
+            if name not in self.parameter_names:
+                continue
+            yield name, param
+
+    def get_buffers_iter(self, model):
+        for name, buffer in model.named_buffers():
+            if name not in self.buffer_names:
+                continue
+            yield name, buffer
+
+    def copy_params_from_model_to_ema(self):
+        copy = self.inplace_copy
+
+        for (_, ma_params), (_, current_params) in zip(self.get_params_iter(self.ema_model), self.get_params_iter(self.model)):
+            copy(ma_params.data, current_params.data)
+
+        for (_, ma_buffers), (_, current_buffers) in zip(self.get_buffers_iter(self.ema_model), self.get_buffers_iter(self.model)):
+            copy(ma_buffers.data, current_buffers.data)
+
+    def copy_params_from_ema_to_model(self):
+        copy = self.inplace_copy
+
+        for (_, ma_params), (_, current_params) in zip(self.get_params_iter(self.ema_model), self.get_params_iter(self.model)):
+            copy(current_params.data, ma_params.data)
+
+        for (_, ma_buffers), (_, current_buffers) in zip(self.get_buffers_iter(self.ema_model), self.get_buffers_iter(self.model)):
+            copy(current_buffers.data, ma_buffers.data)
+
+    def get_current_decay(self):
+        if self.post_hoc:
+            return self.beta
+
+        epoch = (self.step - self.update_after_step - 1).clamp(min = 0.)
+        value = 1 - (1 + epoch / self.inv_gamma) ** - self.power
+
+        if epoch.item() <= 0:
+            return 0.
+
+        return value.clamp(min = self.min_value, max = self.beta).item()
+
+    def update(self):
+        step = self.step.item()
+
+        self.step += 1
+
+        if (step % self.update_every) != 0:
+            return
+
+        if step <= self.update_after_step:
+            self.copy_params_from_model_to_ema()
+            return
+
+        if not self.initted.item():
+            self.copy_params_from_model_to_ema()
+            self.initted.data.copy_(torch.tensor(True))
+
+        self.update_moving_average(self.ema_model, self.model)
+
+    @torch.no_grad()
+    def update_moving_average(self, ma_model, current_model):
+        if self.is_frozen:
+            return
+
+        copy, lerp = self.inplace_copy, self.inplace_lerp
+        current_decay = self.get_current_decay()
+
+        for (name, current_params), (_, ma_params) in zip(self.get_params_iter(current_model), self.get_params_iter(ma_model)):
+            if name in self.ignore_names:
+                continue
+
+            if any([name.startswith(prefix) for prefix in self.ignore_startswith_names]):
+                continue
+
+            if name in self.param_or_buffer_names_no_ema:
+                copy(ma_params.data, current_params.data)
+                continue
+
+            lerp(ma_params.data, current_params.data, 1. - current_decay)
+
+        for (name, current_buffer), (_, ma_buffer) in zip(self.get_buffers_iter(current_model), self.get_buffers_iter(ma_model)):
+            if name in self.ignore_names:
+                continue
+
+            if any([name.startswith(prefix) for prefix in self.ignore_startswith_names]):
+                continue
+
+            if name in self.param_or_buffer_names_no_ema:
+                copy(ma_buffer.data, current_buffer.data)
+                continue
+
+            lerp(ma_buffer.data, current_buffer.data, 1. - current_decay)
+
+    def __call__(self, *args, **kwargs):
+        return self.ema_model(*args, **kwargs)
+
+
+
+
+
+
+# endregion

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3145,7 +3145,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
     parser.add_argument(
         "--ema_update_after_step",
         type=int,
-        default=100,
+        default=0,
         help="EMA warmup steps. Only for traditional EMA. ",
     )
     parser.add_argument(
@@ -5010,8 +5010,8 @@ def setup_emas(args, model):
     emas = []
     if args.ema_type == 'post-hoc':
         snapshot_every = math.ceil(args.max_train_steps / args.ema_k_num_snapshots)
-        ema1 = EMA(model, update_after_step = 0, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
-        ema2 = EMA(model, update_after_step = 0, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
+        ema1 = EMA(model, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
+        ema2 = EMA(model, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
         emas = [ema1, ema2]
     return emas
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4981,22 +4981,6 @@ def sigma_rel_to_gamma(sigma_rel):
     gamma = np.roots([1, 7, 16 - t, 12 - t]).real.max()
     return gamma
 
-def p_dot_p(t_a, gamma_a, t_b, gamma_b):
-    t_ratio = t_a / t_b
-    t_exp = np.where(t_a < t_b, gamma_b, -gamma_a)
-    t_max = np.maximum(t_a, t_b)
-    num = (gamma_a + 1) * (gamma_b + 1) * t_ratio**t_exp
-    den = (gamma_a + gamma_b + 1) * t_max
-    return num / den
-
-def solve_weights(t_i, gamma_i, t_r, gamma_r):
-    rv = lambda x: np.float64(x).reshape(-1, 1)
-    cv = lambda x: np.float64(x).reshape(1, -1)
-    A = p_dot_p(rv(t_i), rv(gamma_i), cv(t_i), cv(gamma_i))
-    B = p_dot_p(rv(t_i), rv(gamma_i), cv(t_r), cv(gamma_r))
-    X = np.linalg.solve(A, B)
-    return X
-
 def exists(val):
     return val is not None
 
@@ -5260,10 +5244,6 @@ class EMA(torch.nn.Module):
 
     def __call__(self, *args, **kwargs):
         return self.ema_model(*args, **kwargs)
-
-
-
-
 
 
 # endregion

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2856,7 +2856,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--max_token_length",
         type=int,
         default=None,
-        choices=[None, 150, 225],
+        choices=[None, 150, 225, 300, 375],
         help="max token length of text encoder (default for 75, 150 or 225) / text encoderのトークンの最大長（未指定で75、150または225が指定可）",
     )
     parser.add_argument(
@@ -3146,7 +3146,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         "--ema_update_after_step",
         type=int,
         default=0,
-        help="EMA warmup steps. Only for traditional EMA. ",
+        help="EMA warmup steps. ",
     )
     parser.add_argument(
         "--ema_update_every",
@@ -3154,12 +3154,11 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         default=10,
         help="Update EMA every x steps ",
     )
-    #parser.add_argument(
-    #    "--ema_device",
-    #    type=str,
-    #    default="cpu", 
-    #    help=" "
-    #)
+    parser.add_argument(
+        "--ema_on_gpu",
+        action="store_true", 
+        help="Keep EMA weights in VRAM "
+    )
 
 
     # SAI Model spec
@@ -5009,7 +5008,7 @@ def check_and_update_ema(args, ema, checkpoint_index=0, model_type=None):
 def setup_emas(args, model):
     emas = []
     if args.ema_type == 'post-hoc':
-        snapshot_every = math.ceil(args.max_train_steps / args.ema_k_num_snapshots)
+        snapshot_every = math.floor(args.max_train_steps / args.ema_k_num_snapshots)
         ema1 = EMA(model, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
         ema2 = EMA(model, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
         emas = [ema1, ema2]

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3103,18 +3103,18 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         help="'traditional' = traditional EMA \
         'post-hoc' = karras EMA. Save multiple snaphots. Reconstruct any profile after training ",
     )
-    parser.add_argument(
-        "--ema_k_sigma_rel_1",
-        type=float,
-        default=0.05,
-        help="Averaging length for karras EMA profile.  0 < sigma_rel < 0.28 ",
-    )
-    parser.add_argument(
-        "--ema_k_sigma_rel_2",
-        type=float,
-        default=0.1,
-        help="Averaging length for karras EMA profile.  0 < sigma_rel < 0.28 ",
-    )
+    #parser.add_argument(
+    #    "--ema_k_sigma_rel_1",
+    #    type=float,
+    #    default=0.05,
+    #    help="Averaging length for karras EMA profile.  0 < sigma_rel < 0.28 ",
+    #)
+    #parser.add_argument(
+    #    "--ema_k_sigma_rel_2",
+    #    type=float,
+    #    default=0.1,
+    #    help="Averaging length for karras EMA profile.  0 < sigma_rel < 0.28 ",
+    #)
     parser.add_argument(
         "--ema_k_num_snapshots",
         type=int,
@@ -3154,12 +3154,12 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         default=10,
         help="Update EMA every x steps ",
     )
-    parser.add_argument(
-        "--ema_device",
-        type=str,
-        default="cpu", 
-        help=" "
-    )
+    #parser.add_argument(
+    #    "--ema_device",
+    #    type=str,
+    #    default="cpu", 
+    #    help=" "
+    #)
 
 
     # SAI Model spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ easygui==0.98.3
 toml==0.10.2
 voluptuous==0.13.1
 huggingface-hub==0.20.1
+beartype
 # for BLIP captioning
 # requests==2.28.2
 # timm==0.6.12

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -35,7 +35,10 @@ from library.custom_train_functions import (
     apply_debiased_estimation,
 )
 from library.sdxl_original_unet import SdxlUNet2DConditionModel
-
+from library.train_util import (
+    EMA,
+    check_and_update_ema,
+)
 
 UNET_NUM_BLOCKS_FOR_BLOCK_LR = 23
 
@@ -389,6 +392,11 @@ def train(args):
         text_encoder1.to(weight_dtype)
         text_encoder2.to(weight_dtype)
 
+    if args.enable_ema:      # u-net only
+        raise NotImplementedError
+        emas = train_util.setup_emas(args, unet)
+
+
     # acceleratorがなんかよろしくやってくれるらしい
     if train_unet:
         unet = accelerator.prepare(unet)
@@ -594,6 +602,9 @@ def train(args):
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+                if args.enable_ema:
+                    raise NotImplementedError
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/tools/reconstruct_ema_weights.py
+++ b/tools/reconstruct_ema_weights.py
@@ -50,7 +50,7 @@ def reconstruct_weights_from_snapshots(args):
 
     x = solve_weights(ts, gammas, ts[-1] + 1, args.target_gamma)    # x = solve_weights(ts, gammas, args.target_step, args.target_gamma)
     print(x)
-    x = torch.from_numpy(x)
+    x = torch.from_numpy(x)  # .to(device=args.device)
 
     if args.saving_precision == "fp16":
         save_dtype = torch.float16

--- a/tools/reconstruct_ema_weights.py
+++ b/tools/reconstruct_ema_weights.py
@@ -1,0 +1,143 @@
+import argparse
+import os
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import load_file, save_file
+from tqdm import tqdm
+import numpy as np
+
+def sigma_rel_to_gamma(sigma_rel):
+    t = sigma_rel ** -2
+    gamma = np.roots([1, 7, 16 - t, 12 - t]).real.max()
+    return gamma
+
+def p_dot_p(t_a, gamma_a, t_b, gamma_b):
+    t_ratio = t_a / t_b
+    t_exp = np.where(t_a < t_b, gamma_b, -gamma_a)
+    t_max = np.maximum(t_a, t_b)
+    num = (gamma_a + 1) * (gamma_b + 1) * t_ratio**t_exp
+    den = (gamma_a + gamma_b + 1) * t_max
+    return num / den
+
+def solve_weights(t_i, gamma_i, t_r, gamma_r):
+    rv = lambda x: np.float64(x).reshape(-1, 1)
+    cv = lambda x: np.float64(x).reshape(1, -1)
+    A = p_dot_p(rv(t_i), rv(gamma_i), cv(t_i), cv(gamma_i))
+    B = p_dot_p(rv(t_i), rv(gamma_i), cv(t_r), cv(gamma_r))
+    X = np.linalg.solve(A, B)
+    return X
+
+
+def reconstruct_weights_from_snapshots(args):
+    # TODO add checks for target_step ?
+    #  copy metadata
+
+    args.snapshot_dir = args.snapshot_dir.rstrip('\\').rstrip('/')
+    snaps = os.listdir(args.snapshot_dir)
+    gammas = [float(os.path.splitext(s)[0].split("_")[-1]) for s in snaps] 
+    # # load gammas from snapshots 
+    #gammas = []
+    #for s in snaps:
+    #    with safe_open(os.path.join(args.snapshot_dir, s), framework="pt", device=args.device) as f:
+    #        gammas.append(float(f.get_tensor('ema_gamma')))
+    ts = [int(os.path.splitext(s)[0].split("_")[-2]) for s in snaps]
+
+    if not args.target_step:
+        args.target_step = ts[-1] + 1
+
+    x = solve_weights(ts, gammas, args.target_step, args.target_gamma)
+    print(x)
+    x = torch.from_numpy(x)
+
+    if args.saving_precision == "fp16":
+        save_dtype = torch.float16
+    elif args.saving_precision == "bf16":
+        save_dtype = torch.bfloat16
+    else:
+        save_dtype = torch.float
+
+    supplementary_key_ratios = {}
+    merged_sd = None
+    first_model_keys = set()
+    dtype = torch.float
+    for i, s in enumerate(snaps):
+        # load snapshots and add weights 
+
+        if merged_sd is None:
+            # load first model
+            print(f"Loading {s}, x = {x[i].item()}...")
+            merged_sd = {}
+            with safe_open(os.path.join(args.snapshot_dir, s), framework="pt", device=args.device) as f:
+                for key in tqdm(f.keys()):
+                    value = f.get_tensor(key)
+
+                    first_model_keys.add(key)
+
+                    value = x[i] * value.to(dtype)  # first model's value * ratio
+                    merged_sd[key] = value
+
+            print(f"Model has {len(merged_sd)} keys " )
+            continue
+
+        # load other models
+        print(f"Loading {s}, x = {x[i].item()}...")
+
+        with safe_open(os.path.join(args.snapshot_dir, s), framework="pt", device=args.device) as f:
+            model_keys = f.keys()
+            for key in tqdm(model_keys):
+                if key not in merged_sd:
+                    print(f"Skip: {key}")
+                    continue
+
+                value = f.get_tensor(key)
+                merged_sd[key] = merged_sd[key] + x[i] * value.to(dtype)
+
+            # enumerate keys not in this model
+            model_keys = set(model_keys)
+            for key in merged_sd.keys():
+                if key in model_keys:
+                    continue
+                print(f"Key {key} not in model {s}, use first model's value")
+                if key in supplementary_key_ratios:
+                    supplementary_key_ratios[key] += x[i]
+                else:
+                    supplementary_key_ratios[key] = x[i]
+
+    # save
+    if not args.output_dir:
+        args.output_dir = os.path.dirname(args.snapshot_dir)
+    output_file = os.path.join(args.output_dir, os.path.basename(args.snapshot_dir).replace("_snapshots","") + "_gamma_{:4f}.safetensors".format(args.target_gamma))
+
+    print(f"Saving to {output_file}...")
+
+    # convert to save_dtype
+    for k in merged_sd.keys():
+        merged_sd[k] = merged_sd[k].to(save_dtype)
+
+    save_file(merged_sd, output_file)
+
+    print("Done!")
+        
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=" ")
+    parser.add_argument("snapshot_dir", type=str, help=" ")
+    parser.add_argument("--target_gamma", type=float, required=True, help=" ")
+    parser.add_argument("--target_step", type=int, default = None, help=" ")
+    parser.add_argument("--output_dir", type=str, default = None, help=" ")
+    parser.add_argument("--device", type=str, default="cpu", help="Device to use, default is cpu")
+    #parser.add_argument(
+    #    "--precision", type=str, default="float", choices=["float", "fp16", "bf16"], help="Calculation precision, default is float"
+    #)
+    parser.add_argument(
+        "--saving_precision",
+        type=str,
+        default="float",
+        choices=["float", "fp16", "bf16"],
+        help="Saving precision, default is float",
+    )
+
+    args = parser.parse_args()
+    reconstruct_weights_from_snapshots(args)

--- a/tools/reconstruct_ema_weights.py
+++ b/tools/reconstruct_ema_weights.py
@@ -38,6 +38,7 @@ def reconstruct_weights_from_snapshots(args):
     args.device = "cpu"
     assert (args.target_sigma_rel or args.target_gamma) and not (args.target_sigma_rel and args.target_gamma), "Either target_sigma_rel or target_gamma is required"
     if args.target_sigma_rel:
+        assert 0 < args.target_sigma_rel < 0.28, "target_sigma_rel mush be in range from 0 to 0.28"
         args.target_gamma = sigma_rel_to_gamma(args.target_sigma_rel)
 
     args.snapshot_dir = args.snapshot_dir.rstrip('\\').rstrip('/')
@@ -139,7 +140,7 @@ def reconstruct_weights_from_snapshots(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Reconstruct EMA weights from snapshots ")
     parser.add_argument("snapshot_dir", type=str, help="Folder with snapshots ")
-    parser.add_argument("--target_gamma", type=float, help="Averaging factor. Recommended values: 5 - 50  ")  #  Lower gamma gives more weight to early steps 
+    parser.add_argument("--target_gamma", type=float, help="Averaging factor. Recommended values: 5 - 50  ")  #  Lower gamma gives more weight to early steps? 
     #parser.add_argument("--base_model", type=str, help="If EMA is unet-only, text encoder and vae will be copied from this model.")
     parser.add_argument("--target_sigma_rel", type=float, default = None, help="Averaging length. Alternative way of specifying gamma. Allowed values: 0 < sigma_rel < 0.28 ")
     #parser.add_argument("--target_step", type=int, default = None, help="Last step to average at ")

--- a/tools/reconstruct_ema_weights.py
+++ b/tools/reconstruct_ema_weights.py
@@ -140,7 +140,7 @@ def reconstruct_weights_from_snapshots(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Reconstruct EMA weights from snapshots ")
     parser.add_argument("snapshot_dir", type=str, help="Folder with snapshots ")
-    parser.add_argument("--target_gamma", type=float, help="Averaging factor. Recommended values: 5 - 50  ")  #  Lower gamma gives more weight to early steps? 
+    parser.add_argument("--target_gamma", type=float, help="Averaging factor. Recommended values: 5 - 50  ")  #  Lower gamma gives more weight to early steps 
     #parser.add_argument("--base_model", type=str, help="If EMA is unet-only, text encoder and vae will be copied from this model.")
     parser.add_argument("--target_sigma_rel", type=float, default = None, help="Averaging length. Alternative way of specifying gamma. Allowed values: 0 < sigma_rel < 0.28 ")
     #parser.add_argument("--target_step", type=int, default = None, help="Last step to average at ")

--- a/train_db.py
+++ b/train_db.py
@@ -35,8 +35,11 @@ from library.custom_train_functions import (
     scale_v_prediction_loss_like_noise_prediction,
     apply_debiased_estimation,
 )
-
 # perlin_noise,
+from library.train_util import (
+    EMA,
+    check_and_update_ema,
+)
 
 
 def train(args):
@@ -213,6 +216,10 @@ def train(args):
         unet.to(weight_dtype)
         text_encoder.to(weight_dtype)
 
+    if args.enable_ema:      # u-net only
+        raise NotImplementedError
+        emas = train_util.setup_emas(args, unet)
+
     # acceleratorがなんかよろしくやってくれるらしい
     if train_text_encoder:
         unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
@@ -359,6 +366,15 @@ def train(args):
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+                if args.enable_ema:
+                    raise NotImplementedError
+                    for i, e in enumerate(emas):
+                        if args.ema_type == "post-hoc" and ((e.step + 1) % e.post_hoc_snapshot_every) == 0 and e.step != 0:
+                            #save snapshot
+                            pass
+                            # TODO
+                        check_and_update_ema(args, e, i)
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/train_network.py
+++ b/train_network.py
@@ -25,6 +25,8 @@ from library import model_util
 import library.train_util as train_util
 from library.train_util import (
     DreamBoothDataset,
+    EMA,
+    check_and_update_ema,
 )
 import library.config_util as config_util
 from library.config_util import (
@@ -421,6 +423,17 @@ class NetworkTrainer:
                 text_encoders = [text_encoder]
         else:
             pass  # if text_encoder is not trained, no need to prepare. and device and dtype are already set
+
+        if args.enable_ema: 
+            if args.ema_type == 'traditional':
+                ema = EMA(network, beta = 0.5, karras_beta = False, update_after_step = 100, update_every = 10, power = 3 / 4, include_online_model = False, allow_different_devices = True)
+                #ema.to(accelerator.device)
+                emas = [ema]
+            elif args.ema_type == 'post-hoc':
+                snapshot_every = math.ceil(args.max_train_steps / args.ema_k_num_snapshots)
+                ema1 = EMA(network, update_after_step = 0, update_every = 10, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
+                ema2 = EMA(network, update_after_step = 0, update_every = 10, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
+                emas = [ema1, ema2]
 
         network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(network, optimizer, train_dataloader, lr_scheduler)
 
@@ -852,6 +865,19 @@ class NetworkTrainer:
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 
+                    if args.enable_ema:
+                        for i, e in enumerate(emas):
+                            if args.ema_type == "post-hoc" and ((e.step + 1) % e.post_hoc_snapshot_every) == 0 and e.step != 0:
+                                #save snapshot
+                                snapshot_dir = os.path.join(args.output_dir, args.output_name + "_ema_snapshots")
+                                os.makedirs(snapshot_dir, exist_ok=True)
+                                #snap_num = math.floor(ema.step / ema.post_hoc_snapshot_every)
+                                snapshot_name = os.path.join(snapshot_dir, "snapshot_{}_{:09d}_{:04f}".format(i, e.step, e.post_hoc_gamma))
+                                #print("saving snapshot")
+                                #safetensors.torch.save_file(ema.state_dict(), snapshot_name + ".safetensors")
+                                save_model(snapshot_name + ".safetensors", e.ema_model, global_step, num_train_epochs)
+                            check_and_update_ema(args, e, i)
+
                 if args.scale_weight_norms:
                     keys_scaled, mean_norm, maximum_norm = accelerator.unwrap_model(network).apply_max_norm_regularization(
                         args.scale_weight_norms, accelerator.device
@@ -937,6 +963,16 @@ class NetworkTrainer:
         if is_main_process:
             ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
             save_model(ckpt_name, network, global_step, num_train_epochs, force_sync_upload=True)
+
+            if args.enable_ema and args.ema_type == 'traditional':
+                # direct EMA save
+                ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+                save_model(os.path.splitext(ckpt_name)[0] + "-EMA-direct" + os.path.splitext(ckpt_name)[1], emas[0].ema_model, global_step, num_train_epochs, force_sync_upload=True)    # emas[0].ema_model ?
+
+                # save EMA - copy and save
+                emas[0].copy_params_from_ema_to_model()
+                ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+                save_model(os.path.splitext(ckpt_name)[0] + "-EMA" + os.path.splitext(ckpt_name)[1], network, global_step, num_train_epochs, force_sync_upload=True)
 
             print("model saved.")
 

--- a/train_network.py
+++ b/train_network.py
@@ -431,8 +431,8 @@ class NetworkTrainer:
                 emas = [ema]
             elif args.ema_type == 'post-hoc':
                 snapshot_every = math.ceil(args.max_train_steps / args.ema_k_num_snapshots)
-                ema1 = EMA(network, update_after_step = 0, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
-                ema2 = EMA(network, update_after_step = 0, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
+                ema1 = EMA(network, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
+                ema2 = EMA(network, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
                 emas = [ema1, ema2]
 
         network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(network, optimizer, train_dataloader, lr_scheduler)

--- a/train_network.py
+++ b/train_network.py
@@ -538,6 +538,7 @@ class NetworkTrainer:
             "ss_scale_weight_norms": args.scale_weight_norms,
             "ss_ip_noise_gamma": args.ip_noise_gamma,
             "ss_debiased_estimation": bool(args.debiased_estimation_loss),
+            "ss_enable_ema": bool(args.enable_ema),
         }
 
         if use_user_config:
@@ -871,7 +872,6 @@ class NetworkTrainer:
                                 #save snapshot
                                 snapshot_dir = os.path.join(args.output_dir, args.output_name + "_ema_snapshots")
                                 os.makedirs(snapshot_dir, exist_ok=True)
-                                #snap_num = math.floor(ema.step / ema.post_hoc_snapshot_every)
                                 snapshot_name = os.path.join(snapshot_dir, "snapshot_{}_{:09d}_{:.6f}".format(i, e.step, e.post_hoc_gamma))
                                 save_model(snapshot_name + ".safetensors", e.ema_model, global_step, num_train_epochs)
                             check_and_update_ema(args, e, i)
@@ -963,7 +963,7 @@ class NetworkTrainer:
             save_model(ckpt_name, network, global_step, num_train_epochs, force_sync_upload=True)
 
             if args.enable_ema and args.ema_type == 'traditional':
-                # direct EMA save
+                # save directly
                 ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
                 save_model(os.path.splitext(ckpt_name)[0] + "-EMA" + os.path.splitext(ckpt_name)[1], emas[0].ema_model, global_step, num_train_epochs, force_sync_upload=True)
 

--- a/train_network.py
+++ b/train_network.py
@@ -426,13 +426,13 @@ class NetworkTrainer:
 
         if args.enable_ema: 
             if args.ema_type == 'traditional':
-                ema = EMA(network, beta = 0.5, karras_beta = False, update_after_step = 100, update_every = 10, power = 3 / 4, include_online_model = False, allow_different_devices = True)
+                ema = EMA(network, beta = args.ema_beta, karras_beta = args.ema_karras_beta, update_after_step = args.ema_update_after_step, update_every = args.ema_update_every, power = args.ema_warmup_power, include_online_model = False, allow_different_devices = True)
                 #ema.to(accelerator.device)
                 emas = [ema]
             elif args.ema_type == 'post-hoc':
                 snapshot_every = math.ceil(args.max_train_steps / args.ema_k_num_snapshots)
-                ema1 = EMA(network, update_after_step = 0, update_every = 10, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
-                ema2 = EMA(network, update_after_step = 0, update_every = 10, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
+                ema1 = EMA(network, update_after_step = 0, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 16.97, post_hoc_snapshot_every = snapshot_every)
+                ema2 = EMA(network, update_after_step = 0, update_every = args.ema_update_every, include_online_model = False, allow_different_devices = True, post_hoc = True, post_hoc_gamma = 6.94, post_hoc_snapshot_every = snapshot_every)
                 emas = [ema1, ema2]
 
         network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(network, optimizer, train_dataloader, lr_scheduler)
@@ -872,9 +872,7 @@ class NetworkTrainer:
                                 snapshot_dir = os.path.join(args.output_dir, args.output_name + "_ema_snapshots")
                                 os.makedirs(snapshot_dir, exist_ok=True)
                                 #snap_num = math.floor(ema.step / ema.post_hoc_snapshot_every)
-                                snapshot_name = os.path.join(snapshot_dir, "snapshot_{}_{:09d}_{:04f}".format(i, e.step, e.post_hoc_gamma))
-                                #print("saving snapshot")
-                                #safetensors.torch.save_file(ema.state_dict(), snapshot_name + ".safetensors")
+                                snapshot_name = os.path.join(snapshot_dir, "snapshot_{}_{:09d}_{:.6f}".format(i, e.step, e.post_hoc_gamma))
                                 save_model(snapshot_name + ".safetensors", e.ema_model, global_step, num_train_epochs)
                             check_and_update_ema(args, e, i)
 
@@ -967,12 +965,12 @@ class NetworkTrainer:
             if args.enable_ema and args.ema_type == 'traditional':
                 # direct EMA save
                 ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
-                save_model(os.path.splitext(ckpt_name)[0] + "-EMA-direct" + os.path.splitext(ckpt_name)[1], emas[0].ema_model, global_step, num_train_epochs, force_sync_upload=True)    # emas[0].ema_model ?
+                save_model(os.path.splitext(ckpt_name)[0] + "-EMA" + os.path.splitext(ckpt_name)[1], emas[0].ema_model, global_step, num_train_epochs, force_sync_upload=True)
 
-                # save EMA - copy and save
-                emas[0].copy_params_from_ema_to_model()
-                ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
-                save_model(os.path.splitext(ckpt_name)[0] + "-EMA" + os.path.splitext(ckpt_name)[1], network, global_step, num_train_epochs, force_sync_upload=True)
+                ## save EMA - copy and save
+                #emas[0].copy_params_from_ema_to_model()
+                #ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+                #save_model(os.path.splitext(ckpt_name)[0] + "-EMA_" + os.path.splitext(ckpt_name)[1], network, global_step, num_train_epochs, force_sync_upload=True)
 
             print("model saved.")
 


### PR DESCRIPTION
This allows to generate different EMA profiles after training, without having to retrain.
Explanation of the method:  https://github.com/cloneofsimo/karras-power-ema-tutorial
Traditional EMA implementation is based on https://github.com/lucidrains/ema-pytorch

**Only train_network and sdxl_train_network are supported currently.**

### How to use:
Add `--enable_ema --ema_type="post-hoc"` to training options. `--ema_on_gpu` to use gpu.
It will save snapshots in `OUTPUT_DIR/OUTPUT_NAME_snapshots`
After training you can generate EMA checkpoints with `python .\tools\reconstruct_ema_weights.py PATH_TO_SNAPSHOT_FOLDER --target_gamma GAMMA`

Different values of gamma correspond to different "averaging length" sigma_rel. You can use `--target_sigma_rel` instead of gamma.
![Screenshot 2024-02-01 151122](https://github.com/kohya-ss/sd-scripts/assets/143861044/d6254682-9fd4-4e4a-bb2a-96fbf0497633)

### Examples of different gamma:
SD1.5:
![xyz_grid-resized](https://github.com/kohya-ss/sd-scripts/assets/143861044/f4dfbaaf-ef45-469f-9ddf-fcc92279462f)
SDXL: 
![resize-25](https://github.com/kohya-ss/sd-scripts/assets/143861044/d4146601-f23b-4254-850d-2eeab7a7baa6)

Different models may require different gamma for best results. 
