### PR TITLE
Update train_util.py, bug fix

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1489,7 +1489,7 @@ class DreamBoothDataset(BaseDataset):
         def load_dreambooth_dir(subset: DreamBoothSubset):
             if not os.path.isdir(subset.image_dir):
                 logger.warning(f"not directory: {subset.image_dir}")
-                return [], []
+                return [], [], []
 
             info_cache_file = os.path.join(subset.image_dir, self.IMAGE_INFO_CACHE_FILE)
             use_cached_info_for_subset = subset.cache_info


### PR DESCRIPTION
Error message:

```
2024-08-30 08:10:37 INFO     Loading dataset config from dataset.toml                                          train_network.py:270
                    INFO     prepare images.                                                                     train_util.py:1803
                    WARNING  not directory: nandodataset                                                         train_util.py:1710
Traceback (most recent call last):
  File "/scratch2/metzgern/misc/kohya_ss/sd-scripts/flux_train_network.py", line 446, in <module>
    trainer.train(args)
  File "/scratch2/metzgern/misc/kohya_ss/sd-scripts/train_network.py", line 307, in train
    train_dataset_group = config_util.generate_dataset_group_by_blueprint(blueprint.dataset_group)
  File "/scratch2/metzgern/misc/kohya_ss/sd-scripts/library/config_util.py", line 485, in generate_dataset_group_by_blueprint
    dataset = dataset_klass(subsets=subsets, **asdict(dataset_blueprint.params))
  File "/scratch2/metzgern/misc/kohya_ss/sd-scripts/library/train_util.py", line 1820, in __init__
    img_paths, captions, sizes = load_dreambooth_dir(subset)
ValueError: not enough values to unpack (expected 3, got 2)
Traceback (most recent call last):
  File "/scratch2/metzgern/misc/kohya_ss/venv/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/scratch2/metzgern/misc/kohya_ss/venv/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 48, in main
    args.func(args)
  File "/scratch2/metzgern/misc/kohya_ss/venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 1106, in launch_command
    simple_launcher(args)
  File "/scratch2/metzgern/misc/kohya_ss/venv/lib/python3.10/site-packages/accelerate/commands/launch.py", line 704, in simple_launcher
```

this can be solved by replacing

```
return [], [],
```

with

```
return [], [], []
```

in the ```load_dreambooth_dir``` function.