### PR TITLE
Add New lr scheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 accelerate==0.25.0
-transformers==4.36.2
+transformers==4.41.2
 diffusers[torch]==0.25.0
 ftfy==6.1.1
 # albumentations==1.3.0


### PR DESCRIPTION
Change Lr schedulers library from diffusers to transformers, they use same library but transformers had more lr schedulers.
Considering the community has always wanted custom learning rate, I think these newly added regulators will meet the demand.

[Add inverse sqrt learning rate scheduler](https://github.com/huggingface/transformers/pull/21495)
![image](https://github.com/kohya-ss/sd-scripts/assets/8085926/5b06ea35-2c65-46f1-adf1-a936cabf7ac3)
new argument lr_scheduler_timescale,default to warms_up_steps

[Add cosine with min lr scheduler](https://github.com/huggingface/transformers/pull/29341)
When set the num_steps=100, num_warmup_steps=10, lr=0.2, min_lr=0.01. The learning rate looks like:
![image](https://github.com/kohya-ss/sd-scripts/assets/8085926/1af708b6-4cab-400c-81ea-ba2d45dc1bc3)

new argument lr_scheduler_min_lr_ratio,default to 0 as cosine lr scheduler.

[Add WSD scheduler](https://github.com/huggingface/transformers/pull/30231)
The ladder scheduler that so many people have been wanting.
![image](https://github.com/kohya-ss/sd-scripts/assets/8085926/09fe19e8-c69a-4f3c-b235-177b7645a692)

new argument lr_decay_steps,
new argument lr_scheduler_min_lr_ratio,default to 0.

need update requirement transformers==4.41.2