### PR TITLE
Allow unknown schedule-free optimizers to continue to module loader

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4100,8 +4100,10 @@ def get_optimizer(args, trainable_params):
             optimizer_class = sf.SGDScheduleFree
             logger.info(f"use SGDScheduleFree optimizer | {optimizer_kwargs}")
         else:
-            raise ValueError(f"Unknown optimizer type: {optimizer_type}")
-        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+            optimizer_class = None
+
+        if optimizer_class is not None:
+            optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     if optimizer is None:
         # 任意のoptimizerを使う

--- a/train_network.py
+++ b/train_network.py
@@ -101,7 +101,7 @@ class NetworkTrainer:
                     args.optimizer_type.lower().endswith("ProdigyPlusScheduleFree".lower())
                 ):  
                     logs[f"lr/d*lr/group{i}"] = (
-                        optimizer.param_groups[0]["d"] * optimizer.param_groups[0]["lr"]
+                        optimizer.param_groups[i]["d"] * optimizer.param_groups[i]["lr"]
                     )
 
         return logs


### PR DESCRIPTION
To support [ProdigyPlusScheduleFree](https://github.com/LoganBooker/prodigy-plus-schedule-free)
```bash
pip install git+http://github.com/LoganBooker/prodigy-plus-schedule-free
```

```
--optimizer_type prodigyplus.ProdigyPlusScheduleFree
```

```
                    INFO     use prodigyplus.ProdigyPlusScheduleFree | {'weight_decay': 0.1}                                         train_util.py:4111
[Prodigy+ScheduleFree] Optimiser contains single param_group -- 'split_groups' has been disabled.
```

Related #1796