### PR TITLE
Use model_util.is_safetensors everywhere

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2849,7 +2849,7 @@ def load_metadata_from_safetensors(safetensors_file: str) -> dict:
     This method locks the file. see https://github.com/huggingface/safetensors/issues/164
     If the file isn't .safetensors or doesn't have metadata, return empty dict.
     """
-    if os.path.splitext(safetensors_file)[1] != ".safetensors":
+    if not model_util.is_safetensors(safetensors_file):
         return {}
 
     with safetensors.safe_open(safetensors_file, framework="pt", device="cpu") as f:

--- a/networks/check_lora_weights.py
+++ b/networks/check_lora_weights.py
@@ -3,13 +3,14 @@ import os
 import torch
 from safetensors.torch import load_file
 from library.utils import setup_logging
+from library import model_util
 setup_logging()
 import logging
 logger = logging.getLogger(__name__)
 
 def main(file):
     logger.info(f"loading: {file}")
-    if os.path.splitext(file)[1] == ".safetensors":
+    if model_util.is_safetensors(file):
         sd = load_file(file)
     else:
         sd = torch.load(file, map_location="cpu")

--- a/networks/control_net_lllite.py
+++ b/networks/control_net_lllite.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional, List, Type
 import torch
-from library import sdxl_original_unet
+from library import model_util, sdxl_original_unet
 from library.utils import setup_logging
 setup_logging()
 import logging
@@ -311,7 +311,7 @@ class ControlNetLLLite(torch.nn.Module):
             module.multiplier = multiplier
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             weights_sd = load_file(file)
@@ -363,7 +363,7 @@ class ControlNetLLLite(torch.nn.Module):
                 v = v.detach().clone().to("cpu").to(dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
 
             save_file(state_dict, file, metadata)

--- a/networks/control_net_lllite_for_train.py
+++ b/networks/control_net_lllite_for_train.py
@@ -5,7 +5,7 @@ import os
 import re
 from typing import Optional, List, Type
 import torch
-from library import sdxl_original_unet
+from library import sdxl_original_unet, model_util
 from library.utils import setup_logging
 
 setup_logging()
@@ -328,7 +328,7 @@ class SdxlUNet2DConditionModelControlNetLLLite(sdxl_original_unet.SdxlUNet2DCond
                 v = v.detach().clone().to("cpu").to(dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
 
             save_file(state_dict, file, metadata)
@@ -351,7 +351,7 @@ class SdxlUNet2DConditionModelControlNetLLLite(sdxl_original_unet.SdxlUNet2DCond
             info = self.load_state_dict(state_dict, False)
             return info
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             weights_sd = load_file(file)

--- a/networks/dylora.py
+++ b/networks/dylora.py
@@ -17,6 +17,7 @@ from diffusers import AutoencoderKL
 from transformers import CLIPTextModel
 import torch
 from torch import nn
+from library import model_util
 from library.utils import setup_logging
 
 setup_logging()
@@ -230,7 +231,7 @@ def create_network(
 # Create network from weights for inference, weights are not loaded here (because can be merged)
 def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weights_sd=None, for_inference=False, **kwargs):
     if weights_sd is None:
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file, safe_open
 
             weights_sd = load_file(file)
@@ -377,7 +378,7 @@ class DyLoRANetwork(torch.nn.Module):
             lora.multiplier = self.multiplier
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             weights_sd = load_file(file)
@@ -506,7 +507,7 @@ class DyLoRANetwork(torch.nn.Module):
                 v = v.detach().clone().to("cpu").to(dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
             from library import train_util
 

--- a/networks/extract_lora_from_models.py
+++ b/networks/extract_lora_from_models.py
@@ -26,7 +26,7 @@ def save_to_file(file_name, model, state_dict, dtype):
             if type(state_dict[key]) == torch.Tensor:
                 state_dict[key] = state_dict[key].to(dtype)
 
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         save_file(model, file_name)
     else:
         torch.save(model, file_name)

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -11,6 +11,7 @@ from transformers import CLIPTextModel
 import numpy as np
 import torch
 import re
+from library import model_util
 from library.utils import setup_logging
 from library.sdxl_original_unet import SdxlUNet2DConditionModel
 
@@ -807,7 +808,7 @@ def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weigh
     is_sdxl = unet is not None and issubclass(unet.__class__, SdxlUNet2DConditionModel)
 
     if weights_sd is None:
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file, safe_open
 
             weights_sd = load_file(file)
@@ -1062,7 +1063,7 @@ class LoRANetwork(torch.nn.Module):
             lora.enabled = is_enabled
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             weights_sd = load_file(file)
@@ -1257,7 +1258,7 @@ class LoRANetwork(torch.nn.Module):
                 v = v.detach().clone().to("cpu").to(dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
             from library import train_util
 

--- a/networks/lora_diffusers.py
+++ b/networks/lora_diffusers.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 from transformers import CLIPTextModel
 
 import torch
+from library import model_util
 from library.device_utils import init_ipex, get_preferred_device
 init_ipex()
 
@@ -511,7 +512,7 @@ if __name__ == "__main__":
 
     # load LoRA weights
     logger.info(f"load LoRA weights from {args.lora_weights}")
-    if os.path.splitext(args.lora_weights)[1] == ".safetensors":
+    if model_util.is_safetensors(args.lora_weights):
         from safetensors.torch import load_file
 
         lora_sd = load_file(args.lora_weights)

--- a/networks/lora_fa.py
+++ b/networks/lora_fa.py
@@ -14,6 +14,7 @@ from transformers import CLIPTextModel
 import numpy as np
 import torch
 import re
+from library import model_util
 from library.utils import setup_logging
 setup_logging()
 import logging
@@ -709,7 +710,7 @@ def get_block_index(lora_name: str) -> int:
 # Create network from weights for inference, weights are not loaded here (because can be merged)
 def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weights_sd=None, for_inference=False, **kwargs):
     if weights_sd is None:
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file, safe_open
 
             weights_sd = load_file(file)
@@ -945,7 +946,7 @@ class LoRANetwork(torch.nn.Module):
             lora.multiplier = self.multiplier
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             weights_sd = load_file(file)
@@ -1105,7 +1106,7 @@ class LoRANetwork(torch.nn.Module):
                 v = v.detach().clone().to("cpu").to(dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
             from library import train_util
 

--- a/networks/merge_lora.py
+++ b/networks/merge_lora.py
@@ -13,7 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 def load_state_dict(file_name, dtype):
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         sd = load_file(file_name)
         metadata = train_util.load_metadata_from_safetensors(file_name)
     else:
@@ -33,7 +33,7 @@ def save_to_file(file_name, model, state_dict, dtype, metadata):
             if type(state_dict[key]) == torch.Tensor:
                 state_dict[key] = state_dict[key].to(dtype)
 
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         save_file(model, file_name, metadata=metadata)
     else:
         torch.save(model, file_name)

--- a/networks/merge_lora_old.py
+++ b/networks/merge_lora_old.py
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 def load_state_dict(file_name, dtype):
-  if os.path.splitext(file_name)[1] == '.safetensors':
+  if model_util.is_safetensors(file_name):
     sd = load_file(file_name)
   else:
     sd = torch.load(file_name, map_location='cpu')
@@ -28,7 +28,7 @@ def save_to_file(file_name, model, state_dict, dtype):
       if type(state_dict[key]) == torch.Tensor:
         state_dict[key] = state_dict[key].to(dtype)
 
-  if os.path.splitext(file_name)[1] == '.safetensors':
+  if model_util.is_safetensors(file_name):
     save_file(model, file_name)
   else:
     torch.save(model, file_name)

--- a/networks/oft.py
+++ b/networks/oft.py
@@ -8,6 +8,7 @@ from transformers import CLIPTextModel
 import numpy as np
 import torch
 import re
+from library import model_util
 from library.utils import setup_logging
 setup_logging()
 import logging
@@ -171,7 +172,7 @@ def create_network(
 # Create network from weights for inference, weights are not loaded here (because can be merged)
 def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weights_sd=None, for_inference=False, **kwargs):
     if weights_sd is None:
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file, safe_open
 
             weights_sd = load_file(file)
@@ -296,7 +297,7 @@ class OFTNetwork(torch.nn.Module):
             oft.multiplier = self.multiplier
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             weights_sd = load_file(file)
@@ -380,7 +381,7 @@ class OFTNetwork(torch.nn.Module):
                 v = v.detach().clone().to("cpu").to(dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
             from library import train_util
 

--- a/networks/sdxl_merge_lora.py
+++ b/networks/sdxl_merge_lora.py
@@ -14,7 +14,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 def load_state_dict(file_name, dtype):
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         sd = load_file(file_name)
         metadata = train_util.load_metadata_from_safetensors(file_name)
     else:
@@ -34,7 +34,7 @@ def save_to_file(file_name, model, state_dict, dtype, metadata):
             if type(state_dict[key]) == torch.Tensor:
                 state_dict[key] = state_dict[key].to(dtype)
 
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         save_file(model, file_name, metadata=metadata)
     else:
         torch.save(model, file_name)

--- a/networks/svd_merge_lora.py
+++ b/networks/svd_merge_lora.py
@@ -16,7 +16,7 @@ CLAMP_QUANTILE = 0.99
 
 
 def load_state_dict(file_name, dtype):
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         sd = load_file(file_name)
         metadata = train_util.load_metadata_from_safetensors(file_name)
     else:
@@ -36,7 +36,7 @@ def save_to_file(file_name, state_dict, dtype, metadata):
             if type(state_dict[key]) == torch.Tensor:
                 state_dict[key] = state_dict[key].to(dtype)
 
-    if os.path.splitext(file_name)[1] == ".safetensors":
+    if model_util.is_safetensors(file_name):
         save_file(state_dict, file_name, metadata=metadata)
     else:
         torch.save(state_dict, file_name)

--- a/sdxl_train_textual_inversion.py
+++ b/sdxl_train_textual_inversion.py
@@ -7,7 +7,7 @@ import torch
 from library.device_utils import init_ipex
 init_ipex()
 
-from library import sdxl_model_util, sdxl_train_util, train_util
+from library import model_util, sdxl_model_util, sdxl_train_util, train_util
 
 import train_textual_inversion
 
@@ -95,7 +95,7 @@ class SdxlTextualInversionTrainer(train_textual_inversion.TextualInversionTraine
                 v = v.detach().clone().to("cpu").to(save_dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
 
             save_file(state_dict, file, metadata)
@@ -103,7 +103,7 @@ class SdxlTextualInversionTrainer(train_textual_inversion.TextualInversionTraine
             torch.save(state_dict, file)
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             data = load_file(file)

--- a/tools/latent_upscaler.py
+++ b/tools/latent_upscaler.py
@@ -12,6 +12,7 @@ import numpy as np
 
 import torch
 from library.device_utils import init_ipex, get_preferred_device
+from library import model_util
 init_ipex()
 
 from torch import nn
@@ -249,7 +250,7 @@ def create_upscaler(**kwargs):
     model = Upscaler()
 
     logger.info(f"Loading weights from {weights}...")
-    if os.path.splitext(weights)[1] == ".safetensors":
+    if model_util.is_safetensors(weights):
         from safetensors.torch import load_file
 
         sd = load_file(weights)

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -222,7 +222,7 @@ def train(args):
     if args.controlnet_model_name_or_path:
         filename = args.controlnet_model_name_or_path
         if os.path.isfile(filename):
-            if os.path.splitext(filename)[1] == ".safetensors":
+            if model_util.is_safetensors(filename):
                 state_dict = load_file(filename)
             else:
                 state_dict = torch.load(filename)
@@ -389,7 +389,7 @@ def train(args):
                 v = v.detach().clone().to("cpu").to(save_dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(ckpt_file)[1] == ".safetensors":
+        if model_util.is_safetensors(ckpt_file):
             from safetensors.torch import save_file
 
             save_file(state_dict, ckpt_file)

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -136,7 +136,7 @@ class TextualInversionTrainer:
                 v = v.detach().clone().to("cpu").to(save_dtype)
                 state_dict[key] = v
 
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import save_file
 
             save_file(state_dict, file, metadata)
@@ -144,7 +144,7 @@ class TextualInversionTrainer:
             torch.save(state_dict, file)  # can be loaded in Web UI
 
     def load_weights(self, file):
-        if os.path.splitext(file)[1] == ".safetensors":
+        if model_util.is_safetensors(file):
             from safetensors.torch import load_file
 
             data = load_file(file)

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -8,7 +8,7 @@ from multiprocessing import Value
 from tqdm import tqdm
 
 import torch
-from library import deepspeed_utils
+from library import deepspeed_utils, model_util
 from library.device_utils import init_ipex, clean_memory_on_device
 
 init_ipex()
@@ -636,7 +636,7 @@ def save_weights(file, updated_embs, save_dtype):
     #         v = v.detach().clone().to("cpu").to(save_dtype)
     #         state_dict[key] = v
 
-    if os.path.splitext(file)[1] == ".safetensors":
+    if model_util.is_safetensors(file):
         from safetensors.torch import save_file
 
         save_file(state_dict, file)
@@ -645,7 +645,7 @@ def save_weights(file, updated_embs, save_dtype):
 
 
 def load_weights(file):
-    if os.path.splitext(file)[1] == ".safetensors":
+    if model_util.is_safetensors(file):
         from safetensors.torch import load_file
 
         data = load_file(file)


### PR DESCRIPTION
Instead of having a copy of the same code everywhere, use the same model_util function across the project

Function in question: https://github.com/kohya-ss/sd-scripts/blob/56bb81c9e6483b8b4d5b83639548855b8359f4b4/library/model_util.py#L963

In preparation for consolidating the model saving code so that this PR can be applied across all model types without copying the code to every one of them individually: https://github.com/kohya-ss/sd-scripts/pull/1279