### PR TITLE
Fixed a possible ZeroDivisionError

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4870,10 +4870,14 @@ def sample_images_common(
             return
         if args.sample_every_n_epochs is not None:
             # sample_every_n_steps は無視する
-            if epoch is None or epoch % args.sample_every_n_epochs != 0:
+            if (epoch is None
+                or args.sample_every_n_epochs <= 0
+                or epoch % args.sample_every_n_epochs != 0):
                 return
         else:
-            if steps % args.sample_every_n_steps != 0 or epoch is not None:  # steps is not divisible or end of epoch
+            if (args.sample_every_n_steps <= 0
+                or steps % args.sample_every_n_steps != 0
+                or epoch is not None):  # steps is not divisible or end of epoch
                 return
 
     logger.info("")


### PR DESCRIPTION
以下の 2 つのオプションに `0` が指定された場合、`ZeroDivisionError` が発生していたため、修正してみました。
- `--sample_every_n_steps`
- `--sample_every_n_epochs`

経緯としては、
- [Kohya's GUI](https://github.com/bmaltais/kohya_ss) にて、当該のオプションに `0` が指定された場合にも実行されてしまっていた。
- こちらのスクリプトでは、`0` が指定されても、値がチェックされずに剰余演算が行われて `ZeroDivisionError` が発生していた。
という 2 点です。

Kohya's GUI の方では該当部分は 2 日前に修正され、`0` が指定された場合はオプションとして実行されなくなっているようです。
`1` 以上の整数値が指定されることを想定したオプションだと思いましたので、`0` 以下の値が指定された場合は `return` するように条件を加えました。

オプションの役割上、このエラーが起きることは稀だとは思いますので、もし余計な修正であったら、お手数をお掛けしますがこのプルリクエストは破棄して頂けたらと思います。
このリクエストを読んでいただき、ありがとうございます。