### PR TITLE
Add VRAM free after sample images

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -1028,6 +1028,8 @@ class NetworkTrainer:
 
                     self.sample_images(accelerator, args, None, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
+                    clean_memory_on_device(accelerator.device)
+
                     # 指定ステップごとにモデルを保存
                     if args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0:
                         accelerator.wait_for_everyone()
@@ -1083,6 +1085,8 @@ class NetworkTrainer:
                         train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
             self.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
+
+            clean_memory_on_device(accelerator.device)
 
             # end of epoch
 


### PR DESCRIPTION
This PR addresses an issue with VRAM usage after generating sample images.

Without using this PR, when training with SDXL and batch size > 1, the first time during training when sample images are generated, I would run out of VRAM even with 24GB (no --xformers or --mem_eff_attn).

Notably, the `sample_images_common` method in train_util calls `clean_memory_on_device` near the end of the function, but I hypothesize that some of the memory is still used after the operation at the end. So calling it again after exiting the function clears the remaining.

I'm not sure if anyone else has had this issue or if it's an issue with my configuration only. Please feel free to close this PR if it's unnecessary. Thank you for your consideration.