### PR TITLE
register reg images with correct subset

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1554,7 +1554,7 @@ class DreamBoothDataset(BaseDataset):
             for img_path, caption in zip(img_paths, captions):
                 info = ImageInfo(img_path, subset.num_repeats, caption, subset.is_reg, img_path)
                 if subset.is_reg:
-                    reg_infos.append(info)
+                    reg_infos.append((info, subset))
                 else:
                     self.register_image(info, subset)
 
@@ -1575,7 +1575,7 @@ class DreamBoothDataset(BaseDataset):
             n = 0
             first_loop = True
             while n < num_train_images:
-                for info in reg_infos:
+                for info, subset in reg_infos:
                     if first_loop:
                         self.register_image(info, subset)
                         n += info.num_repeats


### PR DESCRIPTION
I have multiple reg subsets defined in a TOML config and noticed only the last one's settings were applied to all of them. This PR saves the subset together with the image info into `reg_infos` so reg images get registered with the correct subset.