### PR TITLE
make guidance_scale keep float in args

### DIFF
--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -324,7 +324,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         img_ids = flux_utils.prepare_img_ids(bsz, packed_latent_height, packed_latent_width).to(device=accelerator.device)
 
         # get guidance
-        guidance_vec = torch.full((bsz,), args.guidance_scale, device=accelerator.device)
+        # ensure guidance_scale in args is float
+        guidance_vec = torch.full((bsz,), float(args.guidance_scale), device=accelerator.device)
 
         # ensure the hidden state will require grad
         if args.gradient_checkpointing:


### PR DESCRIPTION
The `read_config_from_file` function [train_util.py#L3760](https://github.com/kohya-ss/sd-scripts/blob/main/library/train_util.py#L3760) cannot guarantee that the variable types of the parameters in the toml file meet the requirements of argparser. 

When we specify `guidance_scale=1` instead of `1.0` in the toml file, `args.guidance_scale` incorrectly becomes an int type. 

Moreover, since `guidance_vec.requires_grad_(True)`, it is necessary to ensure that `guidance_vec = torch.full((bsz,), float(args.guidance_scale), device=accelerator.device)`. 
The related error is: RuntimeError: only Tensors of floating point dtype can require gradients.