### PR TITLE
fix always_first_tags

### DIFF
--- a/finetune/tag_images_by_wd14_tagger.py
+++ b/finetune/tag_images_by_wd14_tagger.py
@@ -290,7 +290,7 @@ def main(args):
                 for tag in always_first_tags:
                     if tag in combined_tags:
                         combined_tags.remove(tag)
-                        combined_tags.insert(0, tag)
+                    combined_tags.insert(0, tag)
 
             # 先頭のカンマを取る
             if len(general_tag_text) > 0:


### PR DESCRIPTION

tag_images_by_wd14_tagger.py で生成されたタグ に always_first_tags で指定したタグが含まれない場合に always_first_tags が機能しない問題を修正しました。
