### PR TITLE
Sd3 freeze x_block

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3061,6 +3061,12 @@ def add_sd_models_arguments(parser: argparse.ArgumentParser):
         default=None,
         help="directory for caching Tokenizer (for offline training) / Tokenizerをキャッシュするディレクトリ（ネット接続なしでの学習のため）",
     )
+    parser.add_argument(
+        "--num_last_layers_to_freeze",
+        type=int,
+        default=None,
+        help="num_last_layers_to_freeze",
+    )
 
 
 def add_optimizer_arguments(parser: argparse.ArgumentParser):
@@ -5597,6 +5603,20 @@ def sample_image_inference(
     except:  # wandb 無効時
         pass
 
+
+def freeze_blocks_lr(model, num_last_layers_to_freeze, base_lr, block_name="x_block"):
+    bottom_layers = list(model.children())[-num_last_layers_to_freeze:]
+
+    params_to_optimize = []
+
+    for layer in reversed(bottom_layers):
+        for name, param in layer.named_parameters():
+            if block_name in name:
+                params_to_optimize.append({"params": [param], "lr": 0.0})
+            else:
+                params_to_optimize.append({"params": [param], "lr": base_lr})
+
+    return params_to_optimize
 
 # endregion
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -5605,14 +5605,14 @@ def sample_image_inference(
 
 
 def freeze_blocks_lr(model, num_last_layers_to_freeze, base_lr, block_name="x_block"):
-    bottom_layers = list(model.children())[-num_last_layers_to_freeze:]
-
     params_to_optimize = []
+    frozen_params_count = 0
 
-    for layer in reversed(bottom_layers):
-        for name, param in layer.named_parameters():
-            if block_name in name:
+    for module in reversed(model.children()):
+        for name, param in module.named_parameters():
+            if block_name in name and frozen_params_count < num_last_layers_to_freeze:
                 params_to_optimize.append({"params": [param], "lr": 0.0})
+                frozen_params_count += 1
             else:
                 params_to_optimize.append({"params": [param], "lr": base_lr})
 

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -60,7 +60,6 @@ def train(args):
     assert (
         not args.weighted_captions
     ), "weighted_captions is not supported currently / weighted_captionsは現在サポートされていません"
-
     # assert (
     #     not args.train_text_encoder or not args.cache_text_encoder_outputs
     # ), "cache_text_encoder_outputs is not supported when training text encoder / text encoderを学習するときはcache_text_encoder_outputsはサポートされていません"
@@ -283,7 +282,8 @@ def train(args):
     # if train_unet:
     training_models.append(mmdit)
     # if block_lrs is None:
-    params_to_optimize.append({"params": list(mmdit.parameters()), "lr": args.learning_rate})
+    params_to_optimize = train_util.freeze_blocks_lr(mmdit, args.num_last_layers_to_freeze,args.args.learning_rate)
+    # params_to_optimize.append({"params": list(mmdit.parameters()), "lr": args.learning_rate})
     # else:
     #     params_to_optimize.extend(get_block_params_to_optimize(mmdit, block_lrs))
 

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -277,13 +277,15 @@ def train(args):
     if not train_mmdit:
         mmdit.to(accelerator.device, dtype=weight_dtype)  # because of unet is not prepared
 
+    if args.num_last_block_to_freeze:
+        train_util.freeze_blocks(mmdit,num_last_block_to_freeze=args.num_last_block_to_freeze)
+
     training_models = []
     params_to_optimize = []
     # if train_unet:
     training_models.append(mmdit)
     # if block_lrs is None:
-    params_to_optimize = train_util.freeze_blocks_lr(mmdit, args.num_last_layers_to_freeze,args.args.learning_rate)
-    # params_to_optimize.append({"params": list(mmdit.parameters()), "lr": args.learning_rate})
+    params_to_optimize.append({"params": list(filter(lambda p: p.requires_grad, mmdit.parameters())), "lr": args.learning_rate})
     # else:
     #     params_to_optimize.extend(get_block_params_to_optimize(mmdit, block_lrs))
 

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -60,9 +60,6 @@ def train(args):
     assert (
         not args.weighted_captions
     ), "weighted_captions is not supported currently / weighted_captionsは現在サポートされていません"
-    assert (
-        not args.train_text_encoder or not args.cache_text_encoder_outputs
-    ), "cache_text_encoder_outputs is not supported when training text encoder / text encoderを学習するときはcache_text_encoder_outputsはサポートされていません"
 
     # if args.block_lr:
     #     block_lrs = [float(lr) for lr in args.block_lr.split(",")]


### PR DESCRIPTION
use
`--num_last_block_to_freeze`
to set freeze blocks num,reverse freeze.
(default none,you can set 0~240)

SD3 has 240 x_blocks, i test if freeze half of it will get better effect.

Comparison：
Before↓
![image](https://github.com/kohya-ss/sd-scripts/assets/8085926/0a2e3f91-2602-40c9-89d9-994a05b40e57)

After freeze 120↓
![image](https://github.com/kohya-ss/sd-scripts/assets/8085926/7688d6d1-82f9-4ee4-ac98-58ffd1d43c0f)
