### PR TITLE
Faster training with token downsampling

### DIFF
--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 from transformers import CLIPTokenizer
 from library import model_util, sdxl_model_util, train_util, sdxl_original_unet
 from library.sdxl_lpw_stable_diffusion import SdxlStableDiffusionLongPromptWeightingPipeline
+from library import token_merging
 from .utils import setup_logging
 setup_logging()
 import logging
@@ -56,6 +57,10 @@ def load_target_model(args, accelerator, model_version: str, weight_dtype):
 
             clean_memory_on_device(accelerator.device)
         accelerator.wait_for_everyone()
+
+    # apply token merging patch
+    if args.todo_factor:
+        token_merging.patch_attention(unet, args)
 
     return load_stable_diffusion_format, text_encoder1, text_encoder2, vae, unet, logit_scale, ckpt_info
 

--- a/library/token_merging.py
+++ b/library/token_merging.py
@@ -1,0 +1,106 @@
+# based on:
+#   https://github.com/ethansmith2000/ImprovedTokenMerge
+#   https://github.com/ethansmith2000/comfy-todo (MIT)
+
+import ast
+import math
+
+import torch
+import torch.nn.functional as F
+
+from library.sdxl_original_unet import SdxlUNet2DConditionModel
+
+from library.utils import setup_logging
+setup_logging()
+import logging
+logger = logging.getLogger(__name__)
+
+
+def up_or_downsample(item, cur_w, cur_h, new_w, new_h, method):
+    batch_size = item.shape[0]
+
+    item = item.reshape(batch_size, cur_h, cur_w, -1).permute(0, 3, 1, 2)
+    item = F.interpolate(item, size=(new_h, new_w), mode=method).permute(0, 2, 3, 1)
+    item = item.reshape(batch_size, new_h * new_w, -1)
+
+    return item
+
+
+def compute_merge(x: torch.Tensor, tome_info: dict):
+    original_h, original_w = tome_info["size"]
+    original_tokens = original_h * original_w
+    downsample = int(math.ceil(math.sqrt(original_tokens // x.shape[1])))
+    cur_h = original_h // downsample
+    cur_w = original_w // downsample
+    downsample_factor_1 = tome_info["args"]["downsample_factor_depth_1"]
+    downsample_factor_2 = tome_info["args"]["downsample_factor_depth_2"]
+
+    merge_op = lambda x: x
+    if downsample == 1 and downsample_factor_1 > 1:
+        new_h = int(cur_h / downsample_factor_1)
+        new_w = int(cur_w / downsample_factor_1)
+        merge_op = lambda x: up_or_downsample(x, cur_w, cur_h, new_w, new_h, tome_info["args"]["downsample_method"])
+    elif downsample == 2 and downsample_factor_2 > 1:
+        new_h = int(cur_h / downsample_factor_2)
+        new_w = int(cur_w / downsample_factor_2)
+        merge_op = lambda x: up_or_downsample(x, cur_w, cur_h, new_w, new_h, tome_info["args"]["downsample_method"])
+
+    return merge_op
+
+
+def hook_tome_model(model: torch.nn.Module):
+    """ Adds a forward pre hook to get the image size. This hook can be removed with remove_patch. """
+    def hook(module, args):
+        module._tome_info["size"] = (args[0].shape[2], args[0].shape[3])
+        return None
+
+    model._tome_info["hooks"].append(model.register_forward_pre_hook(hook))
+
+
+def hook_attention(attn: torch.nn.Module):
+    """ Adds a forward pre hook to downsample attention keys and values. This hook can be removed with remove_patch. """
+    def hook(module, args, kwargs):
+        hidden_states = args[0]
+        m = compute_merge(hidden_states, module._tome_info)
+        kwargs["context"] = m(hidden_states)
+        return args, kwargs
+
+    attn._tome_info["hooks"].append(attn.register_forward_pre_hook(hook, with_kwargs=True))
+
+
+def patch_attention(unet: torch.nn.Module, args):
+    """ Patches the UNet's transformer blocks to apply token downsampling. """
+    is_sdxl = isinstance(unet, SdxlUNet2DConditionModel)
+    todo_kwargs = {
+        "downsample_factor_depth_1": args.todo_factor,
+        "downsample_factor_depth_2": args.todo_factor if is_sdxl else 1,  # SDXL doesn't have depth 1, so downsample here
+        "downsample_method": "nearest-exact",
+    }
+    if args.todo_args:
+        for arg in args.todo_args:
+            key, value = arg.split("=")
+            todo_kwargs[key] = ast.literal_eval(value)
+    logger.info(f"enable token downsampling optimization | {todo_kwargs}")
+
+    unet._tome_info = {
+        "size": None,
+        "hooks": [],
+        "args": todo_kwargs,
+    }
+    hook_tome_model(unet)
+
+    for _, module in unet.named_modules():
+        if module.__class__.__name__ == "BasicTransformerBlock":
+            module.attn1._tome_info = unet._tome_info
+            hook_attention(module.attn1)
+
+    return unet
+
+
+def remove_patch(unet: torch.nn.Module):
+    if hasattr(unet, "_tome_info"):
+        for hook in unet._tome_info["hooks"]:
+            hook.remove()
+        unet._tome_info["hooks"].clear()
+
+    return unet


### PR DESCRIPTION
This PR adds support for training with [token downsampling](https://github.com/ethansmith2000/ImprovedTokenMerge) and replaces my token merge PR (#1146).

Token downsampling is a lossy optimization that significantly speeds up inference and training. It tries to avoid the quality loss of [token merging](https://github.com/dbolya/tomesd) by only downsampling K and V in the attention operation (Q is preserved) and replaces the expensive token similarity calculation with simple downsampling.
Applying the optimization during training seems to have less quality loss compared to inference, so I was able to increase the amount of downsampling a lot without negative effects.

With a downsampling factor of 2 and resolution of 768px I get a **2x speedup** for SD1.x LoRA training.
Downsampling at both levels with factors 4 and 2 gave me an even bigger **3.2x speedup** with no visible quality loss. I'm not sure how much this is affected by dataset, so YMMV.
SDXL benefits less because its architecture is already more efficient, but I still saw about 1.3x speedup at 1024px with downsample factor 2.

This PR adds two new flags:
- `--todo_factor`: (float) token downsampling factor. The inputs of the unet's self-attention layers are scaled down by this factor.
- `--todo_args`: (list[str]) pass "key=value" args to ToDo. See list below.

Advanced options:
- downsample_factor_depth_1: (float) amount to downsample in 1st down block of unet.
  - Default: `--todo_factor`
  - Note: Does nothing for SDXL because it doesn't have this block.
- downsample_factor_depth_2: (float) amount to downsample in 2nd down block of unet.
  - SD1/2 default: 1 (no downsampling)
  - SDXL default: `--todo_factor`
- downsample_method: (str) `torch.nn.functional.interpolate` mode argument for downsampling.
  - Default: `nearest-exact`

The unet is patched when the model is loaded, so the optimization should automatically work with all training scripts, but I only tested train_network.py and sdxl_train_network.py.
The downsampling operation is implemented with pytorch forward pre hooks, so model saving should be unaffected.

Example:
| Name | Downsample factors | s/it | Speedup |
|---|---|---|---|
| feffy-v3.50 | None | 2.0 | 1x |
| feffy-todo2 | 2/1 | 1.0 | 2x |
| feffy-todo4_2 | 4/2 | 0.63 | 3.2x |

![image](https://github.com/kohya-ss/sd-scripts/assets/114889020/93dad6bb-f61d-4edd-89c5-c5e51d90eac9)

Training details:
- 7900 XTX with `--mem_eff_attn`
- 768px resolution with bucketing
- Batch size 4