### PR TITLE
Compute aspect ratios in log-space

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -245,7 +245,7 @@ class BucketManager:
             if reso in self.predefined_resos_set:
                 pass
             else:
-                ar_errors = self.predefined_aspect_ratios - aspect_ratio
+                ar_errors = np.log(self.predefined_aspect_ratios) - np.log(aspect_ratio)
                 predefined_bucket_id = np.abs(ar_errors).argmin()  # 当該解像度以外でaspect ratio errorが最も少ないもの
                 reso = self.predefined_resos[predefined_bucket_id]
 


### PR DESCRIPTION
Updates aspect ratio bucketing to align with NovelAI's implementation. See their GitHub repo and paper (specifically footnote [2]) for reference.

https://github.com/NovelAI/novelai-aspect-ratio-bucketing/commits/main/?since=2024-09-25&until=2024-09-25
https://arxiv.org/abs/2409.15997

> [2] aspect ratios compared in log-space have the desirable property that a 1:1 aspect ratio can be equidistant
from buckets 2:1 and 1:2, each of which fit an equal proportion of its area.