### PR TITLE
Pad number in wandb sample name to allow alphabetical sorting

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -5325,7 +5325,7 @@ def sample_image_inference(
         except ImportError:  # 事前に一度確認するのでここはエラー出ないはず
             raise ImportError("No wandb / wandb がインストールされていないようです")
 
-        wandb_tracker.log({f"sample_{i}": wandb.Image(image)})
+        wandb_tracker.log({f"sample_{i:02}": wandb.Image(image)})
     except:  # wandb 無効時
         pass
 


### PR DESCRIPTION
Wandb sorts alphabetically without taking numbers into consideration.  Padding single digit numbers with a 0 allows them to be properly sorted.