### PR TITLE
Fix a bug with the always_first_tags argument in tag_images_by_wd14_t…

### DIFF
--- a/finetune/tag_images_by_wd14_tagger.py
+++ b/finetune/tag_images_by_wd14_tagger.py
@@ -290,7 +290,7 @@ def main(args):
                 for tag in always_first_tags:
                     if tag in combined_tags:
                         combined_tags.remove(tag)
-                        combined_tags.insert(0, tag)
+                    combined_tags.insert(0, tag)
 
             # 先頭のカンマを取る
             if len(general_tag_text) > 0:


### PR DESCRIPTION
The `--always_first_tags` argument for the tag_images_by_wd14_tagger.py script does not work. The bugfix is a 1 liner.