### PR TITLE
add Optimi(more fused_background_optimizer and new function)

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4017,7 +4017,7 @@ def get_optimizer(args, trainable_params):
 
     if args.fused_backward_pass:
         assert (
-            optimizer_type == "Adafactor".lower()
+            optimizer_type in ["Adafactor".lower(),"lion", "adan", "adamw","ranger","stableadamw"]
         ), "fused_backward_pass currently only works with optimizer_type Adafactor / fused_backward_passは現在optimizer_type Adafactorでのみ機能します"
         assert (
             args.gradient_accumulation_steps == 1
@@ -4052,6 +4052,8 @@ def get_optimizer(args, trainable_params):
             import optimi
             logger.info(f"use optimi Lion optimizer | {optimizer_kwargs}")
             optimizer_class = optimi.Lion
+            if args.fused_backward_pass and "gradient_release" not in optimizer_kwargs:
+                optimizer_kwargs["gradient_release"] = True
         except:
             try:
                 import lion_pytorch
@@ -4157,6 +4159,8 @@ def get_optimizer(args, trainable_params):
             import optimi
         except ImportError:
             raise ImportError("No optimi / optimi がインストールされていないようです")
+        if args.fused_backward_pass and "gradient_release" not in optimizer_kwargs:
+            optimizer_kwargs["gradient_release"] = True
         optimizer_class = optimi.Adan
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
@@ -4168,6 +4172,8 @@ def get_optimizer(args, trainable_params):
             import optimi
         except ImportError:
             raise ImportError("No optimi / optimi がインストールされていないようです")
+        if args.fused_backward_pass and "gradient_release" not in optimizer_kwargs:
+            optimizer_kwargs["gradient_release"] = True
         optimizer_class = optimi.Ranger
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
@@ -4307,6 +4313,8 @@ def get_optimizer(args, trainable_params):
             import optimi
             optimizer_class = optimi.AdamW
             logger.info(f"use optimi AdamW optimizer | {optimizer_kwargs}")
+            if args.fused_backward_pass and "gradient_release" not in optimizer_kwargs:
+                optimizer_kwargs["gradient_release"] = True
         except:
             optimizer_class = torch.optim.AdamW
             logger.info(f"use AdamW optimizer | {optimizer_kwargs}")

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3041,6 +3041,12 @@ def add_optimizer_arguments(parser: argparse.ArgumentParser):
         help="Combines backward pass and optimizer step to reduce VRAM usage. Only available in SDXL"
         + " / バックワードパスとオプティマイザステップを組み合わせてVRAMの使用量を削減します。SDXLでのみ有効",
     )
+    parser.add_argument(
+        "--optimizer_accumulation_steps",
+        type=int,
+        default=0,
+        help="Number of updates steps to accumulate before performing a backward/update pass / 学習時に逆伝播をする前に勾配を合計するステップ数",
+    )
 
 
 def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: bool):
@@ -4043,11 +4049,16 @@ def get_optimizer(args, trainable_params):
 
     if optimizer_type == "Lion".lower():
         try:
-            import lion_pytorch
-        except ImportError:
-            raise ImportError("No lion_pytorch / lion_pytorch がインストールされていないようです")
-        logger.info(f"use Lion optimizer | {optimizer_kwargs}")
-        optimizer_class = lion_pytorch.Lion
+            import optimi
+            logger.info(f"use optimi Lion optimizer | {optimizer_kwargs}")
+            optimizer_class = optimi.Lion
+        except:
+            try:
+                import lion_pytorch
+                logger.info(f"use Lion optimizer | {optimizer_kwargs}")
+                optimizer_class = lion_pytorch.Lion
+            except ImportError:
+                raise ImportError("No lion_pytorch / lion_pytorch がインストールされていないようです")
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     elif optimizer_type.endswith("8bit".lower()):
@@ -4137,6 +4148,28 @@ def get_optimizer(args, trainable_params):
 
         optimizer_class = torch.optim.SGD
         optimizer = optimizer_class(trainable_params, lr=lr, nesterov=True, **optimizer_kwargs)
+
+    elif optimizer_type == "Adan".lower():
+        logger.info(f"use Adan optimizer | {optimizer_kwargs}")
+        # optimi
+        # check optimi is installed
+        try:
+            import optimi
+        except ImportError:
+            raise ImportError("No optimi / optimi がインストールされていないようです")
+        optimizer_class = optimi.Adan
+        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+
+    elif optimizer_type == "Ranger".lower():
+        logger.info(f"use RAdam optimizer | {optimizer_kwargs}")
+        # optimi
+        # check optimi is installed
+        try:
+            import optimi
+        except ImportError:
+            raise ImportError("No optimi / optimi がインストールされていないようです")
+        optimizer_class = optimi.Ranger
+        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     elif optimizer_type.startswith("DAdapt".lower()) or optimizer_type == "Prodigy".lower():
         # check lr and lr_count, and logger.info warning
@@ -4254,9 +4287,29 @@ def get_optimizer(args, trainable_params):
         optimizer_class = transformers.optimization.Adafactor
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
+    elif optimizer_type == "StableAdamW".lower():
+        logger.info(f"use StableAdamW optimizer | {optimizer_kwargs}")
+        # optimi
+        # check optimi is installed
+        try:
+            import optimi
+        except ImportError:
+            raise ImportError("No optimi / optimi がインストールされていないようです")
+        if args.fused_backward_pass and "gradient_release" not in optimizer_kwargs:
+            optimizer_kwargs["gradient_release"] = True
+        optimizer_class = optimi.StableAdamW
+        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+
     elif optimizer_type == "AdamW".lower():
-        logger.info(f"use AdamW optimizer | {optimizer_kwargs}")
-        optimizer_class = torch.optim.AdamW
+        # optimi
+        # check optimi is installed
+        try:
+            import optimi
+            optimizer_class = optimi.AdamW
+            logger.info(f"use optimi AdamW optimizer | {optimizer_kwargs}")
+        except:
+            optimizer_class = torch.optim.AdamW
+            logger.info(f"use AdamW optimizer | {optimizer_kwargs}")
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     if optimizer is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytorch-lightning==1.9.0
 bitsandbytes==0.43.0
 prodigyopt==1.0
 lion-pytorch==0.0.6
-optimi==0.2.1
+torch-optimi==0.2.1
 tensorboard
 safetensors==0.4.2
 # gradio==3.16.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytorch-lightning==1.9.0
 bitsandbytes==0.43.0
 prodigyopt==1.0
 lion-pytorch==0.0.6
+optimi==0.2.1
 tensorboard
 safetensors==0.4.2
 # gradio==3.16.2


### PR DESCRIPTION
https://optimi.benjaminwarner.dev/

New optimizer:
adamw、lion、ranger and stableadamw from Optimi

New function:
Low Precision Training with Kahan Summation(auto use when use above optimizers)
![image](https://github.com/kohya-ss/sd-scripts/assets/8085926/44bd66eb-bcad-45f9-b985-060cd36916d6)

Gradient Release(same as fused background pass)
Auto use when use above optimizers.

Fully Decoupled Weight Decay(looks like decoupled lr)

Optimizer Accumulation
[Gradient accumulation](https://pytorch.org/docs/stable/notes/amp_examples.html#gradient-accumulation) reduces training memory by splitting a batch into micro-batches and accumulating micro-batch gradients into the larger batch. [Gradient release](https://optimi.benjaminwarner.dev/gradient_release/) reduces training memory by limiting gradients to one layer at any given time. Optimizer accumulation unifies these two disparate approaches by accumulating gradients directly into optimizer states while performing gradient release.

