### PR TITLE
Critical typo fix

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3355,15 +3355,14 @@ def add_optimizer_arguments(parser: argparse.ArgumentParser):
         type=int,
         default=None,
         help="Inverse sqrt timescale for inverse sqrt scheduler,defaults to `num_warmup_steps`"
-        " / 逆平方根スケジューラのタイムスケール、デフォルトは`num_warmup_steps`",
-        ,
+        + " / 逆平方根スケジューラのタイムスケール、デフォルトは`num_warmup_steps`",
     )
     parser.add_argument(
         "--lr_scheduler_min_lr_ratio",
         type=float,
         default=None,
         help="The minimum learning rate as a ratio of the initial learning rate for cosine with min lr scheduler and warmup decay scheduler"
-        " / 初期学習率の比率としての最小学習率を指定する、cosine with min lr と warmup decay スケジューラ で有効",
+        + " / 初期学習率の比率としての最小学習率を指定する、cosine with min lr と warmup decay スケジューラ で有効",
     )
 
 


### PR DESCRIPTION
The latest update is broken because of these typos:

```
INFO] Traceback (most recent call last):
[2024-09-11 05:58:19] [INFO] File "C:\pinokio\api\fluxgym.git\sd-scripts\flux_train_network.py", line 13, in <module>
[2024-09-11 05:58:19] [INFO] from library import flux_models, flux_train_utils, flux_utils, sd3_train_utils, strategy_base, strategy_flux, train_util
[2024-09-11 05:58:19] [INFO] File "C:\pinokio\api\fluxgym.git\sd-scripts\library\flux_train_utils.py", line 17, in <module>
[2024-09-11 05:58:19] [INFO] from library import flux_models, flux_utils, strategy_base, train_util
[2024-09-11 05:58:19] [INFO] File "C:\pinokio\api\fluxgym.git\sd-scripts\library\train_util.py", line 3359
[2024-09-11 05:58:19] [INFO] ,
[2024-09-11 05:58:20] [INFO] ^
[2024-09-11 05:58:20] [INFO] SyntaxError: invalid syntax
```