### PR TITLE
Add LoRA+ support

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2789,6 +2789,8 @@ def add_optimizer_arguments(parser: argparse.ArgumentParser):
         default=1,
         help="Polynomial power for polynomial scheduler / polynomialスケジューラでのpolynomial power",
     )
+    parser.add_argument("--loraplus_unet_lr_ratio", default=None, type=float, help="LoRA+ UNet learning rate ratio")
+    parser.add_argument("--loraplus_text_encoder_lr_ratio", default=None, type=float, help="LoRA+ text encoder learning rate ratio")
 
 
 def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: bool):

--- a/networks/dylora.py
+++ b/networks/dylora.py
@@ -406,27 +406,48 @@ class DyLoRANetwork(torch.nn.Module):
         logger.info(f"weights are merged")
     """
 
-    def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr):
+    # 二つのText Encoderに別々の学習率を設定できるようにするといいかも
+    def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr, unet_lora_plus_ratio=None, text_encoder_lora_plus_ratio=None):
         self.requires_grad_(True)
         all_params = []
 
-        def enumerate_params(loras):
-            params = []
+        def assemble_params(loras, lr, lora_plus_ratio):
+            param_groups = {"lora": {}, "plus": {}}
             for lora in loras:
-                params.extend(lora.parameters())
+                for name, param in lora.named_parameters():
+                    if lora_plus_ratio is not None and "lora_up" in name:
+                        param_groups["plus"][f"{lora.lora_name}.{name}"] = param
+                    else:
+                        param_groups["lora"][f"{lora.lora_name}.{name}"] = param
+
+            # assigned_param_groups = ""
+            # for group in param_groups:
+            #     assigned_param_groups += f"{group}\n {list(param_groups[group].keys())}\n\n"
+            # logger.info(assigned_param_groups)
+
+            params = []
+            for key in param_groups.keys():
+                param_data = {"params": param_groups[key].values()}
+                if lr is not None:
+                    if key == "plus":
+                        param_data["lr"] = lr * lora_plus_ratio
+                    else:
+                        param_data["lr"] = lr
+
+                if ("lr" in param_data) and (param_data["lr"] == 0):
+                    continue
+
+                params.append(param_data)
+
             return params
 
         if self.text_encoder_loras:
-            param_data = {"params": enumerate_params(self.text_encoder_loras)}
-            if text_encoder_lr is not None:
-                param_data["lr"] = text_encoder_lr
-            all_params.append(param_data)
+            params = assemble_params(self.text_encoder_loras, text_encoder_lr, text_encoder_lora_plus_ratio)
+            all_params.extend(params)
 
         if self.unet_loras:
-            param_data = {"params": enumerate_params(self.unet_loras)}
-            if unet_lr is not None:
-                param_data["lr"] = unet_lr
-            all_params.append(param_data)
+            params = assemble_params(self.unet_loras, unet_lr, unet_lora_plus_ratio)
+            all_params.extend(params)
 
         return all_params
 

--- a/networks/lora_fa.py
+++ b/networks/lora_fa.py
@@ -1033,22 +1033,43 @@ class LoRANetwork(torch.nn.Module):
         return lr_weight
 
     # 二つのText Encoderに別々の学習率を設定できるようにするといいかも
-    def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr):
+    def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr, , unet_lora_plus_ratio=None, text_encoder_lora_plus_ratio=None):
         self.requires_grad_(True)
         all_params = []
 
-        def enumerate_params(loras: List[LoRAModule]):
-            params = []
+        def assemble_params(loras: List[LoRAModule], lr, lora_plus_ratio):
+            param_groups = {"lora": {}, "plus": {}}
             for lora in loras:
-                # params.extend(lora.parameters())
-                params.extend(lora.get_trainable_params())
+                for name, param in lora.get_trainable_named_params():
+                    if lora_plus_ratio is not None and "lora_up" in name:
+                        param_groups["plus"][f"{lora.lora_name}.{name}"] = param
+                    else:
+                        param_groups["lora"][f"{lora.lora_name}.{name}"] = param
+
+            # assigned_param_groups = ""
+            # for group in param_groups:
+            #     assigned_param_groups += f"{group}\n {list(param_groups[group].keys())}\n\n"
+            # logger.info(assigned_param_groups)
+
+            params = []
+            for key in param_groups.keys():
+                param_data = {"params": param_groups[key].values()}
+                if lr is not None:
+                    if key == "plus":
+                        param_data["lr"] = lr * lora_plus_ratio
+                    else:
+                        param_data["lr"] = lr
+
+                if ("lr" in param_data) and (param_data["lr"] == 0):
+                    continue
+
+                params.append(param_data)
+
             return params
 
         if self.text_encoder_loras:
-            param_data = {"params": enumerate_params(self.text_encoder_loras)}
-            if text_encoder_lr is not None:
-                param_data["lr"] = text_encoder_lr
-            all_params.append(param_data)
+            params = assemble_params(self.text_encoder_loras, text_encoder_lr, text_encoder_lora_plus_ratio)
+            all_params.extend(params)
 
         if self.unet_loras:
             if self.block_lr:
@@ -1062,21 +1083,15 @@ class LoRANetwork(torch.nn.Module):
 
                 # blockごとにパラメータを設定する
                 for idx, block_loras in block_idx_to_lora.items():
-                    param_data = {"params": enumerate_params(block_loras)}
-
                     if unet_lr is not None:
-                        param_data["lr"] = unet_lr * self.get_lr_weight(block_loras[0])
+                        params = assemble_params(block_loras, unet_lr * self.get_lr_weight(block_loras[0]), unet_lora_plus_ratio)
                     elif default_lr is not None:
-                        param_data["lr"] = default_lr * self.get_lr_weight(block_loras[0])
-                    if ("lr" in param_data) and (param_data["lr"] == 0):
-                        continue
-                    all_params.append(param_data)
+                        params = assemble_params(block_loras, default_lr * self.get_lr_weight(block_loras[0]), unet_lora_plus_ratio)
+                    all_params.extend(params)
 
             else:
-                param_data = {"params": enumerate_params(self.unet_loras)}
-                if unet_lr is not None:
-                    param_data["lr"] = unet_lr
-                all_params.append(param_data)
+                params = assemble_params(self.unet_loras, unet_lr, unet_lora_plus_ratio)
+                all_params.extend(params)
 
         return all_params
 
@@ -1092,6 +1107,9 @@ class LoRANetwork(torch.nn.Module):
 
     def get_trainable_params(self):
         return self.parameters()
+
+    def get_trainable_named_params(self):
+        return self.named_parameters()
 
     def save_weights(self, file, dtype, metadata):
         if metadata is not None and len(metadata) == 0:

--- a/train_network.py
+++ b/train_network.py
@@ -339,7 +339,7 @@ class NetworkTrainer:
 
         # 後方互換性を確保するよ
         try:
-            trainable_params = network.prepare_optimizer_params(args.text_encoder_lr, args.unet_lr, args.learning_rate)
+            trainable_params = network.prepare_optimizer_params(args.text_encoder_lr, args.unet_lr, args.learning_rate, args.loraplus_text_encoder_lr_ratio, args.loraplus_unet_lr_ratio)
         except TypeError:
             accelerator.print(
                 "Deprecated: use prepare_optimizer_params(text_encoder_lr, unet_lr, learning_rate) instead of prepare_optimizer_params(text_encoder_lr, unet_lr)"


### PR DESCRIPTION
LoRA+ adds a hyperparameter to the optimizer for B or up in the LoRA to increase the ratio of that LR.
![Screenshot 2024-03-25 at 13-55-27 2402 12354 pdf](https://github.com/kohya-ss/sd-scripts/assets/15027/7d0e4bd6-88f0-4a05-906a-03dfdca8ed38)

![Screenshot 2024-03-25 at 16-20-08 2402 12354 pdf](https://github.com/kohya-ss/sd-scripts/assets/15027/01c0f7f5-335c-40fa-84de-95b8379143d9)

The hyperparameter should be adjusted depending on your dataset and  how difficult it is to train. They suggest starting at 2^4 or 16 ratio to start.

The Text Encoder and UNet are currently separate ratios as with recommended starting values as follows. 

`--loraplus_unet_lr_ratio=16`
`--loraplus_text_encoder_lr_ratio=16`

I am willing to change how the code is implemented, name of arguments and so on as necessary. 

https://arxiv.org/abs/2402.12354
https://github.com/nikhil-ghosh-berkeley/loraplus