### PR TITLE
Expose training parameters to wandb.ai

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -296,6 +296,9 @@ def train(args):
             init_kwargs["wandb"] = {"name": args.wandb_run_name}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+            init_kwargs["wandb"] = {"name": run_name, "config": args}
         accelerator.init_trackers("finetuning" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs)
 
     # For --sample_at_first

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -466,6 +466,9 @@ def train(args):
             init_kwargs["wandb"] = {"name": args.wandb_run_name}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+            init_kwargs["wandb"] = {"name": run_name, "config": args}
         accelerator.init_trackers("finetuning" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs)
 
     # For --sample_at_first

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -352,6 +352,9 @@ def train(args):
             init_kwargs["wandb"] = {"name": args.wandb_run_name}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+            init_kwargs["wandb"] = {"name": run_name, "config": args}
         accelerator.init_trackers(
             "lllite_control_net_train" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs
         )

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -323,6 +323,8 @@ def train(args):
         init_kwargs = {}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            init_kwargs["wandb"] = {"name": args.output_name, "config": args}
         accelerator.init_trackers(
             "lllite_control_net_train" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs
         )

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -225,7 +225,7 @@ def train(args):
             )
         vae.to("cpu")
         clean_memory_on_device(accelerator.device)
-        
+
         accelerator.wait_for_everyone()
 
     if args.gradient_checkpointing:
@@ -342,6 +342,9 @@ def train(args):
             init_kwargs["wandb"] = {"name": args.wandb_run_name}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+            init_kwargs["wandb"] = {"name": run_name, "config": args}
         accelerator.init_trackers(
             "controlnet_train" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs
         )

--- a/train_db.py
+++ b/train_db.py
@@ -272,6 +272,9 @@ def train(args):
             init_kwargs["wandb"] = {"name": args.wandb_run_name}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+            init_kwargs["wandb"] = {"name": run_name, "config": args}
         accelerator.init_trackers("dreambooth" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs)
 
     # For --sample_at_first

--- a/train_network.py
+++ b/train_network.py
@@ -702,6 +702,9 @@ class NetworkTrainer:
                 init_kwargs["wandb"] = {"name": args.wandb_run_name}
             if args.log_tracker_config is not None:
                 init_kwargs = toml.load(args.log_tracker_config)
+            else:
+                run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+                init_kwargs["wandb"] = {"name": run_name, "config": args}
             accelerator.init_trackers(
                 "network_train" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs
             )

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -506,6 +506,9 @@ class TextualInversionTrainer:
                 init_kwargs["wandb"] = {"name": args.wandb_run_name}
             if args.log_tracker_config is not None:
                 init_kwargs = toml.load(args.log_tracker_config)
+            else:
+                run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+                init_kwargs["wandb"] = {"name": run_name, "config": args}
             accelerator.init_trackers(
                 "textual_inversion" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs
             )

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -403,6 +403,9 @@ def train(args):
             init_kwargs["wandb"] = {"name": args.wandb_run_name}
         if args.log_tracker_config is not None:
             init_kwargs = toml.load(args.log_tracker_config)
+        else:
+            run_name = args.wandb_run_name if args.wandb_run_name else args.output_name
+            init_kwargs["wandb"] = {"name": run_name, "config": args}
         accelerator.init_trackers(
             "textual_inversion" if args.log_tracker_name is None else args.log_tracker_name, init_kwargs=init_kwargs
         )


### PR DESCRIPTION
This change sends the the training parameters as a payload to [wandb.ai](https://wandb.ai/) when that is used instead of TensorBoard.

They show up in the Runs table so it helps to get a better understanding of what the difference is between runs. It also uses the model's name as run name to give more context.

<img width="1156" alt="263689196-57506e88-1eda-477e-8b16-54adcb80f7e4" src="https://github.com/kohya-ss/sd-scripts/assets/6632271/c77976c5-8739-4a8b-b9fb-4bb3fdb6a38f">

---

This is a re-implementation of #792.