### PR TITLE
Faster training with token merging via tomesd

### DIFF
--- a/library/token_merging.py
+++ b/library/token_merging.py
@@ -1,0 +1,103 @@
+# adapted from tomesd, which uses the MIT license
+# https://github.com/dbolya/tomesd/blob/main/tomesd/patch.py
+
+from typing import Type
+
+import torch
+from tomesd.patch import compute_merge, hook_tome_model, remove_patch
+from tomesd.utils import isinstance_str
+
+
+def make_tome_block(block_class: Type[torch.nn.Module]) -> Type[torch.nn.Module]:
+    """
+    Make a patched class on the fly so we don't have to import any specific modules.
+    This patch applies ToMe to the forward function of the block.
+    """
+
+    class ToMeBlock(block_class):
+        # Save for unpatching later
+        _parent = block_class
+
+        def forward(self, hidden_states: torch.Tensor, context: torch.Tensor = None, timestep=None) -> torch.Tensor:
+            m_a, m_c, m_m, u_a, u_c, u_m = compute_merge(hidden_states, self._tome_info)
+
+            # 1. Self-Attention
+            norm_hidden_states = m_a(self.norm1(hidden_states))
+            hidden_states = u_a(self.attn1(norm_hidden_states)) + hidden_states
+
+            # 2. Cross-Attention
+            norm_hidden_states = m_c(self.norm2(hidden_states))
+            hidden_states = u_c(self.attn2(norm_hidden_states, context=context)) + hidden_states
+
+            # 3. Feed-forward
+            hidden_states = u_m(self.ff(m_m(self.norm3(hidden_states)))) + hidden_states
+
+            return hidden_states
+
+    return ToMeBlock
+
+
+def apply_patch(
+        model: torch.nn.Module,
+        ratio: float = 0.5,
+        max_downsample: int = 1,
+        sx: int = 2, sy: int = 2,
+        use_rand: bool = True,
+        merge_attn: bool = True,
+        merge_crossattn: bool = False,
+        merge_mlp: bool = False):
+    """
+    Patches a stable diffusion model with ToMe. Modified to work with kohya-ss/sd-scripts
+    Apply this to the unet.
+
+    Important Args:
+     - model: A Stable Diffusion unet module to patch in place.
+     - ratio: The ratio of tokens to merge. I.e., 0.4 would reduce the total number of tokens by 40%.
+              The maximum value for this is 1-(1/(sx*sy)). By default, the max is 0.75 (I recommend <= 0.5 though).
+              Higher values result in more speed-up, but with more visual quality loss.
+    
+    Args to tinker with if you want:
+     - max_downsample [1, 2, 4, or 8]: Apply ToMe to layers with at most this amount of downsampling.
+                                       E.g., 1 only applies to layers with no downsampling (4/15) while
+                                       8 applies to all layers (15/15). I recommend a value of 1 or 2.
+     - sx, sy: The stride for computing dst sets (see paper). A higher stride means you can merge more tokens,
+               but the default of (2, 2) works well in most cases. Doesn't have to divide image size.
+     - use_rand: Whether or not to allow random perturbations when computing dst sets (see paper). Usually
+                 you'd want to leave this on, but if you're having weird artifacts try turning this off.
+     - merge_attn: Whether or not to merge tokens for attention (recommended).
+     - merge_crossattn: Whether or not to merge tokens for cross attention (not recommended).
+     - merge_mlp: Whether or not to merge tokens for the mlp layers (very not recommended).
+    """
+
+    # Make sure the module is not currently patched
+    remove_patch(model)
+
+    diffusion_model = model
+
+    diffusion_model._tome_info = {
+        "size": None,
+        "hooks": [],
+        "args": {
+            "ratio": ratio,
+            "max_downsample": max_downsample,
+            "sx": sx, "sy": sy,
+            "use_rand": use_rand,
+            "generator": None,
+            "merge_attn": merge_attn,
+            "merge_crossattn": merge_crossattn,
+            "merge_mlp": merge_mlp
+        }
+    }
+    hook_tome_model(diffusion_model)
+
+    for _, module in diffusion_model.named_modules():
+        # If for some reason this has a different name, create an issue and I'll fix it
+        if isinstance_str(module, "BasicTransformerBlock"):
+            module.__class__ = make_tome_block(module.__class__)
+            module._tome_info = diffusion_model._tome_info
+
+            # Something introduced in SD 2.0 (LDM only)
+            if not hasattr(module, "disable_self_attn"):
+                module.disable_self_attn = False
+
+    return model

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3135,6 +3135,16 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         default=None,
         help="set maximum time step for U-Net training (1~1000, default is 1000) / U-Net学習時のtime stepの最大値を設定する（1~1000で指定、省略時はデフォルト値(1000)）",
     )
+    parser.add_argument(
+        "--tome_ratio",
+        type=float,
+        help="token merge ratio for tomesd",
+    )
+    parser.add_argument(
+        "--stop_tome",
+        type=float,
+        help="step to disable token merging. value less than 1.0 is treated as portion of total training steps",
+    )
 
     parser.add_argument(
         "--lowram",


### PR DESCRIPTION
This PR adds support for training with token merging from the `tomesd` library (needs to be installed in the venv).
This significantly speeds up training at the cost of some quality loss. With 50% merge ratio I saw a 50% reduction in training time for SD1.x loras. The quality loss seems minor because the model learns to compensate during training.
I've added two new flags:
- `--tome_ratio` (float) token merging ratio. Float between 0 and 1. `tomesd` recommends 0.5 or lower and there are diminishing returns on speed improvement above this.
- `--stop_tome` (int or float) disable token merging after this many steps. Value less than 1.0 is treated as a fraction of total training time. The reason for this option is to minimize quality loss by disabling ToMe towards the end of training.

Currently, only train_network.py is supported. SDXL technically works too but I didn't see any speedup (might need different settings but it's also just more efficient overall so it benefits less from token merging).
Draft PR for now because I'm not sure if this is the best way to integrate the functionality. Patching could potentially be moved to `train_util.py` in the model loading function to avoid duplicate code. I am not sure how this might affect model saving for finetune or dreambooth. It only overrides the forward method of BasicTransformerBlock, so I think saving won't be affected?

Example:
| Name | Merge ratio | s/it | Speedup |
|---|---|---|---|
| feffy-v3.50 | 0 | 2 | 1x |
| feffy-tome30 | 0.3 | 1.36 | 1.47x |
| feffy-tome50 | 0.5 | 1 | 2x |

![xyz_grid-5026-332293423-feffy female anthro latias, fluffy, fur tuft, cheek tuft, white fur, red hair, highlights _(coloring_), yellow eyes, black pupil](https://github.com/kohya-ss/sd-scripts/assets/114889020/656d6ce5-6b52-47af-ae27-43a01ca2d2a8)
