### PR TITLE
Implement Test and Validation Loss for Flux Finetuning and LoRA Training

### DIFF
--- a/flux_train.py
+++ b/flux_train.py
@@ -716,6 +716,7 @@ def train(args):
             if global_step % test_step_freq == 0 and test_step_freq > 0:
                 test_loss, test_fixed_states = train_util.calc_test_val_loss(dataset=test_set, loss_func=calculate_loss, repeat_count=test_val_repeat_count, fixed_states=test_fixed_states, test=True)
                 test_losses.append(test_loss)
+                accelerator.log({'test_loss':test_loss}, step=global_step)
 
             # CALCULATE LOSS ON VALIDATION SET AT TEST SET FREQUENCY
             if global_step==0:
@@ -724,6 +725,7 @@ def train(args):
             if global_step % val_step_freq == 0 and val_step_freq > 0:
                 val_loss, val_fixed_states = train_util.calc_test_val_loss(dataset=val_set, loss_func=calculate_loss, repeat_count=test_val_repeat_count, fixed_states=val_fixed_states, test=False)
                 val_losses.append(val_loss)
+                accelerator.log({'val_loss':val_loss}, step=global_step)
 
             # STANDARD LOSS CALCULATION
             loss, _ = calculate_loss(batch, accumulate_loss=True) # Loss should be accumulated when not running the test/validation samples though

--- a/flux_train.py
+++ b/flux_train.py
@@ -579,8 +579,11 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    logger.info('CREATING TEST AND VALIDATION SETS')
-    test_set, val_set = train_util.create_test_val_set(train_dataloader, args.test_set_count, args.val_set_count)
+    test_set_count = args.test_set_count if args.test_step_freq > 0 else 0
+    val_set_count = args.test_set_count if args.val_step_freq > 0 else 0
+    if (test_set_count + val_set_count) > 0:
+        logger.info('CREATING TEST AND VALIDATION SETS')
+        test_set, val_set = train_util.create_test_val_set(train_dataloader, args.test_set_count, args.val_set_count)
 
     def calculate_loss(batch, state=None, accumulate_loss: bool=True, accelerator=accelerator):
         
@@ -701,7 +704,7 @@ def train(args):
             if global_step==0:
                 test_fixed_states = []
                 test_losses       = []
-            if global_step % args.test_step_freq == 0 and args.test_step_freq > 0:
+            if args.test_step_freq > 0 and global_step % args.test_step_freq == 0:
                 test_loss, test_fixed_states = train_util.calc_test_val_loss(dataset=test_set, loss_func=calculate_loss, repeat_count=args.test_val_repeat_count, fixed_states=test_fixed_states, test=True)
                 test_losses.append(test_loss)
                 accelerator.log({'test_loss':test_loss, 'combined/test_relative':test_loss/test_losses[0]}, step=global_step)
@@ -710,7 +713,7 @@ def train(args):
             if global_step==0:
                 val_fixed_states = []
                 val_losses       = []
-            if global_step % args.val_step_freq == 0 and args.val_step_freq > 0:
+            if args.val_step_freq > 0 and global_step % args.val_step_freq == 0:
                 val_loss, val_fixed_states = train_util.calc_test_val_loss(dataset=val_set, loss_func=calculate_loss, repeat_count=args.test_val_repeat_count, fixed_states=val_fixed_states, test=False)
                 val_losses.append(val_loss)
                 accelerator.log({'val_loss':val_loss, 'combined/val_relative':val_loss/val_losses[0]}, step=global_step)

--- a/flux_train.py
+++ b/flux_train.py
@@ -593,7 +593,7 @@ def train(args):
     # TODO: Get arguments for step_freq values
     # TODO: Get arguments for test_set_count, test_noise_iter
 
-    def calculate_loss(step=step, batch=batch, state=None, accumulate_loss: bool=True, accelerator=accelerator):
+    def calculate_loss(batch, state=None, accumulate_loss: bool=True, accelerator=accelerator):
 
         if state is not None:
             noise, noisy_model_input, timesteps, sigmas = state
@@ -726,7 +726,7 @@ def train(args):
                 val_losses.append(val_loss)
 
             # STANDARD LOSS CALCULATION
-            loss, _ = calculate_loss(step, batch, accumulate_loss=True) # Loss should be accumulated when not running the test/validation samples though
+            loss, _ = calculate_loss(batch, accumulate_loss=True) # Loss should be accumulated when not running the test/validation samples though
 
             # backward
             accelerator.backward(loss)

--- a/flux_train.py
+++ b/flux_train.py
@@ -583,9 +583,6 @@ def train(args):
     test_set, val_set = train_util.create_test_val_set(train_dataloader, args.test_set_count, args.val_set_count)
 
     def calculate_loss(batch, state=None, accumulate_loss: bool=True, accelerator=accelerator):
-
-        if state is not None:
-            noise, noisy_model_input, timesteps, sigmas = state
         
         with accelerator.accumulate(*training_models) if accumulate_loss else nullcontext(): # Only utilize the accumulate context if loss is marked to be accumulated, otherwise, just use a null context. This avoids the test and validation samples impacting the training.
             if "latents" in batch and batch["latents"] is not None:
@@ -626,6 +623,8 @@ def train(args):
                 noisy_model_input, timesteps, sigmas = flux_train_utils.get_noisy_model_input_and_timesteps(
                     args, noise_scheduler_copy, latents, noise, accelerator.device, weight_dtype
                 )
+            else:
+                noise, noisy_model_input, timesteps, sigmas = state
 
             # pack latents and get img_ids
             packed_noisy_model_input = flux_utils.pack_latents(noisy_model_input)  # b, c, h*2, w*2 -> b, h*w, c*4

--- a/flux_train.py
+++ b/flux_train.py
@@ -691,9 +691,10 @@ def train(args):
             m.train()
 
         for step, batch in enumerate(train_dataloader):
-            if step in val_set['steps']: # Skip validation steps, don't increment global step
-                logger.warning('SKIPPING BATCH IN VALIDATION SET')
-                continue
+            if args.val_step_freq > 0:
+                if step in val_set['steps']: # Skip validation steps, don't increment global step
+                    logger.warning('SKIPPING BATCH IN VALIDATION SET')
+                    continue
 
             current_step.value = global_step
 

--- a/flux_train.py
+++ b/flux_train.py
@@ -19,6 +19,8 @@ from multiprocessing import Value
 import time
 from typing import List, Optional, Tuple, Union
 import toml
+import random
+from contextlib import nullcontext
 
 from tqdm import tqdm
 
@@ -577,6 +579,117 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
+
+    ### PLACEHOLDERS ###
+    test_step_freq = 10
+    val_step_freq = 25
+    test_set_count = 5
+    val_set_count = 5
+    test_val_repeat_count = 2
+
+    logger.warning('CREATING TEST AND VALIDATION SETS')
+    test_set, val_set = train_util.create_test_val_set(train_dataloader, test_set_count, val_set_count)
+
+    # TODO: Get arguments for step_freq values
+    # TODO: Get arguments for test_set_count, test_noise_iter
+
+    def calculate_loss(step=step, batch=batch, state=None, accumulate_loss: bool=True, accelerator=accelerator):
+
+        if state is not None:
+            noise, noisy_model_input, timesteps, sigmas = state
+        
+        with accelerator.accumulate(*training_models) if accumulate_loss else nullcontext(): # Only utilize the accumulate context if loss is marked to be accumulated, otherwise, just use a null context. This avoids the test and validation samples impacting the training.
+            if "latents" in batch and batch["latents"] is not None:
+                latents = batch["latents"].to(accelerator.device, dtype=weight_dtype)
+            else:
+                with torch.no_grad():
+                    # encode images to latents. images are [-1, 1]
+                    latents = ae.encode(batch["images"].to(ae.dtype)).to(accelerator.device, dtype=weight_dtype)
+
+                # NaNが含まれていれば警告を表示し0に置き換える
+                if torch.any(torch.isnan(latents)):
+                    accelerator.print("NaN found in latents, replacing with zeros")
+                    latents = torch.nan_to_num(latents, 0, out=latents)
+
+            text_encoder_outputs_list = batch.get("text_encoder_outputs_list", None)
+            if text_encoder_outputs_list is not None:
+                text_encoder_conds = text_encoder_outputs_list
+            else:
+                # not cached or training, so get from text encoders
+                tokens_and_masks = batch["input_ids_list"]
+                with torch.no_grad():
+                    input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]
+                    text_encoder_conds = text_encoding_strategy.encode_tokens(
+                        flux_tokenize_strategy, [clip_l, t5xxl], input_ids, args.apply_t5_attn_mask
+                    )
+                    if args.full_fp16:
+                        text_encoder_conds = [c.to(weight_dtype) for c in text_encoder_conds]
+
+            # TODO support some features for noise implemented in get_noise_noisy_latents_and_timesteps
+
+            bsz = latents.shape[0]
+
+            # get noisy model input and timesteps
+            if state is None: # Only calculate if not using stored values for validation
+                # Sample noise that we'll add to the latents
+                noise = torch.randn_like(latents)
+                
+                noisy_model_input, timesteps, sigmas = flux_train_utils.get_noisy_model_input_and_timesteps(
+                    args, noise_scheduler_copy, latents, noise, accelerator.device, weight_dtype
+                )
+
+            # pack latents and get img_ids
+            packed_noisy_model_input = flux_utils.pack_latents(noisy_model_input)  # b, c, h*2, w*2 -> b, h*w, c*4
+            packed_latent_height, packed_latent_width = noisy_model_input.shape[2] // 2, noisy_model_input.shape[3] // 2
+            img_ids = flux_utils.prepare_img_ids(bsz, packed_latent_height, packed_latent_width).to(device=accelerator.device)
+
+            # get guidance: ensure args.guidance_scale is float
+            guidance_vec = torch.full((bsz,), float(args.guidance_scale), device=accelerator.device)
+
+            # call model
+            l_pooled, t5_out, txt_ids, t5_attn_mask = text_encoder_conds
+            if not args.apply_t5_attn_mask:
+                t5_attn_mask = None
+
+            with accelerator.autocast():
+                # YiYi notes: divide it by 1000 for now because we scale it by 1000 in the transformer model (we should not keep it but I want to keep the inputs same for the model for testing)
+                model_pred = flux(
+                    img=packed_noisy_model_input,
+                    img_ids=img_ids,
+                    txt=t5_out,
+                    txt_ids=txt_ids,
+                    y=l_pooled,
+                    timesteps=timesteps / 1000,
+                    guidance=guidance_vec,
+                    txt_attention_mask=t5_attn_mask,
+                )
+
+            # unpack latents
+            model_pred = flux_utils.unpack_latents(model_pred, packed_latent_height, packed_latent_width)
+
+            # apply model prediction type
+            model_pred, weighting = flux_train_utils.apply_model_prediction_type(args, model_pred, noisy_model_input, sigmas)
+
+            # flow matching loss: this is different from SD3
+            target = noise - latents
+
+            # calculate loss
+            huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+            loss = train_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
+            if weighting is not None:
+                loss = loss * weighting
+            if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
+                loss = apply_masked_loss(loss, batch)
+            loss = loss.mean([1, 2, 3])
+
+            loss_weights = batch["loss_weights"]  # 各sampleごとのweight
+            loss = loss * loss_weights
+            loss = loss.mean()
+
+            state = (noise, noisy_model_input, timesteps, sigmas)
+
+            return loss, state
+                
     loss_recorder = train_util.LossRecorder()
     epoch = 0  # avoid error when max_train_steps is 0
     for epoch in range(num_train_epochs):
@@ -587,116 +700,53 @@ def train(args):
             m.train()
 
         for step, batch in enumerate(train_dataloader):
+            if step in val_set['steps']: # Skip validation steps, don't increment global step
+                logger.warning('SKIPPING BATCH IN VALIDATION SET')
+                continue
+
             current_step.value = global_step
 
             if args.blockwise_fused_optimizers:
                 optimizer_hooked_count = {i: 0 for i in range(len(optimizers))}  # reset counter for each step
 
-            with accelerator.accumulate(*training_models):
-                if "latents" in batch and batch["latents"] is not None:
-                    latents = batch["latents"].to(accelerator.device, dtype=weight_dtype)
-                else:
-                    with torch.no_grad():
-                        # encode images to latents. images are [-1, 1]
-                        latents = ae.encode(batch["images"].to(ae.dtype)).to(accelerator.device, dtype=weight_dtype)
+            # CALCULATE LOSS ON TEST SET AT TEST SET FREQUENCY
+            if global_step==0:
+                test_fixed_states = []
+                test_losses       = []
+            if global_step % test_step_freq == 0 and test_step_freq > 0:
+                test_loss, test_fixed_states = train_util.calc_test_val_loss(dataset=test_set, loss_func=calculate_loss, repeat_count=test_val_repeat_count, fixed_states=test_fixed_states, test=True)
+                test_losses.append(test_loss)
 
-                    # NaNが含まれていれば警告を表示し0に置き換える
-                    if torch.any(torch.isnan(latents)):
-                        accelerator.print("NaN found in latents, replacing with zeros")
-                        latents = torch.nan_to_num(latents, 0, out=latents)
+            # CALCULATE LOSS ON VALIDATION SET AT TEST SET FREQUENCY
+            if global_step==0:
+                val_fixed_states = []
+                val_losses       = []
+            if global_step % val_step_freq == 0 and val_step_freq > 0:
+                val_loss, val_fixed_states = train_util.calc_test_val_loss(dataset=val_set, loss_func=calculate_loss, repeat_count=test_val_repeat_count, fixed_states=val_fixed_states, test=False)
+                val_losses.append(val_loss)
 
-                text_encoder_outputs_list = batch.get("text_encoder_outputs_list", None)
-                if text_encoder_outputs_list is not None:
-                    text_encoder_conds = text_encoder_outputs_list
-                else:
-                    # not cached or training, so get from text encoders
-                    tokens_and_masks = batch["input_ids_list"]
-                    with torch.no_grad():
-                        input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]
-                        text_encoder_conds = text_encoding_strategy.encode_tokens(
-                            flux_tokenize_strategy, [clip_l, t5xxl], input_ids, args.apply_t5_attn_mask
-                        )
-                        if args.full_fp16:
-                            text_encoder_conds = [c.to(weight_dtype) for c in text_encoder_conds]
+            # STANDARD LOSS CALCULATION
+            loss, _ = calculate_loss(step, batch, accumulate_loss=True) # Loss should be accumulated when not running the test/validation samples though
 
-                # TODO support some features for noise implemented in get_noise_noisy_latents_and_timesteps
+            # backward
+            accelerator.backward(loss)
 
-                # Sample noise that we'll add to the latents
-                noise = torch.randn_like(latents)
-                bsz = latents.shape[0]
+            if not (args.fused_backward_pass or args.blockwise_fused_optimizers):
+                if accelerator.sync_gradients and args.max_grad_norm != 0.0:
+                    params_to_clip = []
+                    for m in training_models:
+                        params_to_clip.extend(m.parameters())
+                    accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
-                # get noisy model input and timesteps
-                noisy_model_input, timesteps, sigmas = flux_train_utils.get_noisy_model_input_and_timesteps(
-                    args, noise_scheduler_copy, latents, noise, accelerator.device, weight_dtype
-                )
-
-                # pack latents and get img_ids
-                packed_noisy_model_input = flux_utils.pack_latents(noisy_model_input)  # b, c, h*2, w*2 -> b, h*w, c*4
-                packed_latent_height, packed_latent_width = noisy_model_input.shape[2] // 2, noisy_model_input.shape[3] // 2
-                img_ids = flux_utils.prepare_img_ids(bsz, packed_latent_height, packed_latent_width).to(device=accelerator.device)
-
-                # get guidance: ensure args.guidance_scale is float
-                guidance_vec = torch.full((bsz,), float(args.guidance_scale), device=accelerator.device)
-
-                # call model
-                l_pooled, t5_out, txt_ids, t5_attn_mask = text_encoder_conds
-                if not args.apply_t5_attn_mask:
-                    t5_attn_mask = None
-
-                with accelerator.autocast():
-                    # YiYi notes: divide it by 1000 for now because we scale it by 1000 in the transformer model (we should not keep it but I want to keep the inputs same for the model for testing)
-                    model_pred = flux(
-                        img=packed_noisy_model_input,
-                        img_ids=img_ids,
-                        txt=t5_out,
-                        txt_ids=txt_ids,
-                        y=l_pooled,
-                        timesteps=timesteps / 1000,
-                        guidance=guidance_vec,
-                        txt_attention_mask=t5_attn_mask,
-                    )
-
-                # unpack latents
-                model_pred = flux_utils.unpack_latents(model_pred, packed_latent_height, packed_latent_width)
-
-                # apply model prediction type
-                model_pred, weighting = flux_train_utils.apply_model_prediction_type(args, model_pred, noisy_model_input, sigmas)
-
-                # flow matching loss: this is different from SD3
-                target = noise - latents
-
-                # calculate loss
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                loss = train_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
-                if weighting is not None:
-                    loss = loss * weighting
-                if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
-                    loss = apply_masked_loss(loss, batch)
-                loss = loss.mean([1, 2, 3])
-
-                loss_weights = batch["loss_weights"]  # 各sampleごとのweight
-                loss = loss * loss_weights
-                loss = loss.mean()
-
-                # backward
-                accelerator.backward(loss)
-
-                if not (args.fused_backward_pass or args.blockwise_fused_optimizers):
-                    if accelerator.sync_gradients and args.max_grad_norm != 0.0:
-                        params_to_clip = []
-                        for m in training_models:
-                            params_to_clip.extend(m.parameters())
-                        accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
-
-                    optimizer.step()
-                    lr_scheduler.step()
-                    optimizer.zero_grad(set_to_none=True)
-                else:
-                    # optimizer.step() and optimizer.zero_grad() are called in the optimizer hook
-                    lr_scheduler.step()
-                    if args.blockwise_fused_optimizers:
-                        for i in range(1, len(optimizers)):
-                            lr_schedulers[i].step()
+                optimizer.step()
+                lr_scheduler.step()
+                optimizer.zero_grad(set_to_none=True)
+            else:
+                # optimizer.step() and optimizer.zero_grad() are called in the optimizer hook
+                lr_scheduler.step()
+                if args.blockwise_fused_optimizers:
+                    for i in range(1, len(optimizers)):
+                        lr_schedulers[i].step()
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -6405,11 +6405,11 @@ def calc_test_val_loss(dataset, loss_func, repeat_count, fixed_states=[], test=T
     losses = []
     for step, batch in enumerate(dataset['batches'] * repeat_count):
         if len(fixed_states) < len(dataset['batches']) * repeat_count: # If accumulating fixed states, calculate state as normal and return
-            loss, state = loss_func(step, batch, None, accumulate_loss=False)
+            loss, state = loss_func(batch, None, accumulate_loss=False)
             fixed_states.append(state)
         else: # Otherwise, recall the stored values and use those instead so the test loss is consistently calculated for each sample
             state = fixed_states[step]
-            loss, _ = loss_func(step, batch, state, accumulate_loss=False)
+            loss, _ = loss_func(batch, state, accumulate_loss=False)
         losses.append(loss.detach().item())                      
     avg_loss = sum(losses) / len(losses)
     logger.info(f'AVERAGE {test_val_ind} LOSS: {avg_loss:.6f}')

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4103,6 +4103,46 @@ def add_dit_training_arguments(parser: argparse.ArgumentParser):
         "この数を増やすと、トレーニング中のVRAM使用量が減りますが、トレーニング速度（s/it）も低下します。",
     )
 
+    # offloading
+    parser.add_argument(
+        "--test_step_freq",
+        type=int,
+        default=0,
+        help="Frequency of test training error calculation",
+    )
+
+    # offloading
+    parser.add_argument(
+        "--val_step_freq",
+        type=int,
+        default=0,
+        help="Frequency of validation training error calculation",
+    )
+
+    # offloading
+    parser.add_argument(
+        "--test_set_count",
+        type=int,
+        default=5,
+        help="Size of test set for test error calculation.",
+    )
+
+    # offloading
+    parser.add_argument(
+        "--val_set_count",
+        type=int,
+        default=5,
+        help="Size of test set for test error calculation",
+    )
+
+    # offloading
+    parser.add_argument(
+        "--test_val_repeat_count",
+        type=int,
+        default=4,
+        help="Number of noise iterations to use for each training or test error calculation.",
+    )
+
 
 def get_sanitized_config_or_none(args: argparse.Namespace):
     # if `--log_config` is enabled, return args for logging. if not, return None.

--- a/train_network.py
+++ b/train_network.py
@@ -1259,8 +1259,11 @@ class NetworkTrainer:
                     # ***********************************
 
 
-        logger.info('CREATING TEST AND VALIDATION SETS')
-        test_set, val_set = train_util.create_test_val_set(train_dataloader, args.test_set_count, args.val_set_count)
+        test_set_count = args.test_set_count if args.test_step_freq > 0 else 0
+        val_set_count = args.test_set_count if args.val_step_freq > 0 else 0
+        if (test_set_count + val_set_count) > 0:
+            logger.info('CREATING TEST AND VALIDATION SETS')
+            test_set, val_set = train_util.create_test_val_set(train_dataloader, args.test_set_count, args.val_set_count)
 
         # ***********************************
         # TRAINING LOOP STARTS HERE
@@ -1292,7 +1295,7 @@ class NetworkTrainer:
                 if global_step==0:
                     test_fixed_states = []
                     test_losses       = []
-                if global_step % args.test_step_freq == 0 and args.test_step_freq > 0:
+                if args.test_step_freq > 0 and global_step % args.test_step_freq == 0:
                     test_loss, test_fixed_states = train_util.calc_test_val_loss(dataset=test_set, loss_func=calculate_loss, repeat_count=args.test_val_repeat_count, fixed_states=test_fixed_states, test=True)
                     test_losses.append(test_loss)
                     accelerator.log({'test_loss':test_loss, 'combined/test_relative':test_loss/test_losses[0]}, step=global_step)
@@ -1301,7 +1304,7 @@ class NetworkTrainer:
                 if global_step==0:
                     val_fixed_states = []
                     val_losses       = []
-                if global_step % args.val_step_freq == 0 and args.val_step_freq > 0:
+                if args.val_step_freq > 0 and global_step % args.val_step_freq == 0:
                     val_loss, val_fixed_states = train_util.calc_test_val_loss(dataset=val_set, loss_func=calculate_loss, repeat_count=args.test_val_repeat_count, fixed_states=val_fixed_states, test=False)
                     val_losses.append(val_loss)
                     accelerator.log({'val_loss':val_loss, 'combined/val_relative':val_loss/val_losses[0]}, step=global_step)

--- a/train_network.py
+++ b/train_network.py
@@ -1282,9 +1282,10 @@ class NetworkTrainer:
                 initial_step = 1
 
             for step, batch in enumerate(skipped_dataloader or train_dataloader):
-                if step in val_set['steps']: # Skip validation steps, don't increment global step
-                    logger.warning('SKIPPING BATCH IN VALIDATION SET')
-                    continue
+                if args.val_step_freq > 0:
+                    if step in val_set['steps']: # Skip validation steps, don't increment global step
+                        logger.warning('SKIPPING BATCH IN VALIDATION SET')
+                        continue
 
                 current_step.value = global_step
                 if initial_step > 0:


### PR DESCRIPTION
As discussed in the issue I created here: https://github.com/kohya-ss/sd-scripts/issues/1897

This is based off of the work done by spacepxl here: https://github.com/spacepxl/demystifying-sd-finetuning

The general point of it is that traditionally, the loss that is calculated at each step is more or less fully random and conveys very little information about the actual progress of training and very little about the performance. 

Instead, we can calculate test and validation loss values as one would when doing traditional machine learning. By selecting a specific set of samples and running them with identical noise and timesteps over time, we can evaluate a test loss for the model. Further, by selecting a portion of the training set to hold out, we can calculate a validation error as well as identify when the model begins overtraining.

This means that until this capability becomes available, we are effectively just guessing at the progress of our training and have no real quantitative measurement of progress or of overtraining.

In this PR, I implement this capability for Flex Finetuning and LoRA training which allows for these two sets to be automatically identified and for the two loss values to be captured at regular intervals.

So far, I've done several runs to verify that it is working properly, and you can see a brief snippet of this here:
![image](https://github.com/user-attachments/assets/a2dbbece-fa8e-4fda-b2fb-f6e2a3cb1d76)
(Pictured: Test loss relative to initial value, Validation loss relative to initial value)

The test error relative to the initial test error is on the left, while the respective validation results are on the right. As opposed to the raw loss values (below), you can see they are much smoother and more directionally indicative of training progress.
![image](https://github.com/user-attachments/assets/c506bf84-e77d-4f11-88ff-733510e8f6f2)
(Pictured: Raw loss values, i.e. garbage)

To use the functionality, I have added 5 new arguments:
--test_step_freq 25 (The frequency at which test loss is calculated; 0 turns off feature)
--val_step_freq 25 (The frequency at which validation loss is calculated; 0 turns off feature)
--test_set_count 10 (The number of training samples used for the test set)
--val_set_count 10 (The number of training samples used for the validation set; These are then skipped in training since they are held out)
--test_val_repeat_count 6 (The number of noise/timestep iterations to use for each test and validation sample)

I will say that this required some fairly sizable changes to the training loops to accommodate the additional loss calculations seamlessly, so I would definitely like feedback regarding the approach. I'm also not very familiar with accelerate and pytorch (and am a middling programmer to boot), so I may be doing something wrong along the way and almost certainly could benefit from some best practices. From my initial tests however, things at least seem to be working appropriately and generating the desired result.

This is also limited to just Flux for now, but the general logic that I used could be applied more broadly to other training types.