### PR TITLE
Auto mask uniform background base on PR #589 mask loss

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -31,6 +31,7 @@ from library.custom_train_functions import (
     prepare_scheduler_for_custom_training,
     scale_v_prediction_loss_like_noise_prediction,
     apply_debiased_estimation,
+    get_latent_masks
 )
 
 
@@ -345,6 +346,11 @@ def train(args):
                     target = noise_scheduler.get_velocity(latents, noise, timesteps)
                 else:
                     target = noise
+
+                if args.masked_loss and batch['masks'] is not None:
+                    mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
+                    noise_pred = noise_pred * mask
+                    target = target * mask
 
                 if args.min_snr_gamma or args.scale_v_pred_loss_like_noise_pred or args.debiased_estimation_loss:
                     # do not mean over batch dimension for snr weight or scale v-pred loss

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -347,7 +347,7 @@ def train(args):
                 else:
                     target = noise
 
-                if args.masked_loss and batch['masks'] is not None:
+                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -347,7 +347,7 @@ def train(args):
                 else:
                     target = noise
 
-                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
+                if (args.masked_loss or args.mask_simple_background) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -61,6 +61,7 @@ class BaseSubsetParams:
     flip_aug: bool = False
     face_crop_aug_range: Optional[Tuple[float, float]] = None
     random_crop: bool = False
+    mask_simple_background: bool = False
     caption_prefix: Optional[str] = None
     caption_suffix: Optional[str] = None
     caption_dropout_rate: float = 0.0
@@ -175,6 +176,7 @@ class ConfigSanitizer:
         "flip_aug": bool,
         "num_repeats": int,
         "random_crop": bool,
+        "mask_simple_background": bool,
         "shuffle_caption": bool,
         "keep_tokens": int,
         "keep_tokens_separator": str,
@@ -510,6 +512,7 @@ def generate_dataset_group_by_blueprint(dataset_group_blueprint: DatasetGroupBlu
           flip_aug: {subset.flip_aug}
           face_crop_aug_range: {subset.face_crop_aug_range}
           random_crop: {subset.random_crop}
+          mask_simple_background: {subset.mask_simple_background}          
           token_warmup_min: {subset.token_warmup_min},
           token_warmup_step: {subset.token_warmup_step},
       """

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1181,7 +1181,7 @@ class BaseDataset(torch.utils.data.Dataset):
                     original_size = [im_w, im_h]
                     crop_ltrb = (0, 0, 0, 0)
                     
-                if mask_simple_background:
+                if subset.mask_simple_background:
                     edge_width = max(1, min(image.shape[0], image.shape[1]) // 20)
                     top_edge = image[:edge_width, :, :]
                     bottom_edge = image[-edge_width:, :, :]

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2213,10 +2213,11 @@ def load_image(image_path):
     image = Image.open(image_path)
     if not image.mode == "RGBA":
         image = image.convert("RGBA")
+    custom_bg = Image.new("RGBA", image.size, (255, 255, 255, 255))
+    image = Image.alpha_composite(custom_bg, image)                    
     img = np.array(image, np.uint8)
     img[..., -1] = load_mask(image_path, img.shape[:2])
     return img
-
 
 def load_mask(image_path, target_shape):
     p = pathlib.Path(image_path)
@@ -2247,7 +2248,6 @@ def load_mask(image_path, target_shape):
         result = cv2.resize(result, dsize=target_shape, interpolation=cv2.INTER_LINEAR)
 
     return result
-
 
 # 画像を読み込む。戻り値はnumpy.ndarray,(original width, original height),(crop left, crop top, crop right, crop bottom)
 def trim_and_resize_if_required(

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -326,7 +326,7 @@ class AugHelper:
         hue_shift_limit = 8
 
         rgb_channels = image[:, :, :3] 
-        alpha_channel = image[:, :, 3] 
+        alpha_channel = image[:, :, -1]
         # remove dependency to albumentations
         if random.random() <= 0.33:
             if random.random() > 0.5:
@@ -1135,7 +1135,6 @@ class BaseDataset(torch.utils.data.Dataset):
                 image = None
             elif image_info.latents_npz is not None:  # FineTuningDatasetまたはcache_latents_to_disk=Trueの場合
                 latents, original_size, crop_ltrb, flipped_latents, mask = load_latents_from_disk(image_info.latents_npz)
-                mask = mask / 255
                 if flipped:
                     latents = flipped_latents
                     mask = np.flip(mask, axis=1)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -325,21 +325,24 @@ class AugHelper:
         # )
         hue_shift_limit = 8
 
+        rgb_channels = image[:, :, :3] 
+        alpha_channel = image[:, :, 3] 
         # remove dependency to albumentations
         if random.random() <= 0.33:
             if random.random() > 0.5:
                 # hue shift
-                hsv_img = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+                hsv_img = cv2.cvtColor(rgb_channels, cv2.COLOR_BGR2HSV)
                 hue_shift = random.uniform(-hue_shift_limit, hue_shift_limit)
                 if hue_shift < 0:
                     hue_shift = 180 + hue_shift
                 hsv_img[:, :, 0] = (hsv_img[:, :, 0] + hue_shift) % 180
-                image = cv2.cvtColor(hsv_img, cv2.COLOR_HSV2BGR)
+                rgb_channels = cv2.cvtColor(hsv_img, cv2.COLOR_HSV2BGR)
             else:
                 # random gamma
                 gamma = random.uniform(0.95, 1.05)
-                image = np.clip(image**gamma, 0, 255).astype(np.uint8)
+                rgb_channels = np.clip(rgb_channels**gamma, 0, 255).astype(np.uint8)
 
+        image = np.dstack((rgb_channels, alpha_channel)) 
         return {"image": image}
 
     def get_augmentor(self, use_color_aug: bool):  # -> Optional[Callable[[np.ndarray], Dict[str, np.ndarray]]]:
@@ -3318,6 +3321,10 @@ def add_dataset_arguments(
 
     parser.add_argument(
         "--masked_loss", action="store_true", help="Enable masking of latent loss using grayscale mask images"
+    )
+
+    parser.add_argument(
+        "--auto_masked_loss", action="store_true", help="Enable auto-masking of latent loss for images that are completely white (255, 255, 255), completely black (0, 0, 0), and transparent / 完全に白い（255, 255, 255）、完全に黒い（0, 0, 0）、および透明な部分の画像の潜在損失の自動マスキングを有効にします"
     )
 
     parser.add_argument(

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -33,6 +33,7 @@ from library.custom_train_functions import (
     scale_v_prediction_loss_like_noise_prediction,
     add_v_prediction_like_loss,
     apply_debiased_estimation,
+    get_latent_masks
 )
 from library.sdxl_original_unet import SdxlUNet2DConditionModel
 
@@ -560,6 +561,11 @@ def train(args):
                     noise_pred = unet(noisy_latents, timesteps, text_embedding, vector_embedding)
 
                 target = noise
+
+                if args.masked_loss and batch['masks'] is not None:
+                    mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
+                    noise_pred = noise_pred * mask
+                    target = target * mask
 
                 if (
                     args.min_snr_gamma

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -562,7 +562,7 @@ def train(args):
 
                 target = noise
 
-                if args.masked_loss and batch['masks'] is not None:
+                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -562,7 +562,7 @@ def train(args):
 
                 target = noise
 
-                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
+                if (args.masked_loss or args.mask_simple_background) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/train_db.py
+++ b/train_db.py
@@ -334,7 +334,7 @@ def train(args):
                 else:
                     target = noise
 
-                if args.masked_loss and batch['masks'] is not None:
+                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/train_db.py
+++ b/train_db.py
@@ -34,6 +34,7 @@ from library.custom_train_functions import (
     apply_noise_offset,
     scale_v_prediction_loss_like_noise_prediction,
     apply_debiased_estimation,
+    get_latent_masks
 )
 
 # perlin_noise,
@@ -332,6 +333,11 @@ def train(args):
                     target = noise_scheduler.get_velocity(latents, noise, timesteps)
                 else:
                     target = noise
+
+                if args.masked_loss and batch['masks'] is not None:
+                    mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
+                    noise_pred = noise_pred * mask
+                    target = target * mask
 
                 loss = torch.nn.functional.mse_loss(noise_pred.float(), target.float(), reduction="none")
                 loss = loss.mean([1, 2, 3])

--- a/train_db.py
+++ b/train_db.py
@@ -334,7 +334,7 @@ def train(args):
                 else:
                     target = noise
 
-                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
+                if (args.masked_loss or args.mask_simple_background) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/train_network.py
+++ b/train_network.py
@@ -825,7 +825,7 @@ class NetworkTrainer:
                     else:
                         target = noise
 
-                    if args.masked_loss and batch['masks'] is not None:
+                    if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
                         mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                         noise_pred = noise_pred * mask
                         target = target * mask

--- a/train_network.py
+++ b/train_network.py
@@ -825,7 +825,7 @@ class NetworkTrainer:
                     else:
                         target = noise
 
-                    if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
+                    if (args.masked_loss or args.mask_simple_background) and batch['masks'] is not None:
                         mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                         noise_pred = noise_pred * mask
                         target = target * mask

--- a/train_network.py
+++ b/train_network.py
@@ -40,6 +40,7 @@ from library.custom_train_functions import (
     scale_v_prediction_loss_like_noise_prediction,
     add_v_prediction_like_loss,
     apply_debiased_estimation,
+    get_latent_masks
 )
 
 
@@ -823,6 +824,11 @@ class NetworkTrainer:
                         target = noise_scheduler.get_velocity(latents, noise, timesteps)
                     else:
                         target = noise
+
+                    if args.masked_loss and batch['masks'] is not None:
+                        mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
+                        noise_pred = noise_pred * mask
+                        target = target * mask
 
                     loss = torch.nn.functional.mse_loss(noise_pred.float(), target.float(), reduction="none")
                     loss = loss.mean([1, 2, 3])

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -583,7 +583,7 @@ class TextualInversionTrainer:
                     else:
                         target = noise
 
-                    if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
+                    if (args.masked_loss or args.mask_simple_background) and batch['masks'] is not None:
                         mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                         noise_pred = noise_pred * mask
                         target = target * mask

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -583,7 +583,7 @@ class TextualInversionTrainer:
                     else:
                         target = noise
 
-                    if args.masked_loss and batch['masks'] is not None:
+                    if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
                         mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                         noise_pred = noise_pred * mask
                         target = target * mask

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -31,6 +31,7 @@ from library.custom_train_functions import (
     scale_v_prediction_loss_like_noise_prediction,
     add_v_prediction_like_loss,
     apply_debiased_estimation,
+    get_latent_masks
 )
 
 imagenet_templates_small = [
@@ -581,6 +582,11 @@ class TextualInversionTrainer:
                         target = noise_scheduler.get_velocity(latents, noise, timesteps)
                     else:
                         target = noise
+
+                    if args.masked_loss and batch['masks'] is not None:
+                        mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
+                        noise_pred = noise_pred * mask
+                        target = target * mask
 
                     loss = torch.nn.functional.mse_loss(noise_pred.float(), target.float(), reduction="none")
                     loss = loss.mean([1, 2, 3])

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -33,6 +33,7 @@ from library.custom_train_functions import (
     apply_noise_offset,
     scale_v_prediction_loss_like_noise_prediction,
     apply_debiased_estimation,
+    get_latent_masks
 )
 import library.original_unet as original_unet
 from XTI_hijack import unet_forward_XTI, downblock_forward_XTI, upblock_forward_XTI
@@ -458,6 +459,11 @@ def train(args):
                     target = noise_scheduler.get_velocity(latents, noise, timesteps)
                 else:
                     target = noise
+
+                if args.masked_loss and batch['masks'] is not None:
+                    mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
+                    noise_pred = noise_pred * mask
+                    target = target * mask
 
                 loss = torch.nn.functional.mse_loss(noise_pred.float(), target.float(), reduction="none")
                 loss = loss.mean([1, 2, 3])

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -460,7 +460,7 @@ def train(args):
                 else:
                     target = noise
 
-                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
+                if (args.masked_loss or args.mask_simple_background) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -460,7 +460,7 @@ def train(args):
                 else:
                     target = noise
 
-                if args.masked_loss and batch['masks'] is not None:
+                if (args.masked_loss or args.auto_masked_loss) and batch['masks'] is not None:
                     mask = get_latent_masks(batch['masks'], noise_pred.shape, noise_pred.device)
                     noise_pred = noise_pred * mask
                     target = target * mask


### PR DESCRIPTION
Base on [PR #589](https://github.com/kohya-ss/sd-scripts/pull/589/). Thanks [recris](https://github.com/recris).

(1) Change the mechanism for caching_latent_to_disk by directly storing the mask in the NPZ file. Actually, due to trim_and_resize, it was impossible to match the required size, made cache_latent_to_disk unusable.

(2) Modify the way of color augmentation to preserve the original alpha channel unchanged, which should allow for more accurate handling of the mask.

(3) Add `--mask_simple_background`. Enable auto-masking of latent loss based on the dominant edge color if it occupies more than 30% of the image edges. This helps in focusing the model on the main content by ignoring simple or uniform background colors such as solid white or black.

I think this will help improve the quality of datasets with a high proportion of white backgrounds, transparent backgrounds, and simple backgrounds in anime images.


This is a simpler feature implementation. It might be possible to add automatic masking for faces (for clothing training), characters, etc. However, because automatically processed masks are harder to inspect and would introduce a significant amount of additional requirements, it might be better to use the [script ](https://github.com/gesen2egee/dataset_tools/blob/main/makemask.py)I wrote or the webui's rembg to pre-generate masks for manual inspection.