### PR TITLE
Implement Wildcard for Random Caption Selection

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -658,6 +658,7 @@ class BaseDataset(torch.utils.data.Dataset):
         self.replacements[str_from] = str_to
 
     def process_caption(self, subset: BaseSubset, caption):
+        caption = random.choice(caption.split('[[[WiLdCaRd]]]'))
         # caption に prefix/suffix を付ける
         if subset.caption_prefix:
             caption = subset.caption_prefix + " " + caption
@@ -1419,7 +1420,7 @@ class DreamBoothDataset(BaseDataset):
                             logger.error(f"illegal char in file (not UTF-8) / ファイルにUTF-8以外の文字があります: {cap_path}")
                             raise e
                         assert len(lines) > 0, f"caption file is empty / キャプションファイルが空です: {cap_path}"
-                        caption = random.choice(lines).strip()
+                        caption = '[[[WiLdCaRd]]]'.join(lines)
                     break
             return caption
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1419,7 +1419,7 @@ class DreamBoothDataset(BaseDataset):
                             logger.error(f"illegal char in file (not UTF-8) / ファイルにUTF-8以外の文字があります: {cap_path}")
                             raise e
                         assert len(lines) > 0, f"caption file is empty / キャプションファイルが空です: {cap_path}"
-                        caption = lines[0].strip()
+                        caption = random.choice(lines).strip()
                     break
             return caption
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1420,7 +1420,8 @@ class DreamBoothDataset(BaseDataset):
                             logger.error(f"illegal char in file (not UTF-8) / ファイルにUTF-8以外の文字があります: {cap_path}")
                             raise e
                         assert len(lines) > 0, f"caption file is empty / キャプションファイルが空です: {cap_path}"
-                        caption = '[[[WiLdCaRd]]]'.join(lines)
+                        filtered_lines = [line for line in lines if line.strip()]
+                        caption = '[[[WiLdCaRd]]]'.join(filtered_lines)
                     break
             return caption
 


### PR DESCRIPTION
A very simple PR

If there are more than one line in the caption's extension file, it will randomly select one line to be the final caption. This is helpful for those using multiple captioning methods, adding flexibility through wildcards.