### PR TITLE
Fix CNet training for sd1 (and maybe 2)

### DIFF
--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -164,6 +164,7 @@ def train(args):
             "num_class_embeds": None,
             "resnet_time_scale_shift": "default",
             "projection_class_embeddings_input_dim": None,
+            "num_attention_heads": 8,
         }
     else:
         unet.config = {
@@ -192,6 +193,8 @@ def train(args):
             "upcast_attention": False,
             "resnet_time_scale_shift": "default",
             "projection_class_embeddings_input_dim": None,
+            "num_attention_heads": 8,
+            "mid_block_type": "UNetMidBlock2DCrossAttn",
         }
     unet.config = FrozenDict(**unet.config)
 

--- a/train_controlnet.py
+++ b/train_controlnet.py
@@ -5,7 +5,6 @@ import os
 import random
 import time
 from multiprocessing import Value
-from types import SimpleNamespace
 import toml
 
 from tqdm import tqdm
@@ -18,6 +17,7 @@ init_ipex()
 from torch.nn.parallel import DistributedDataParallel as DDP
 from accelerate.utils import set_seed
 from diffusers import DDPMScheduler, ControlNetModel
+from diffusers.configuration_utils import FrozenDict
 from safetensors.torch import load_file
 
 import library.model_util as model_util
@@ -193,7 +193,7 @@ def train(args):
             "resnet_time_scale_shift": "default",
             "projection_class_embeddings_input_dim": None,
         }
-    unet.config = SimpleNamespace(**unet.config)
+    unet.config = FrozenDict(**unet.config)
 
     controlnet = ControlNetModel.from_unet(unet)
 
@@ -226,7 +226,7 @@ def train(args):
             )
         vae.to("cpu")
         clean_memory_on_device(accelerator.device)
-        
+
         accelerator.wait_for_everyone()
 
     if args.gradient_checkpointing:


### PR DESCRIPTION
This PR fixes:
- An incompatible datastructure passed to diffusers as the `unet.config`, which resulted in an error about SimpleNamespace not being iterable. (It doesn't have the `__contains__` method).
- A missing configuration item `num_attention_heads`. The value was taken from the yml model config from the original cnet repo
- A missing configuration item : `"mid_block_type": "UNetMidBlock2DCrossAttn"` which was guessed based on a vague interpretation of the original cnet's code. It seems to work. I haven't added this value for sd2, maybe we should ? In all the cases please correct me if I'm wrong on this side