### PR TITLE
fix: sort order when getting image size from cache file

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1887,7 +1887,7 @@ class DreamBoothDataset(BaseDataset):
 
                     # make image path to npz path mapping
                     npz_paths = glob.glob(os.path.join(subset.image_dir, "*" + strategy.cache_suffix))
-                    npz_paths.sort()
+                    npz_paths.sort(key=lambda item: item.rsplit("_", maxsplit=2)[0])  # sort by name excluding resolution and cache_suffix
                     npz_path_index = 0
 
                     size_set_count = 0


### PR DESCRIPTION
This fixes an edge case when getting image size from the cache filename if one filename is a prefix of a different filename.

Example:
`npz_paths.sort()` sorts `beach_towel-crop` before `beach_towel` (because `"-" < "_"`), which causes `beach_towel` to select the wrong resolution and generates a new, very badly cropped latent.
![image](https://github.com/user-attachments/assets/b9d9b606-2152-4bb6-8c49-1b094cef76ae)

Sorting by just the image name (excluding resolution and cache_suffix) produces the correct order. Now `beach_towel` uses the correct resolution 3200x1920.
![image](https://github.com/user-attachments/assets/d3b8664c-94f3-4659-846a-5213ebcafa02)
