### PR TITLE
No token padding for train_network

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -205,6 +205,9 @@ class NetworkTrainer:
         ds_for_collator = train_dataset_group if args.max_data_loader_n_workers == 0 else None
         collator = train_util.collator_class(current_epoch, current_step, ds_for_collator)
 
+        if args.no_token_padding:
+            train_dataset_group.disable_token_padding()
+
         if args.debug_dataset:
             train_util.debug_dataset(train_dataset_group)
             return
@@ -1161,6 +1164,11 @@ def setup_parser() -> argparse.ArgumentParser:
         default=None,
         nargs="*",
         help="additional arguments for network (key=value) / ネットワークへの追加の引数",
+    )
+    parser.add_argument(
+        "--no_token_padding",
+        action="store_true",
+        help="disable token padding (same as Diffuser's DreamBooth) / トークンのpaddingを無効にする（Diffusers版DreamBoothと同じ動作）",
     )
     parser.add_argument(
         "--network_train_unet_only", action="store_true", help="only training U-Net part / U-Net関連部分のみ学習する"


### PR DESCRIPTION
When training with Illustrious-xl 0.1, it appears that token padding was disabled during the training process. 
https://[arxiv.org/pdf/2409.19946](https://arxiv.org/pdf/2409.19946)
Illustrious: an Open Advanced Illustration Model A.6

Testing with token padding enabled seems to result in worse outcomes. 
To address this issue, I've added the `--no_token_padding option` to the training network, 
allowing users to disable token padding during training for potentially better results.

![image](https://github.com/user-attachments/assets/143d26a3-c288-4cc8-858c-da09023898d0)

