### PR TITLE
Add more dpmsolver++2m samplers to solve SDXL sampling artifacts

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -5980,6 +5980,31 @@ def get_my_scheduler(
     elif sample_sampler == "dpmsolver" or sample_sampler == "dpmsolver++":
         scheduler_cls = DPMSolverMultistepScheduler
         sched_init_args["algorithm_type"] = sample_sampler
+    elif sample_sampler == "dpmsolver++_2m":
+        scheduler_cls = DPMSolverMultistepScheduler
+    elif sample_sampler == "dpmsolver++_2m_lu":
+        scheduler_cls = DPMSolverMultistepScheduler
+    elif sample_sampler == "dpmsolver++_2m_k":
+        scheduler_cls = DPMSolverMultistepScheduler
+        sched_init_args["use_karras_sigmas"] = True
+    elif sample_sampler == "dpmsolver++_2m_stable":
+        scheduler_cls = DPMSolverMultistepScheduler
+        sched_init_args["euler_at_final"] = True
+    elif sample_sampler == "dpmsolver++_2m_sde":
+        scheduler_cls = DPMSolverMultistepScheduler
+        sched_init_args["algorithm_type"] = "sde-dpmsolver++"
+    elif sample_sampler == "dpmsolver++_2m_sde_k":
+        scheduler_cls = DPMSolverMultistepScheduler
+        sched_init_args["algorithm_type"] = "sde-dpmsolver++"
+        sched_init_args["use_karras_sigmas"] = True
+    elif sample_sampler == "dpmsolver++_2m_sde_lu":
+        scheduler_cls = DPMSolverMultistepScheduler
+        sched_init_args["algorithm_type"] = "sde-dpmsolver++"
+        sched_init_args["use_lu_lambdas"] = True
+    elif sample_sampler == "dpmsolver++_2m_sde_stable":
+        scheduler_cls = DPMSolverMultistepScheduler
+        sched_init_args["algorithm_type"] = "sde-dpmsolver++"
+        sched_init_args["euler_at_final"] = True
     elif sample_sampler == "dpmsingle":
         scheduler_cls = DPMSolverSinglestepScheduler
     elif sample_sampler == "heun":


### PR DESCRIPTION
Visual artifacting for sampling using `dpmsolver++`. This adds more samplers but `dpmsolver++_2m_lu` should produce better results on SDXL. 

![sample_2_880_1c033a0dba24b098ea6d](https://github.com/user-attachments/assets/7038441a-82d1-491a-a5ed-f72fb2ac641c)

https://github.com/huggingface/diffusers/issues/5433
https://github.com/huggingface/diffusers/pull/5541