### PR TITLE
Add scale map to apply_max_norm_regularization

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4537,6 +4537,10 @@ def read_config_from_file(args: argparse.Namespace, parser: argparse.ArgumentPar
             ignore_nesting_dict[section_name] = section_dict
             continue
 
+        if section_name == "scale_weight_norms_map":
+            ignore_nesting_dict[section_name] = section_dict
+            continue
+
         # if value is dict, save all key and value into one dict
         for key, value in section_dict.items():
             ignore_nesting_dict[key] = value

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -1366,7 +1366,7 @@ class LoRANetwork(torch.nn.Module):
             org_module._lora_restored = False
             lora.enabled = False
 
-    def apply_max_norm_regularization(self, max_norm_value, device):
+    def apply_max_norm_regularization(self, max_norm, device, scale_map: dict[str, float]={}):
         downkeys = []
         upkeys = []
         alphakeys = []
@@ -1381,6 +1381,11 @@ class LoRANetwork(torch.nn.Module):
                 alphakeys.append(key.replace("lora_down.weight", "alpha"))
 
         for i in range(len(downkeys)):
+            max_norm_value = max_norm
+            for key in scale_map.keys():
+                if key in downkeys[i]:
+                    max_norm_value = scale_map[key]
+
             down = state_dict[downkeys[i]].to(device)
             up = state_dict[upkeys[i]].to(device)
             alpha = state_dict[alphakeys[i]].to(device)


### PR DESCRIPTION
Allows setting the scale_weight_norms via 
- `--scale_weight_norms_map "{'proj': 100.0}"`
- toml `scale_weight_norms_map = { proj = 100.0 }`

Set `--scale_weight_norms 5.0` to some value for the other values and the map would set those values for matching module keys. 

This is is just an idea to allow us to scale the weight norms differently for different modules. The implementation details are up in the air because I'm not sure what would be best here. 

Could be that we want to use regex for the module name matching. Or make the map work exclusively to `scale_weight_norms`. 

See https://github.com/rockerBOO/sd-ext/blob/main/scale_norms.py which emulates the same behavior but on the static weights. You can try different strategies with the map.