### PR TITLE
Bug fix: alpha_mask load

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2207,7 +2207,7 @@ def is_disk_cached_latents_is_expected(reso, npz_path: str, flip_aug: bool, alph
         if alpha_mask:
             if "alpha_mask" not in npz:
                 return False
-            if npz["alpha_mask"].shape[0:2] != reso:  # HxW
+            if (npz["alpha_mask"].shape[1], npz["alpha_mask"].shape[0]) != reso:  # HxW => WxH != reso
                 return False
         else:
             if "alpha_mask" in npz:


### PR DESCRIPTION
npzからalpha_maskを読み込む時の、reso判定にミスがあるため修正しました。
I fixed the issue with the reso check when reading alpha_mask from the npz file.

before
・　aspect ratio is 1:1 …　Successfully loaded
・　aspect ratio is not 1:1 … Failed to load 

after 
Both of the above　…　Successfully loaded

----
元のコードではWxHではなく、HxWとしていたのか、その意図を理解していないため
もしかすると、間違った修正かもしれません。