### PR TITLE
Fix RGBA Image loading

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2348,6 +2348,9 @@ def load_arbitrary_dataset(args, tokenizer) -> MinimalDataset:
 def load_image(image_path):
     image = Image.open(image_path)
     if not image.mode == "RGB":
+        if image.mode == "RGBA":
+            bg = Image.new("RGBA", image.size, (255, 255, 255))
+            image = Image.alpha_composite(bg, image)
         image = image.convert("RGB")
     img = np.array(image, np.uint8)
     return img


### PR DESCRIPTION
Proposed fix for issue #1269 

Using `Image.convert("RGB")` results in broken backgrounds for some images, this PR changes the logic for RGBA images to use `Image.alpha_composite` with a new empty image instead. See issue above for details.

The color chosen for the alpha fill in this PR is pure white, which is different from what the old implementation defaulted to (pure black), since it seemed like a better fit for most images. This can be changed if required.