### PR TITLE
Prepend imagenet template to caption like train textual inversion

### DIFF
--- a/library/config_util.py
+++ b/library/config_util.py
@@ -180,8 +180,8 @@ class ConfigSanitizer:
         "shuffle_caption": bool,
         "keep_tokens": int,
         "keep_tokens_separator": str,
-        "use_object_template": bool
-        "use_style_template": bool
+        "use_object_template": bool,
+        "use_style_template": bool,
         "token_warmup_min": int,
         "token_warmup_step": Any(float, int),
         "caption_prefix": str,

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -57,6 +57,8 @@ class BaseSubsetParams:
     caption_separator: str = (",",)
     keep_tokens: int = 0
     keep_tokens_separator: str = (None,)
+    use_object_template: bool = False
+    use_style_template: bool = False 
     color_aug: bool = False
     flip_aug: bool = False
     face_crop_aug_range: Optional[Tuple[float, float]] = None
@@ -65,7 +67,7 @@ class BaseSubsetParams:
     caption_suffix: Optional[str] = None
     caption_dropout_rate: float = 0.0
     caption_dropout_every_n_epochs: int = 0
-    caption_tag_dropout_rate: float = 0.0
+    caption_tag_dropout_rate: float = 0.0   
     token_warmup_min: int = 1
     token_warmup_step: float = 0
 
@@ -178,6 +180,8 @@ class ConfigSanitizer:
         "shuffle_caption": bool,
         "keep_tokens": int,
         "keep_tokens_separator": str,
+        "use_object_template": bool
+        "use_style_template": bool
         "token_warmup_min": int,
         "token_warmup_step": Any(float, int),
         "caption_prefix": str,
@@ -501,6 +505,8 @@ def generate_dataset_group_by_blueprint(dataset_group_blueprint: DatasetGroupBlu
           shuffle_caption: {subset.shuffle_caption}
           keep_tokens: {subset.keep_tokens}
           keep_tokens_separator: {subset.keep_tokens_separator}
+          use_object_template: bool = {subset.use_object_template}
+          use_style_template: bool = {subset.use_style_template}
           caption_dropout_rate: {subset.caption_dropout_rate}
           caption_dropout_every_n_epoches: {subset.caption_dropout_every_n_epochs}
           caption_tag_dropout_rate: {subset.caption_tag_dropout_rate}

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -720,11 +720,6 @@ class BaseDataset(torch.utils.data.Dataset):
             caption = subset.caption_prefix + " " + caption
         if subset.caption_suffix:
             caption = caption + " " + subset.caption_suffix
-        if subset.use_object_template or subset.use_style_template:
-            accelerator.print(f"use template for training captions.")
-            imagenet_templates = imagenet_templates_small if subset.use_object_template else imagenet_style_templates_small
-            imagenet_template =  = random.choice(imagenet_templates)
-            caption = imagenet_template + " " + caption  
         # dropoutの決定：tag dropがこのメソッド内にあるのでここで行うのが良い
         is_drop_out = subset.caption_dropout_rate > 0 and random.random() < subset.caption_dropout_rate
         is_drop_out = (
@@ -753,7 +748,11 @@ class BaseDataset(torch.utils.data.Dataset):
                     if subset.keep_tokens > 0:
                         fixed_tokens = flex_tokens[: subset.keep_tokens]
                         flex_tokens = tokens[subset.keep_tokens :]
-
+                if subset.use_object_template or subset.use_style_template:
+                    accelerator.print(f"use template for training captions.")
+                    imagenet_templates = imagenet_templates_small if subset.use_object_template else imagenet_style_templates_small
+                    imagenet_template =  = random.choice(imagenet_templates)
+                    caption = imagenet_template + " " + fixed_tokens  
                 if subset.token_warmup_step < 1:  # 初回に上書きする
                     subset.token_warmup_step = math.floor(subset.token_warmup_step * self.max_train_steps)
                 if subset.token_warmup_step and self.current_step < subset.token_warmup_step:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -749,7 +749,6 @@ class BaseDataset(torch.utils.data.Dataset):
                         fixed_tokens = flex_tokens[: subset.keep_tokens]
                         flex_tokens = tokens[subset.keep_tokens :]
                 if subset.use_object_template or subset.use_style_template:
-                    print(f"use template for training captions.")
                     imagenet_templates = imagenet_templates_small if subset.use_object_template else imagenet_style_templates_small
                     imagenet_template = [random.choice(imagenet_templates)]
                     caption = imagenet_template + fixed_tokens  

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -751,7 +751,7 @@ class BaseDataset(torch.utils.data.Dataset):
                 if subset.use_object_template or subset.use_style_template:
                     imagenet_templates = imagenet_templates_small if subset.use_object_template else imagenet_style_templates_small
                     imagenet_template = [random.choice(imagenet_templates)]
-                    caption = imagenet_template + fixed_tokens  
+                    fixed_tokens = imagenet_template + fixed_tokens  
                 if subset.token_warmup_step < 1:  # 初回に上書きする
                     subset.token_warmup_step = math.floor(subset.token_warmup_step * self.max_train_steps)
                 if subset.token_warmup_step and self.current_step < subset.token_warmup_step:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -91,55 +91,55 @@ STEP_DIFFUSERS_DIR_NAME = "{}-step{:08d}"
 IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp", ".bmp", ".PNG", ".JPG", ".JPEG", ".WEBP", ".BMP"]
 
 imagenet_templates_small = [
-    "a photo of a",
-    "a rendering of a",
-    "a cropped photo of the",
-    "the photo of a",
-    "a photo of a clean",
-    "a photo of a dirty",
-    "a dark photo of the",
-    "a photo of my",
-    "a photo of the cool",
-    "a close-up photo of a",
-    "a bright photo of the",
-    "a cropped photo of a",
-    "a photo of the",
-    "a good photo of the",
-    "a photo of one",
-    "a close-up photo of the",
-    "a rendition of the",
-    "a photo of the clean",
-    "a rendition of a",
-    "a photo of a nice",
-    "a good photo of a",
-    "a photo of the nice",
-    "a photo of the small",
-    "a photo of the weird",
-    "a photo of the large",
-    "a photo of a cool",
-    "a photo of a small",
+    "a photo of a ",
+    "a rendering of a ",
+    "a cropped photo of the ",
+    "the photo of a ",
+    "a photo of a clean ",
+    "a photo of a dirty ",
+    "a dark photo of the ",
+    "a photo of my ",
+    "a photo of the cool ",
+    "a close-up photo of a ",
+    "a bright photo of the ",
+    "a cropped photo of a ",
+    "a photo of the ",
+    "a good photo of the ",
+    "a photo of one ",
+    "a close-up photo of the ",
+    "a rendition of the ",
+    "a photo of the clean ",
+    "a rendition of a ",
+    "a photo of a nice ",
+    "a good photo of a ",
+    "a photo of the nice ",
+    "a photo of the small ",
+    "a photo of the weird ",
+    "a photo of the large ",
+    "a photo of a cool ",
+    "a photo of a small ",
 ]
 
 imagenet_style_templates_small = [
-    "a painting in the style of",
-    "a rendering in the style of",
-    "a cropped painting in the style of",
-    "the painting in the style of",
-    "a clean painting in the style of",
-    "a dirty painting in the style of",
-    "a dark painting in the style of",
-    "a picture in the style of",
-    "a cool painting in the style of",
-    "a close-up painting in the style of",
-    "a bright painting in the style of",
-    "a cropped painting in the style of",
-    "a good painting in the style of",
-    "a close-up painting in the style of",
-    "a rendition in the style of",
-    "a nice painting in the style of",
-    "a small painting in the style of",
-    "a weird painting in the style of",
-    "a large painting in the style of",
+    "a painting in the style of ",
+    "a rendering in the style of ",
+    "a cropped painting in the style of ",
+    "the painting in the style of ",
+    "a clean painting in the style of ",
+    "a dirty painting in the style of ",
+    "a dark painting in the style of ",
+    "a picture in the style of ",
+    "a cool painting in the style of ",
+    "a close-up painting in the style of ",
+    "a bright painting in the style of ",
+    "a cropped painting in the style of ",
+    "a good painting in the style of ",
+    "a close-up painting in the style of ",
+    "a rendition in the style of ",
+    "a nice painting in the style of ",
+    "a small painting in the style of ",
+    "a weird painting in the style of ",
+    "a large painting in the style of ",
 ]
 
 
@@ -749,10 +749,10 @@ class BaseDataset(torch.utils.data.Dataset):
                         fixed_tokens = flex_tokens[: subset.keep_tokens]
                         flex_tokens = tokens[subset.keep_tokens :]
                 if subset.use_object_template or subset.use_style_template:
-                    accelerator.print(f"use template for training captions.")
+                    print(f"use template for training captions.")
                     imagenet_templates = imagenet_templates_small if subset.use_object_template else imagenet_style_templates_small
-                    imagenet_template =  = random.choice(imagenet_templates)
-                    caption = imagenet_template + " " + fixed_tokens  
+                    imagenet_template = [random.choice(imagenet_templates)]
+                    caption = imagenet_template + fixed_tokens  
                 if subset.token_warmup_step < 1:  # 初回に上書きする
                     subset.token_warmup_step = math.floor(subset.token_warmup_step * self.max_train_steps)
                 if subset.token_warmup_step and self.current_step < subset.token_warmup_step:


### PR DESCRIPTION
It may be a technique for data augmentation (or called prompt ensembling). I'm not sure if it really helps.
But I had a good experience while training TI and lora test with same caption.

Use `--use_object_template` for objects, `--use_style_template` for styles.

It will prepend a randomly chosen template to the beginning of the caption.

object_templates = [
    "a photo of a ",
    "a rendering of a ",
    "a cropped photo of the ",
    "the photo of a ",
    "a photo of a clean ",
    "a photo of a dirty ",
    "a dark photo of the ",
    "a photo of my ",
    "a photo of the cool ",
    "a close-up photo of a ",
    "a bright photo of the ",
    "a cropped photo of a ",
    "a photo of the ",
    "a good photo of the ",
    "a photo of one ",
    "a close-up photo of the  ",
    "a rendition of the ",
    "a photo of the clean ",
    "a rendition of a ",
    "a photo of a nice ",
    "a good photo of a ",
    "a photo of the nice ",
    "a photo of the small ",
    "a photo of the weird ",
    "a photo of the large ",
    "a photo of a cool ",
    "a photo of a small ",
]

style_templates = [
    "a painting in the style of ",
    "a rendering in the style of ",
    "a cropped painting in the style of ",
    "the painting in the style of ",
    "a clean painting in the style of ",
    "a dirty painting in the style of ",
    "a dark painting in the style of ",
    "a picture in the style of ",
    "a cool painting in the style of ",
    "a close-up painting in the style of ",
    "a bright painting in the style of ",
    "a cropped painting in the style of ",
    "a good painting in the style of ",
    "a close-up painting in the style of ",
    "a rendition in the style of ",
    "a nice painting in the style of ",
    "a small painting in the style of ",
    "a weird painting in the style of ",
    "a large painting in the style of ",
]



