### PR TITLE
Implement Flex.1 Alpha Functionality

### DIFF
--- a/flux_minimal_inference.py
+++ b/flux_minimal_inference.py
@@ -20,6 +20,8 @@ from library import device_utils
 from library.device_utils import init_ipex, get_preferred_device
 from networks import oft_flux
 
+from library.flux_utils import bypass_flux_guidance, restore_flux_guidance
+
 init_ipex()
 
 
@@ -150,6 +152,9 @@ def do_sample(
 ):
     logger.info(f"num_steps: {num_steps}")
     timesteps = get_schedule(num_steps, img.shape[1], shift=not is_schnell)
+
+    # bypass guidance module
+    bypass_flux_guidance(model)
 
     # denoise initial noise
     if accelerator:
@@ -364,6 +369,9 @@ def generate_image(
     x = x.permute(0, 2, 3, 1)
     img = Image.fromarray((127.5 * (x + 1.0)).float().cpu().numpy().astype(np.uint8)[0])
 
+    # restore guidance module
+    restore_flux_guidance(model)
+    
     # save image
     output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)

--- a/flux_minimal_inference.py
+++ b/flux_minimal_inference.py
@@ -154,7 +154,8 @@ def do_sample(
     timesteps = get_schedule(num_steps, img.shape[1], shift=not is_schnell)
 
     # bypass guidance module
-    bypass_flux_guidance(model)
+    if args.bypass_flux_guidance:
+        bypass_flux_guidance(model)
 
     # denoise initial noise
     if accelerator:
@@ -370,7 +371,8 @@ def generate_image(
     img = Image.fromarray((127.5 * (x + 1.0)).float().cpu().numpy().astype(np.uint8)[0])
 
     # restore guidance module
-    restore_flux_guidance(model)
+    if args.bypass_flux_guidance:
+        restore_flux_guidance(model)
     
     # save image
     output_dir = args.output_dir

--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -424,8 +424,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
             """
 
             return model_pred
-
-        flux_utils.bypass_flux_guidance(unet)
+        if args.bypass_flux_guidance:
+            flux_utils.bypass_flux_guidance(unet)
 
         model_pred = call_dit(
             img=packed_noisy_model_input,
@@ -440,8 +440,9 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
 
         # unpack latents
         model_pred = flux_utils.unpack_latents(model_pred, packed_latent_height, packed_latent_width)
-
-        flux_utils.restore_flux_guidance(unet)
+        
+        if args.bypass_flux_guidance:
+            flux_utils.restore_flux_guidance(unet)
 
         # apply model prediction type
         model_pred, weighting = flux_train_utils.apply_model_prediction_type(args, model_pred, noisy_model_input, sigmas)

--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -425,6 +425,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
 
             return model_pred
 
+        flux_utils.bypass_flux_guidance(unet)
+
         model_pred = call_dit(
             img=packed_noisy_model_input,
             img_ids=img_ids,
@@ -438,6 +440,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
 
         # unpack latents
         model_pred = flux_utils.unpack_latents(model_pred, packed_latent_height, packed_latent_width)
+
+        flux_utils.restore_flux_guidance(unet)
 
         # apply model prediction type
         model_pred, weighting = flux_train_utils.apply_model_prediction_type(args, model_pred, noisy_model_input, sigmas)

--- a/library/flux_train_utils.py
+++ b/library/flux_train_utils.py
@@ -617,3 +617,10 @@ def add_flux_train_arguments(parser: argparse.ArgumentParser):
         default=3.0,
         help="Discrete flow shift for the Euler Discrete Scheduler, default is 3.0. / Euler Discrete Schedulerの離散フローシフト、デフォルトは3.0。",
     )
+
+    # bypass guidance module for flux
+    parser.add_argument(
+        "--bypass_flux_guidance"
+        , action="store_true"
+        , help="bypass flux guidance module for Flex.1-Alpha Training / Flex.1-Alpha トレーニング用バイパス フラックス ガイダンス モジュール"
+    )

--- a/library/flux_utils.py
+++ b/library/flux_utils.py
@@ -24,6 +24,32 @@ MODEL_VERSION_FLUX_V1 = "flux1"
 MODEL_NAME_DEV = "dev"
 MODEL_NAME_SCHNELL = "schnell"
 
+def guidance_embed_bypass_forward(self, timestep, guidance, pooled_projection):
+    timesteps_proj = self.time_proj(timestep)
+    timesteps_emb = self.timestep_embedder(
+        timesteps_proj.to(dtype=pooled_projection.dtype))  # (N, D)
+    pooled_projections = self.text_embedder(pooled_projection)
+    conditioning = timesteps_emb + pooled_projections
+    return conditioning
+
+# bypass the forward function
+def bypass_flux_guidance(transformer):
+    if hasattr(transformer.time_text_embed, '_bfg_orig_forward'):
+        return
+    # dont bypass if it doesnt have the guidance embedding
+    if not hasattr(transformer.time_text_embed, 'guidance_embedder'):
+        return
+    transformer.time_text_embed._bfg_orig_forward = transformer.time_text_embed.forward
+    transformer.time_text_embed.forward = partial(
+        guidance_embed_bypass_forward, transformer.time_text_embed
+    )
+
+# restore the forward function
+def restore_flux_guidance(transformer):
+    if not hasattr(transformer.time_text_embed, '_bfg_orig_forward'):
+        return
+    transformer.time_text_embed.forward = transformer.time_text_embed._bfg_orig_forward
+    del transformer.time_text_embed._bfg_orig_forward
 
 def analyze_checkpoint_state(ckpt_path: str) -> Tuple[bool, bool, Tuple[int, int], List[str]]:
     """
@@ -60,6 +86,7 @@ def analyze_checkpoint_state(ckpt_path: str) -> Tuple[bool, bool, Tuple[int, int
 
     is_diffusers = "transformer_blocks.0.attn.add_k_proj.bias" in keys
     is_schnell = not ("guidance_in.in_layer.bias" in keys or "time_text_embed.guidance_embedder.linear_1.bias" in keys)
+    # is_schnell = True
 
     # check number of double and single blocks
     if not is_diffusers:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4103,6 +4103,14 @@ def add_dit_training_arguments(parser: argparse.ArgumentParser):
         "この数を増やすと、トレーニング中のVRAM使用量が減りますが、トレーニング速度（s/it）も低下します。",
     )
 
+    # bypass guidance module for flux
+    parser.add_argument(
+        "--bypass_flux_guidance"
+        , action="store_true"
+        , help="bypass flux guidance module for Flex.1-Alpha Training / Flex.1-Alpha トレーニング用バイパス フラックス ガイダンス モジュール"
+    )
+
+
 
 def get_sanitized_config_or_none(args: argparse.Namespace):
     # if `--log_config` is enabled, return args for logging. if not, return None.

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4103,14 +4103,6 @@ def add_dit_training_arguments(parser: argparse.ArgumentParser):
         "この数を増やすと、トレーニング中のVRAM使用量が減りますが、トレーニング速度（s/it）も低下します。",
     )
 
-    # bypass guidance module for flux
-    parser.add_argument(
-        "--bypass_flux_guidance"
-        , action="store_true"
-        , help="bypass flux guidance module for Flex.1-Alpha Training / Flex.1-Alpha トレーニング用バイパス フラックス ガイダンス モジュール"
-    )
-
-
 
 def get_sanitized_config_or_none(args: argparse.Namespace):
     # if `--log_config` is enabled, return args for logging. if not, return None.


### PR DESCRIPTION
Create --bypass_flux_guidance argument and mechanism to allow training of the Flex.1-Alpha model created by Ostris (https://huggingface.co/ostris/Flex.1-alpha). This is an Apache 2.0 model based off of Flux Schnell with the distillation removed and a custom guidance module created, which allows the model to be more easily finetuned.

Initial testing I've done confirms that this is in fact the case and the model is extremely easy to finetune compared to Flux Dev, with a minor deterioration in quality.

The implementation here is based off of this commit of ai-toolkit: https://github.com/ostris/ai-toolkit/commit/8ef07a9c3662351328407d9249a5418639dd3052

Currently, I have an issue created here in reference to this with some initial testing: https://github.com/kohya-ss/sd-scripts/issues/1891