### PR TITLE
New ScheduleFree support for Flux

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -255,7 +255,7 @@ def train(args):
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet, text_encoder=text_encoder)
         else:
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet)
-        if args.optimizer_type.lower().endswith("scheduleFree"):
+        if args.optimizer_type.lower().endswith("schedulefree"):
             ds_model, optimizer, train_dataloader = accelerator.prepare(
                 ds_model, optimizer, train_dataloader
             )
@@ -267,7 +267,7 @@ def train(args):
     else:
         # acceleratorがなんかよろしくやってくれるらしい
         if args.train_text_encoder:
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 unet, text_encoder, optimizer, train_dataloader  = accelerator.prepare(
                     unet, text_encoder, optimizer, train_dataloader
                 )
@@ -276,7 +276,7 @@ def train(args):
                     unet, text_encoder, optimizer, train_dataloader, lr_scheduler
                 )
         else:
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
             else:
                 unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
@@ -405,7 +405,7 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                if not args.optimizer_type.lower().endswith("schedulefree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -335,10 +335,10 @@ def train(args):
 
         for m in training_models:
             m.train()
-            if (args.optimizer_type.lower().endswith("schedulefree")):
-                optimizer.train()
 
         for step, batch in enumerate(train_dataloader):
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(*training_models):
                 with torch.no_grad():
@@ -408,6 +408,9 @@ def train(args):
                 if not args.optimizer_type.lower().endswith("scheduleFree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -272,7 +272,7 @@ def train(args):
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet, text_encoder=text_encoder)
         else:
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet)
-        if args.optimizer_type.lower().endswith("schedulefree"):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             ds_model, optimizer, train_dataloader = accelerator.prepare(
                 ds_model, optimizer, train_dataloader
             )
@@ -284,7 +284,7 @@ def train(args):
     else:
         # acceleratorがなんかよろしくやってくれるらしい
         if args.train_text_encoder:
-            if args.optimizer_type.lower().endswith("schedulefree"):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 unet, text_encoder, optimizer, train_dataloader  = accelerator.prepare(
                     unet, text_encoder, optimizer, train_dataloader
                 )
@@ -293,7 +293,7 @@ def train(args):
                     unet, text_encoder, optimizer, train_dataloader, lr_scheduler
                 )
         else:
-            if args.optimizer_type.lower().endswith("schedulefree"):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
             else:
                 unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
@@ -363,7 +363,7 @@ def train(args):
             m.train()
 
         for step, batch in enumerate(train_dataloader):
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(*training_models):
@@ -440,11 +440,11 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("schedulefree"):
+                if not (args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -255,18 +255,31 @@ def train(args):
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet, text_encoder=text_encoder)
         else:
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet)
-        ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-            ds_model, optimizer, train_dataloader, lr_scheduler
-        )
+        if args.optimizer_type.lower().endswith("scheduleFree"):
+            ds_model, optimizer, train_dataloader = accelerator.prepare(
+                ds_model, optimizer, train_dataloader
+            )
+        else:
+            ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                ds_model, optimizer, train_dataloader, lr_scheduler
+            )
         training_models = [ds_model]
     else:
         # acceleratorがなんかよろしくやってくれるらしい
         if args.train_text_encoder:
-            unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                unet, text_encoder, optimizer, train_dataloader, lr_scheduler
-            )
+            if args.optimizer_type.lower().endswith("scheduleFree"):
+                unet, text_encoder, optimizer, train_dataloader  = accelerator.prepare(
+                    unet, text_encoder, optimizer, train_dataloader
+                )
+            else:
+                unet, text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                    unet, text_encoder, optimizer, train_dataloader, lr_scheduler
+                )
         else:
-            unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
+            if args.optimizer_type.lower().endswith("scheduleFree"):
+                unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
+            else:
+                unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 
     # 実験的機能：勾配も含めたfp16学習を行う　PyTorchにパッチを当ててfp16でのgrad scaleを有効にする
     if args.full_fp16:

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -322,6 +322,8 @@ def train(args):
 
         for m in training_models:
             m.train()
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
 
         for step, batch in enumerate(train_dataloader):
             current_step.value = global_step
@@ -390,7 +392,8 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                lr_scheduler.step()
+                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/flux_train.py
+++ b/flux_train.py
@@ -416,9 +416,14 @@ def train(args):
     if args.deepspeed:
         ds_model = deepspeed_utils.prepare_deepspeed_model(args, mmdit=flux)
         # most of ZeRO stage uses optimizer partitioning, so we have to prepare optimizer and ds_model at the same time. # pull/1139#issuecomment-1986790007
-        ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-            ds_model, optimizer, train_dataloader, lr_scheduler
-        )
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
+            ds_model, optimizer, train_dataloader = accelerator.prepare(
+                ds_model, optimizer, train_dataloader
+            )
+        else:
+            ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                ds_model, optimizer, train_dataloader, lr_scheduler
+            )
         training_models = [ds_model]
 
     else:
@@ -427,7 +432,10 @@ def train(args):
         flux = accelerator.prepare(flux, device_placement=[not is_swapping_blocks])
         if is_swapping_blocks:
             accelerator.unwrap_model(flux).move_to_device_except_swap_blocks(accelerator.device)  # reduce peak memory usage
-        optimizer, train_dataloader, lr_scheduler = accelerator.prepare(optimizer, train_dataloader, lr_scheduler)
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
+            optimizer, train_dataloader = accelerator.prepare(optimizer, train_dataloader)
+        else:
+            optimizer, train_dataloader, lr_scheduler = accelerator.prepare(optimizer, train_dataloader, lr_scheduler)
 
     # 実験的機能：勾配も含めたfp16学習を行う　PyTorchにパッチを当ててfp16でのgrad scaleを有効にする
     if args.full_fp16:
@@ -643,6 +651,8 @@ def train(args):
             m.train()
 
         for step, batch in enumerate(train_dataloader):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
+                optimizer.train()
             current_step.value = global_step
 
             if args.blockwise_fused_optimizers:
@@ -746,14 +756,19 @@ def train(args):
                         accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                     optimizer.step()
-                    lr_scheduler.step()
+                    if not (args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper):
+                        lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
                 else:
                     # optimizer.step() and optimizer.zero_grad() are called in the optimizer hook
-                    lr_scheduler.step()
+                    if not args.optimizer_schedulefree_wrapper:
+                        lr_scheduler.step()
                     if args.blockwise_fused_optimizers:
                         for i in range(1, len(optimizers)):
                             lr_schedulers[i].step()
+
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3303,6 +3303,20 @@ def add_optimizer_arguments(parser: argparse.ArgumentParser):
         help='additional arguments for optimizer (like "weight_decay=0.01 betas=0.9,0.999 ...") / オプティマイザの追加引数（例： "weight_decay=0.01 betas=0.9,0.999 ..."）',
     )
 
+    parser.add_argument(
+        "--optimizer_schedulefree_wrapper",
+        action="store_true",
+        help="use schedulefree_wrapper any optimizer / 任意のオプティマイザにschedulefree_wrapperを使用",
+    )
+
+    parser.add_argument(
+        "--schedulefree_wrapper_kwargs",
+        type=str,
+        default=None,
+        nargs="*",
+        help='additional arguments for schedulefree_wrapper (like "momentum=0.9 weight_decay_at_y=0.1 ...") / オプティマイザの追加引数（例： "momentum=0.9 weight_decay_at_y=0.1 ..."）',
+    )
+
     parser.add_argument("--lr_scheduler_type", type=str, default="", help="custom scheduler module / 使用するスケジューラ")
     parser.add_argument(
         "--lr_scheduler_args",
@@ -4613,6 +4627,19 @@ def get_optimizer(args, trainable_params):
 
     optimizer_name = optimizer_class.__module__ + "." + optimizer_class.__name__
     optimizer_args = ",".join([f"{k}={v}" for k, v in optimizer_kwargs.items()])
+
+    if args.optimizer_schedulefree_wrapper and not optimizer_type.endswith("schedulefree"):
+        try:
+            import schedulefree as sf
+        except ImportError:
+            raise ImportError("No schedulefree / schedulefreeがインストールされていないようです")
+        schedulefree_wrapper_kwargs = {}
+        if args.schedulefree_wrapper_args is not None and len(args.schedulefree_wrapper_args) > 0:
+            for arg in args.schedulefree_wrapper_kwargs:
+                key, value = arg.split("=")
+                value = ast.literal_eval(value)
+                schedulefree_wrapper_kwargs[key] = value
+        optimizer = sf.ScheduleFreeWrapper(optimizer, **schedulefree_wrapper_kwargs)
 
     return optimizer_name, optimizer_args, optimizer
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3087,7 +3087,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
     )
     parser.add_argument("--seed", type=int, default=None, help="random seed for training / 学習時の乱数のseed")
     parser.add_argument(
-        "--gradient_checkpointing", action="store_true", help="enable gradient checkpointing / grandient checkpointingを有効にする"
+        "--gradient_checkpointing", action="store_true", help="enable gradient checkpointing / gradient checkpointingを有効にする"
     )
     parser.add_argument(
         "--gradient_accumulation_steps",

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4012,6 +4012,21 @@ def get_optimizer(args, trainable_params):
         logger.info(f"use AdamW optimizer | {optimizer_kwargs}")
         optimizer_class = torch.optim.AdamW
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+        
+    elif optimizer_type.endswith("schedulefree".lower()):
+        try:
+            import schedulefree as sf
+        except ImportError:
+            raise ImportError("No schedulefree / schedulefreeがインストールされていないようです")
+        if optimizer_type == "AdamWScheduleFree".lower():
+                optimizer_class = sf.AdamWScheduleFree
+                logger.info(f"use AdamWScheduleFree optimizer | {optimizer_kwargs}")
+        elif optimizer_type == "SGDScheduleFree".lower():
+            optimizer_class = sf.SGDScheduleFree 
+            logger.info(f"use SGDScheduleFree optimizer | {optimizer_kwargs}")
+        else:
+            raise ValueError(f"Unknown optimizer type: {optimizer_type}")
+        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     if optimizer is None:
         # 任意のoptimizerを使う

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -247,14 +247,13 @@ class LoRAInfModule(LoRAModule):
             area = x.size()[1]
 
         mask = self.network.mask_dic.get(area, None)
-        if mask is None:
-            # raise ValueError(f"mask is None for resolution {area}")
+        if mask is None or len(x.size()) == 2:
             # emb_layers in SDXL doesn't have mask
             # if "emb" not in self.lora_name:
             #     print(f"mask is None for resolution {self.lora_name}, {area}, {x.size()}")
             mask_size = (1, x.size()[1]) if len(x.size()) == 2 else (1, *x.size()[1:-1], 1)
             return torch.ones(mask_size, dtype=x.dtype, device=x.device) / self.network.num_sub_prompts
-        if len(x.size()) != 4:
+        if len(x.size()) == 3:
             mask = torch.reshape(mask, (1, -1, 1))
         return mask
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytorch-lightning==1.9.0
 bitsandbytes==0.43.3
 prodigyopt==1.0
 lion-pytorch==0.0.6
+schedulefree==1.2.7
 tensorboard
 safetensors==0.4.4
 # gradio==3.16.2

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -501,6 +501,8 @@ def train(args):
 
         for m in training_models:
             m.train()
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
 
         for step, batch in enumerate(train_dataloader):
             current_step.value = global_step
@@ -626,7 +628,8 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                lr_scheduler.step()
+                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -415,7 +415,7 @@ def train(args):
             text_encoder2=text_encoder2 if train_text_encoder2 else None,
         )
         # most of ZeRO stage uses optimizer partitioning, so we have to prepare optimizer and ds_model at the same time. # pull/1139#issuecomment-1986790007
-        if args.optimizer_type.lower().endswith("scheduleFree"):
+        if args.optimizer_type.lower().endswith("schedulefree"):
             ds_model, optimizer, train_dataloader = accelerator.prepare(
                 ds_model, optimizer, train_dataloader
             )
@@ -433,7 +433,7 @@ def train(args):
             text_encoder1 = accelerator.prepare(text_encoder1)
         if train_text_encoder2:
             text_encoder2 = accelerator.prepare(text_encoder2)
-        if args.optimizer_type.lower().endswith("scheduleFree"):
+        if args.optimizer_type.lower().endswith("schedulefree"):
             optimizer, train_dataloader = accelerator.prepare(optimizer, train_dataloader)
         else:
             optimizer, train_dataloader, lr_scheduler = accelerator.prepare(optimizer, train_dataloader, lr_scheduler)
@@ -636,7 +636,7 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                if not args.optimizer_type.lower().endswith("schedulefree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -415,9 +415,14 @@ def train(args):
             text_encoder2=text_encoder2 if train_text_encoder2 else None,
         )
         # most of ZeRO stage uses optimizer partitioning, so we have to prepare optimizer and ds_model at the same time. # pull/1139#issuecomment-1986790007
-        ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-            ds_model, optimizer, train_dataloader, lr_scheduler
-        )
+        if args.optimizer_type.lower().endswith("scheduleFree"):
+            ds_model, optimizer, train_dataloader = accelerator.prepare(
+                ds_model, optimizer, train_dataloader
+            )
+        else:
+            ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                ds_model, optimizer, train_dataloader, lr_scheduler
+            )
         training_models = [ds_model]
 
     else:
@@ -428,7 +433,10 @@ def train(args):
             text_encoder1 = accelerator.prepare(text_encoder1)
         if train_text_encoder2:
             text_encoder2 = accelerator.prepare(text_encoder2)
-        optimizer, train_dataloader, lr_scheduler = accelerator.prepare(optimizer, train_dataloader, lr_scheduler)
+        if args.optimizer_type.lower().endswith("scheduleFree"):
+            optimizer, train_dataloader = accelerator.prepare(optimizer, train_dataloader)
+        else:
+            optimizer, train_dataloader, lr_scheduler = accelerator.prepare(optimizer, train_dataloader, lr_scheduler)
 
     # TextEncoderの出力をキャッシュするときにはCPUへ移動する
     if args.cache_text_encoder_outputs:

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -484,7 +484,7 @@ def train(args):
             text_encoder2=text_encoder2 if train_text_encoder2 else None,
         )
         # most of ZeRO stage uses optimizer partitioning, so we have to prepare optimizer and ds_model at the same time. # pull/1139#issuecomment-1986790007
-        if args.optimizer_type.lower().endswith("schedulefree"):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             ds_model, optimizer, train_dataloader = accelerator.prepare(
                 ds_model, optimizer, train_dataloader
             )
@@ -502,7 +502,7 @@ def train(args):
             text_encoder1 = accelerator.prepare(text_encoder1)
         if train_text_encoder2:
             text_encoder2 = accelerator.prepare(text_encoder2)
-        if args.optimizer_type.lower().endswith("schedulefree"):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             optimizer, train_dataloader = accelerator.prepare(optimizer, train_dataloader)
         else:
             optimizer, train_dataloader, lr_scheduler = accelerator.prepare(optimizer, train_dataloader, lr_scheduler)
@@ -638,7 +638,7 @@ def train(args):
             m.train()
 
         for step, batch in enumerate(train_dataloader):
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.train()
             current_step.value = global_step
 
@@ -770,7 +770,7 @@ def train(args):
                         for i in range(1, len(optimizers)):
                             lr_schedulers[i].step()
 
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -509,10 +509,10 @@ def train(args):
 
         for m in training_models:
             m.train()
-            if (args.optimizer_type.lower().endswith("schedulefree")):
-                optimizer.train()
 
         for step, batch in enumerate(train_dataloader):
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(*training_models):
                 if "latents" in batch and batch["latents"] is not None:
@@ -639,6 +639,9 @@ def train(args):
                 if not args.optimizer_type.lower().endswith("scheduleFree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -286,7 +286,7 @@ def train(args):
     unet.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    if args.optimizer_type.lower().endswith("scheduleFree"):
+    if args.optimizer_type.lower().endswith("schedulefree"):
         unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
     else:
         unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
@@ -491,7 +491,7 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                if not args.optimizer_type.lower().endswith("schedulefree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -286,7 +286,10 @@ def train(args):
     unet.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
+    if args.optimizer_type.lower().endswith("scheduleFree"):
+        unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
+    else:
+        unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
 
     if args.gradient_checkpointing:
         unet.train()  # according to TI example in Diffusers, train is required -> これオリジナルのU-Netしたので本当は外せる

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -290,8 +290,12 @@ def train(args):
 
     if args.gradient_checkpointing:
         unet.train()  # according to TI example in Diffusers, train is required -> これオリジナルのU-Netしたので本当は外せる
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.train()
     else:
         unet.eval()
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.eval()
 
     # TextEncoderの出力をキャッシュするときにはCPUへ移動する
     if args.cache_text_encoder_outputs:
@@ -481,7 +485,8 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                lr_scheduler.step()
+                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -307,7 +307,7 @@ def train(args):
     unet.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    if args.optimizer_type.lower().endswith("schedulefree"):
+    if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
         unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
     else:
         unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
@@ -316,12 +316,12 @@ def train(args):
         unet._set_static_graph()  # avoid error for multiple use of the parameter
 
     if args.gradient_checkpointing:
-        if (args.optimizer_type.lower().endswith("schedulefree")):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             optimizer.train()
         unet.train()  # according to TI example in Diffusers, train is required -> これオリジナルのU-Netしたので本当は外せる
 
     else:
-        if (args.optimizer_type.lower().endswith("schedulefree")):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             optimizer.eval()
         unet.eval()
 
@@ -424,7 +424,7 @@ def train(args):
         current_epoch.value = epoch + 1
 
         for step, batch in enumerate(train_dataloader):
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(unet):
@@ -520,11 +520,11 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("schedulefree"):
+                if not (args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -254,7 +254,7 @@ def train(args):
         network.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    if args.optimizer_type.lower().endswith("schedulefree"):
+    if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
         unet, network, optimizer, train_dataloader = accelerator.prepare(
             unet, network, optimizer, train_dataloader
         )
@@ -266,11 +266,11 @@ def train(args):
 
     if args.gradient_checkpointing:
         unet.train()  # according to TI example in Diffusers, train is required -> これオリジナルのU-Netしたので本当は外せる
-        if (args.optimizer_type.lower().endswith("schedulefree")):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             optimizer.train()
     else:
         unet.eval()
-        if (args.optimizer_type.lower().endswith("schedulefree")):
+        if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
             optimizer.eval()
 
     network.prepare_grad_etc()
@@ -366,7 +366,7 @@ def train(args):
         network.on_epoch_start()  # train()
 
         for step, batch in enumerate(train_dataloader):
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(network):
@@ -460,11 +460,11 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("schedulefree"):
+                if not (args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -254,9 +254,14 @@ def train(args):
         network.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    unet, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        unet, network, optimizer, train_dataloader, lr_scheduler
-    )
+    if args.optimizer_type.lower().endswith("scheduleFree"):
+        unet, network, optimizer, train_dataloader = accelerator.prepare(
+            unet, network, optimizer, train_dataloader
+        )
+    else:
+        unet, network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+            unet, network, optimizer, train_dataloader, lr_scheduler
+        )
     network: control_net_lllite.ControlNetLLLite
 
     if args.gradient_checkpointing:

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -261,8 +261,12 @@ def train(args):
 
     if args.gradient_checkpointing:
         unet.train()  # according to TI example in Diffusers, train is required -> これオリジナルのU-Netしたので本当は外せる
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.train()
     else:
         unet.eval()
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.eval()
 
     network.prepare_grad_etc()
 
@@ -449,7 +453,8 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                lr_scheduler.step()
+                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -254,7 +254,7 @@ def train(args):
         network.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    if args.optimizer_type.lower().endswith("scheduleFree"):
+    if args.optimizer_type.lower().endswith("schedulefree"):
         unet, network, optimizer, train_dataloader = accelerator.prepare(
             unet, network, optimizer, train_dataloader
         )
@@ -460,7 +460,7 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                if not args.optimizer_type.lower().endswith("schedulefree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 

--- a/sdxl_train_control_net_lllite_old.py
+++ b/sdxl_train_control_net_lllite_old.py
@@ -366,6 +366,8 @@ def train(args):
         network.on_epoch_start()  # train()
 
         for step, batch in enumerate(train_dataloader):
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(network):
                 with torch.no_grad():
@@ -461,6 +463,9 @@ def train(args):
                 if not args.optimizer_type.lower().endswith("scheduleFree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -276,9 +276,14 @@ def train(args):
         controlnet.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    controlnet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        controlnet, optimizer, train_dataloader, lr_scheduler
-    )
+    if args.optimizer_type.lower().endswith("scheduleFree"):
+        controlnet, optimizer, train_dataloader = accelerator.prepare(
+            controlnet, optimizer, train_dataloader
+        )
+    else:
+        controlnet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+            controlnet, optimizer, train_dataloader, lr_scheduler
+        )
 
     unet.requires_grad_(False)
     text_encoder.requires_grad_(False)

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -398,6 +398,8 @@ def train(args):
         current_epoch.value = epoch + 1
 
         for step, batch in enumerate(train_dataloader):
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(controlnet):
                 with torch.no_grad():
@@ -476,6 +478,9 @@ def train(args):
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -276,7 +276,7 @@ def train(args):
         controlnet.to(weight_dtype)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    if args.optimizer_type.lower().endswith("scheduleFree"):
+    if args.optimizer_type.lower().endswith("schedulefree"):
         controlnet, optimizer, train_dataloader = accelerator.prepare(
             controlnet, optimizer, train_dataloader
         )

--- a/train_db.py
+++ b/train_db.py
@@ -302,6 +302,8 @@ def train(args):
 
         # 指定したステップ数までText Encoderを学習する：epoch最初の状態
         unet.train()
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.train()
         # train==True is required to enable gradient_checkpointing
         if args.gradient_checkpointing or global_step < args.stop_text_encoder_training:
             text_encoder.train()
@@ -384,7 +386,8 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                lr_scheduler.step()
+                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
             # Checks if the accelerator has performed an optimization step behind the scenes

--- a/train_db.py
+++ b/train_db.py
@@ -315,13 +315,13 @@ def train(args):
 
         # 指定したステップ数までText Encoderを学習する：epoch最初の状態
         unet.train()
-        if (args.optimizer_type.lower().endswith("schedulefree")):
-            optimizer.train()
         # train==True is required to enable gradient_checkpointing
         if args.gradient_checkpointing or global_step < args.stop_text_encoder_training:
             text_encoder.train()
 
         for step, batch in enumerate(train_dataloader):
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             current_step.value = global_step
             # 指定したステップ数でText Encoderの学習を止める
             if global_step == args.stop_text_encoder_training:
@@ -402,6 +402,9 @@ def train(args):
                 if not args.optimizer_type.lower().endswith("scheduleFree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
+
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/train_db.py
+++ b/train_db.py
@@ -229,7 +229,7 @@ def train(args):
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet, text_encoder=text_encoder)
         else:
             ds_model = deepspeed_utils.prepare_deepspeed_model(args, unet=unet)
-        if args.optimizer_type.lower().endswith("scheduleFree"):
+        if args.optimizer_type.lower().endswith("schedulefree"):
             ds_model, optimizer, train_dataloader = accelerator.prepare(
                 ds_model, optimizer, train_dataloader
             )
@@ -241,7 +241,7 @@ def train(args):
 
     else:
         if train_text_encoder:
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 unet, text_encoder, optimizer, train_dataloader  = accelerator.prepare(
                     unet, text_encoder, optimizer, train_dataloader
                 )
@@ -251,7 +251,7 @@ def train(args):
                 )
             training_models = [unet, text_encoder]
         else:
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 unet, optimizer, train_dataloader = accelerator.prepare(unet, optimizer, train_dataloader)
             else:
                 unet, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(unet, optimizer, train_dataloader, lr_scheduler)
@@ -399,7 +399,7 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                if not args.optimizer_type.lower().endswith("schedulefree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 

--- a/train_network.py
+++ b/train_network.py
@@ -587,7 +587,7 @@ class NetworkTrainer:
                 text_encoder2=(text_encoders[1] if flags[1] else None) if len(text_encoders) > 1 else None,
                 network=network,
             )
-            if args.optimizer_type.lower().endswith("schedulefree"):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 ds_model, optimizer, train_dataloader = accelerator.prepare(
                     ds_model, optimizer, train_dataloader
                 )    
@@ -613,7 +613,7 @@ class NetworkTrainer:
             else:
                 pass  # if text_encoder is not trained, no need to prepare. and device and dtype are already set
             
-            if args.optimizer_type.lower().endswith("schedulefree"):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 network, optimizer, train_dataloader = accelerator.prepare(
                     network, optimizer, train_dataloader
                 )  
@@ -625,7 +625,7 @@ class NetworkTrainer:
 
         if args.gradient_checkpointing:
             # according to TI example in Diffusers, train is required
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.train()
             unet.train()
 
@@ -637,7 +637,7 @@ class NetworkTrainer:
                     self.prepare_text_encoder_grad_ckpt_workaround(i, t_enc)
 
         else:
-            if (args.optimizer_type.lower().endswith("schedulefree")):
+            if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                 optimizer.eval()
             unet.eval()
             for t_enc in text_encoders:
@@ -1200,7 +1200,7 @@ class NetworkTrainer:
                             accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                     optimizer.step()
-                    if not args.optimizer_type.lower().endswith("schedulefree"):
+                    if not (args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper):
                         lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 
@@ -1212,7 +1212,7 @@ class NetworkTrainer:
                 else:
                     keys_scaled, mean_norm, maximum_norm = None, None, None
 
-                if (args.optimizer_type.lower().endswith("schedulefree")):
+                if args.optimizer_type.lower().endswith("schedulefree") or args.optimizer_schedulefree_wrapper:
                     optimizer.eval()
 
                 # Checks if the accelerator has performed an optimization step behind the scenes

--- a/train_network.py
+++ b/train_network.py
@@ -446,6 +446,8 @@ class NetworkTrainer:
         if args.gradient_checkpointing:
             # according to TI example in Diffusers, train is required
             unet.train()
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             for t_enc in text_encoders:
                 t_enc.train()
 
@@ -900,7 +902,8 @@ class NetworkTrainer:
                             accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                     optimizer.step()
-                    lr_scheduler.step()
+                    if not args.optimizer_type.lower().endswith("scheduleFree"):
+                        lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 
                 if args.scale_weight_norms:

--- a/train_network.py
+++ b/train_network.py
@@ -420,7 +420,7 @@ class NetworkTrainer:
                 text_encoder2=text_encoders[1] if train_text_encoder and len(text_encoders) > 1 else None,
                 network=network,
             )
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 ds_model, optimizer, train_dataloader = accelerator.prepare(
                     ds_model, optimizer, train_dataloader
                 )    
@@ -443,7 +443,7 @@ class NetworkTrainer:
             else:
                 pass  # if text_encoder is not trained, no need to prepare. and device and dtype are already set
             
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 network, optimizer, train_dataloader = accelerator.prepare(
                     network, optimizer, train_dataloader
                 )  
@@ -924,7 +924,7 @@ class NetworkTrainer:
                             accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                     optimizer.step()
-                    if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    if not args.optimizer_type.lower().endswith("schedulefree"):
                         lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
 

--- a/train_network.py
+++ b/train_network.py
@@ -455,9 +455,10 @@ class NetworkTrainer:
 
         if args.gradient_checkpointing:
             # according to TI example in Diffusers, train is required
-            unet.train()
             if (args.optimizer_type.lower().endswith("schedulefree")):
                 optimizer.train()
+            unet.train()
+
             for t_enc in text_encoders:
                 t_enc.train()
 
@@ -466,6 +467,8 @@ class NetworkTrainer:
                     t_enc.text_model.embeddings.requires_grad_(True)
 
         else:
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
             unet.eval()
             for t_enc in text_encoders:
                 t_enc.eval()
@@ -814,6 +817,8 @@ class NetworkTrainer:
             accelerator.unwrap_model(network).on_epoch_start(text_encoder, unet)
 
             for step, batch in enumerate(train_dataloader):
+                if (args.optimizer_type.lower().endswith("schedulefree")):
+                    optimizer.train()
                 current_step.value = global_step
                 with accelerator.accumulate(training_model):
                     on_step_start(text_encoder, unet)
@@ -930,6 +935,9 @@ class NetworkTrainer:
                     max_mean_logs = {"Keys Scaled": keys_scaled, "Average key norm": mean_norm}
                 else:
                     keys_scaled, mean_norm, maximum_norm = None, None, None
+
+                if (args.optimizer_type.lower().endswith("schedulefree")):
+                    optimizer.eval()
 
                 # Checks if the accelerator has performed an optimization step behind the scenes
                 if accelerator.sync_gradients:

--- a/train_network.py
+++ b/train_network.py
@@ -420,9 +420,14 @@ class NetworkTrainer:
                 text_encoder2=text_encoders[1] if train_text_encoder and len(text_encoders) > 1 else None,
                 network=network,
             )
-            ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                ds_model, optimizer, train_dataloader, lr_scheduler
-            )
+            if args.optimizer_type.lower().endswith("scheduleFree"):
+                ds_model, optimizer, train_dataloader = accelerator.prepare(
+                    ds_model, optimizer, train_dataloader
+                )    
+            else:
+                ds_model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                    ds_model, optimizer, train_dataloader, lr_scheduler
+                )
             training_model = ds_model
         else:
             if train_unet:
@@ -437,10 +442,15 @@ class NetworkTrainer:
                     text_encoders = [text_encoder]
             else:
                 pass  # if text_encoder is not trained, no need to prepare. and device and dtype are already set
-
-            network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                network, optimizer, train_dataloader, lr_scheduler
-            )
+            
+            if args.optimizer_type.lower().endswith("scheduleFree"):
+                network, optimizer, train_dataloader = accelerator.prepare(
+                    network, optimizer, train_dataloader
+                )  
+            else:
+                network, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                    network, optimizer, train_dataloader, lr_scheduler
+                )
             training_model = network
 
         if args.gradient_checkpointing:

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -416,14 +416,24 @@ class TextualInversionTrainer:
 
         # acceleratorがなんかよろしくやってくれるらしい
         if len(text_encoders) == 1:
-            text_encoder_or_list, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                text_encoder_or_list, optimizer, train_dataloader, lr_scheduler
-            )
+            if args.optimizer_type.lower().endswith("scheduleFree"):
+                text_encoder_or_list, optimizer, train_dataloader = accelerator.preparet(
+                    text_encoder_or_list, optimizer, train_dataloader
+                )   
+            else:
+                text_encoder_or_list, optimizer, train_dataloader, lr_scheduler = accelerator.preparet(
+                    text_encoder_or_list, optimizer, train_dataloader, lr_scheduler
+                )
 
         elif len(text_encoders) == 2:
-            text_encoder1, text_encoder2, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-                text_encoders[0], text_encoders[1], optimizer, train_dataloader, lr_scheduler
-            )
+            if args.optimizer_type.lower().endswith("scheduleFree"):
+                text_encoder1, text_encoder2, optimizer, train_dataloader = accelerator.prepare(
+                    text_encoders[0], text_encoders[1], optimizer, train_dataloader
+                )  
+            else:
+                text_encoder1, text_encoder2, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+                    text_encoders[0], text_encoders[1], optimizer, train_dataloader, lr_scheduler
+                )
 
             text_encoder_or_list = text_encoders = [text_encoder1, text_encoder2]
 

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -416,7 +416,7 @@ class TextualInversionTrainer:
 
         # acceleratorがなんかよろしくやってくれるらしい
         if len(text_encoders) == 1:
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 text_encoder_or_list, optimizer, train_dataloader = accelerator.preparet(
                     text_encoder_or_list, optimizer, train_dataloader
                 )   
@@ -426,7 +426,7 @@ class TextualInversionTrainer:
                 )
 
         elif len(text_encoders) == 2:
-            if args.optimizer_type.lower().endswith("scheduleFree"):
+            if args.optimizer_type.lower().endswith("schedulefree"):
                 text_encoder1, text_encoder2, optimizer, train_dataloader = accelerator.prepare(
                     text_encoders[0], text_encoders[1], optimizer, train_dataloader
                 )  

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -335,9 +335,14 @@ def train(args):
     lr_scheduler = train_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        text_encoder, optimizer, train_dataloader, lr_scheduler
-    )
+    if args.optimizer_type.lower().endswith("scheduleFree"):
+        text_encoder, optimizer, train_dataloader = accelerator.prepare(
+            text_encoder, optimizer, train_dataloader
+        )   
+    else:
+        text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+            text_encoder, optimizer, train_dataloader, lr_scheduler
+        )
 
     index_no_updates = torch.arange(len(tokenizer)) < token_ids_XTI[0]
     # logger.info(len(index_no_updates), torch.sum(index_no_updates))

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -335,7 +335,7 @@ def train(args):
     lr_scheduler = train_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
 
     # acceleratorがなんかよろしくやってくれるらしい
-    if args.optimizer_type.lower().endswith("scheduleFree"):
+    if args.optimizer_type.lower().endswith("schedulefree"):
         text_encoder, optimizer, train_dataloader = accelerator.prepare(
             text_encoder, optimizer, train_dataloader
         )   
@@ -507,7 +507,7 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                if not args.optimizer_type.lower().endswith("schedulefree"):
                     lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -354,8 +354,12 @@ def train(args):
     unet.to(accelerator.device, dtype=weight_dtype)
     if args.gradient_checkpointing:  # according to TI example in Diffusers, train is required
         unet.train()
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.train()
     else:
         unet.eval()
+        if (args.optimizer_type.lower().endswith("schedulefree")):
+            optimizer.eval()
 
     if not cache_latents:
         vae.requires_grad_(False)
@@ -496,7 +500,8 @@ def train(args):
                     accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 optimizer.step()
-                lr_scheduler.step()
+                if not args.optimizer_type.lower().endswith("scheduleFree"):
+                    lr_scheduler.step()
                 optimizer.zero_grad(set_to_none=True)
 
                 # Let's make sure we don't update any embedding weights besides the newly added token

--- a/train_textual_inversion_XTI.py
+++ b/train_textual_inversion_XTI.py
@@ -447,6 +447,8 @@ def train(args):
         loss_total = 0
 
         for step, batch in enumerate(train_dataloader):
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.train()
             current_step.value = global_step
             with accelerator.accumulate(text_encoder):
                 with torch.no_grad():
@@ -514,6 +516,9 @@ def train(args):
                     accelerator.unwrap_model(text_encoder).get_input_embeddings().weight[index_no_updates] = orig_embeds_params[
                         index_no_updates
                     ]
+
+            if (args.optimizer_type.lower().endswith("schedulefree")):
+                optimizer.eval()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:


### PR DESCRIPTION
Old version Details
- [ #1250 ] 

Whats news?
Because testing found that Flux training works well using AdamWScheduleFree.
![image](https://github.com/user-attachments/assets/776ad59f-8f2f-4f14-b2bf-5f9e555c2cd1)

1、add version in `requirements.txt` and add old schedulefree optimizer like 
AdamWschedulefree and SGDScheduleFree

2、(experiment function)add ScheduleFreeWarpper for using any base torch.opti.optimizer like Adam、RAdam、SparseAdam etc...

use `--optimizer_schedulefree_wrapper` to open options
use `--schedulefree_wrapper_args` add extra schedule free args.

SupportList:
```
from .adadelta import Adadelta
from .adagrad import Adagrad
from .adam import Adam
from .adamax import Adamax
from .adamw import AdamW
from .asgd import ASGD
from .lbfgs import LBFGS
from .nadam import NAdam
from .optimizer import Optimizer
from .radam import RAdam
from .rmsprop import RMSprop
from .rprop import Rprop
from .sgd import SGD
from .sparse_adam import SparseAdam
```

example:
--optimizer_type= "RAdam"
--optimizer_schedulefree_wrapper
----schedulefree_wrapper_args momentum=0.9, weight_decay_at_y=0.1


