### PR TITLE
Added RAdamScheduleFree support

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4887,7 +4887,11 @@ def get_optimizer(args, trainable_params) -> tuple[str, str, object]:
             import schedulefree as sf
         except ImportError:
             raise ImportError("No schedulefree / schedulefreeがインストールされていないようです")
-        if optimizer_type == "AdamWScheduleFree".lower():
+        
+        if optimizer_type == "RAdamScheduleFree".lower():
+            optimizer_class = sf.RAdamScheduleFree
+            logger.info(f"use RAdamScheduleFree optimizer | {optimizer_kwargs}")
+        elif optimizer_type == "AdamWScheduleFree".lower():
             optimizer_class = sf.AdamWScheduleFree
             logger.info(f"use AdamWScheduleFree optimizer | {optimizer_kwargs}")
         elif optimizer_type == "SGDScheduleFree".lower():


### PR DESCRIPTION
初めまして。
先日RAdamScheduleFreeというoptimizerを公開したものです。

[公開時ポスト](https://x.com/hamanasu_nagisa/status/1866413964235821492)
[紹介記事](https://zenn.dev/dena/articles/6f04641801b387)

記事公開後、「[sd-scriptsに追加されると嬉しい](https://x.com/_f_ai_9/status/1866783141299622059)」旨のポストを見かけたため僭越ながら追加のPRを作成させていただきました。

branchを見るとscheduler-free-optとsd3が現状schedulefreeに対応していそうで、sd3の方が最新なのかなという気配がしたのでこちらで対応させていただきましたが、もし何か問題等ありましたらお気軽にお申し付けください。


----
[Just in case you're an English speaker reading this PR:]

Hi there,
I'm the developer who recently released the RAdamScheduleFree optimizer.

I saw someone post that they'd like to have RAdamScheduleFree added to sd-scripts, so I just made this PR.

Please let me know if there are any issues or concerns. Thank you.