### PR TITLE
Support for multiple captions in one file

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1203,7 +1203,10 @@ class BaseDataset(torch.utils.data.Dataset):
             flippeds.append(flipped)
 
             # captionとtext encoder outputを処理する
-            caption = image_info.caption  # default
+            raw_caption = image_info.caption  # default
+            captions = [s.strip() for s in raw_caption.split("\n") if len(s.strip())>0]
+            caption = random.choice(captions)
+
             if image_info.text_encoder_outputs1 is not None:
                 text_encoder_outputs1_list.append(image_info.text_encoder_outputs1)
                 text_encoder_outputs2_list.append(image_info.text_encoder_outputs2)
@@ -1419,7 +1422,7 @@ class DreamBoothDataset(BaseDataset):
                             logger.error(f"illegal char in file (not UTF-8) / ファイルにUTF-8以外の文字があります: {cap_path}")
                             raise e
                         assert len(lines) > 0, f"caption file is empty / キャプションファイルが空です: {cap_path}"
-                        caption = lines[0].strip()
+                        caption = "\n".join([l.strip() for l in lines])
                     break
             return caption
 


### PR DESCRIPTION
This is a simple little change which adds support for using multiple captions in a single caption file, one per line. During training, each time the caption is needed, a random line is sampled.

I'm using this with a line of WD14 tags, a LLaVa natural language caption, and a LLaVa natural language caption which was prompted by including the WD14 tags. This seems to have helped quite a bit with training robustness.

It would be cleaner to assign an array of captions to `image_info.caption` rather than splitting the lines on each pass, but I wasn't sure if there was a dependency elsewhere on caption being a string, so this is just my first little quick and dirty pass.