### PR TITLE
Implementation of Sample Weights

### DIFF
--- a/library/config_util.py
+++ b/library/config_util.py
@@ -71,7 +71,7 @@ class BaseSubsetParams:
     caption_tag_dropout_rate: float = 0.0
     token_warmup_min: int = 1
     token_warmup_step: float = 0
-
+    sample_weight: bool = False
 
 @dataclass
 class DreamBoothSubsetParams(BaseSubsetParams):
@@ -185,6 +185,7 @@ class ConfigSanitizer:
         "token_warmup_step": Any(float, int),
         "caption_prefix": str,
         "caption_suffix": str,
+        "sample_weight": bool, 
     }
     # DO means DropOut
     DO_SUBSET_ASCENDABLE_SCHEMA = {

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -375,6 +375,7 @@ class BaseSubset:
         caption_suffix: Optional[str],
         token_warmup_min: int,
         token_warmup_step: Union[float, int],
+        sample_weight: bool,
     ) -> None:
         self.image_dir = image_dir
         self.num_repeats = num_repeats
@@ -394,7 +395,7 @@ class BaseSubset:
 
         self.token_warmup_min = token_warmup_min  # step=0におけるタグの数
         self.token_warmup_step = token_warmup_step  # N（N<1ならN*max_train_steps）ステップ目でタグの数が最大になる
-
+        self.sample_weight = sample_weight
         self.img_count = 0
 
 
@@ -421,6 +422,7 @@ class DreamBoothSubset(BaseSubset):
         caption_suffix,
         token_warmup_min,
         token_warmup_step,
+        sample_weight,
     ) -> None:
         assert image_dir is not None, "image_dir must be specified / image_dirは指定が必須です"
 
@@ -442,6 +444,7 @@ class DreamBoothSubset(BaseSubset):
             caption_suffix,
             token_warmup_min,
             token_warmup_step,
+            sample_weight,
         )
 
         self.is_reg = is_reg
@@ -477,6 +480,7 @@ class FineTuningSubset(BaseSubset):
         caption_suffix,
         token_warmup_min,
         token_warmup_step,
+        sample_weight,
     ) -> None:
         assert metadata_file is not None, "metadata_file must be specified / metadata_fileは指定が必須です"
 
@@ -498,6 +502,7 @@ class FineTuningSubset(BaseSubset):
             caption_suffix,
             token_warmup_min,
             token_warmup_step,
+            sample_weight,
         )
 
         self.metadata_file = metadata_file
@@ -530,6 +535,7 @@ class ControlNetSubset(BaseSubset):
         caption_suffix,
         token_warmup_min,
         token_warmup_step,
+        sample_weight,
     ) -> None:
         assert image_dir is not None, "image_dir must be specified / image_dirは指定が必須です"
 
@@ -551,6 +557,7 @@ class ControlNetSubset(BaseSubset):
             caption_suffix,
             token_warmup_min,
             token_warmup_step,
+            sample_weight,
         )
 
         self.conditioning_data_dir = conditioning_data_dir
@@ -1121,7 +1128,7 @@ class BaseDataset(torch.utils.data.Dataset):
             image_info = self.image_data[image_key]
             subset = self.image_to_subset[image_key]
             sample_weight = 1.0
-            if args.sample_weight is not None:
+            if self.sample_weight is not None:
                 sample_weight_path = os.path.splitext(info.absolute_path)[0] + ".weight"
                 try:
                     with open(sample_weight_path, 'r', encoding='utf-8') as file:
@@ -1791,6 +1798,7 @@ class ControlNetDataset(BaseDataset):
                 subset.caption_suffix,
                 subset.token_warmup_min,
                 subset.token_warmup_step,
+                subset.sample_weight,
             )
             db_subsets.append(db_subset)
 


### PR DESCRIPTION
This proposal introduces a minimalistic implementation of **sample_weight** (default value is 1), which reads the first line of a corresponding ".weight" file and uses this for weighting the loss for each image . If the image is a regularization image, also multiplied by prior_loss_weight (default value is 1) like before.

The feature is enabled with the `--sample_weight`. 

The weight provided can be tailored by the user to reflect various criteria such as similarity (or dissimilarity), importance, aesthetic scores, etc. It is advised to keep these weights within reasonable range (for example, < 2.0) to keep training stability. I'm not sure what would happen if it were less than 0.

Originally, there was consideration for an automatic calculation and aggregation mechanism for different weights. However, I decided to leave such choise to advanced users which have specific needs.

This change allows for a approach to modifying loss weights in a minimalistic implementation.