### PR TITLE
Catch model saving error

### DIFF
--- a/library/sdxl_model_util.py
+++ b/library/sdxl_model_util.py
@@ -469,6 +469,29 @@ def convert_text_encoder_2_state_dict_to_sdxl(checkpoint, logit_scale):
 
     return new_sd
 
+def save_converted_file(state_dict, output_file, metadata, epochs, steps, ckpt_info):
+    try:
+        if model_util.is_safetensors(output_file):
+            save_file(state_dict, output_file, metadata)
+        else:
+            new_ckpt = {"state_dict": state_dict}
+
+            new_ckpt["epoch"] = epochs
+            new_ckpt["global_step"] = steps
+
+            # epoch and global_step are sometimes not int
+            if ckpt_info is not None:
+                new_ckpt["epoch"] += ckpt_info[0]
+                new_ckpt["global_step"] += ckpt_info[1]
+
+            torch.save(new_ckpt, output_file)
+    except Exception as e:
+        print(e)
+        continue_prompt = input("Retry saving model? (y/n): ")
+        if continue_prompt.lower() != 'n':
+            save_converted_file(state_dict, output_file, metadata, epochs, steps, ckpt_info)
+        else:
+            raise
 
 def save_stable_diffusion_checkpoint(
     output_file,
@@ -507,20 +530,7 @@ def save_stable_diffusion_checkpoint(
 
     # Put together new checkpoint
     key_count = len(state_dict.keys())
-    new_ckpt = {"state_dict": state_dict}
-
-    # epoch and global_step are sometimes not int
-    if ckpt_info is not None:
-        epochs += ckpt_info[0]
-        steps += ckpt_info[1]
-
-    new_ckpt["epoch"] = epochs
-    new_ckpt["global_step"] = steps
-
-    if model_util.is_safetensors(output_file):
-        save_file(state_dict, output_file, metadata)
-    else:
-        torch.save(new_ckpt, output_file)
+    save_converted_file(state_dict, output_file, metadata, epochs, steps, ckpt_info)
 
     return key_count
 


### PR DESCRIPTION
If an error is thrown when trying to save a checkpoint, it will give the user the error and ask if they would like to save again.
This helps with cases where something goes wrong at the end of an hours-long training (like if you didn't have enough disk space)
The code was also rearranged so that the epochs and steps parameters do not get altered and new_ckpt is only created if it is used