### PR TITLE
Validation Loss Enhancements

### DIFF
--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -323,7 +323,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         self.noise_scheduler_copy = copy.deepcopy(noise_scheduler)
         return noise_scheduler
 
-    def encode_images_to_latents(self, args, accelerator, vae, images):
+    def encode_images_to_latents(self, args, vae, images):
         return vae.encode(images)
 
     def shift_scale_latents(self, args, latents):

--- a/train_network.py
+++ b/train_network.py
@@ -1387,7 +1387,7 @@ class NetworkTrainer:
                 # VALIDATION PER STEP
                 should_validate_step = (
                     args.validate_every_n_steps is not None
-                    and args.validation_at_start is not None
+                    and args.validation_at_start
                     and (global_step - 1) % args.validate_every_n_steps == 0 # Note: Should use global step - 1 since the global step is incremented prior to this being run
                 )
                 if accelerator.sync_gradients and should_validate_step:

--- a/train_network.py
+++ b/train_network.py
@@ -1386,11 +1386,11 @@ class NetworkTrainer:
 
                 # VALIDATION PER STEP
                 should_validate_step = (
-                    args.validate_every_n_steps is not None 
-                    and global_step != 0 # Skip first step
-                    and global_step % args.validate_every_n_steps == 0
+                    args.validate_every_n_steps is not None
+                    and args.validation_at_start is not None
+                    and (global_step - 1) % args.validate_every_n_steps == 0 # Note: Should use global step - 1 since the global step is incremented prior to this being run
                 )
-                if accelerator.sync_gradients and validation_steps > 0 and should_validate_step:
+                if accelerator.sync_gradients and should_validate_step:
                     val_progress_bar = tqdm(
                         range(validation_steps), smoothing=0, 
                         disable=not accelerator.is_local_main_process, 
@@ -1721,6 +1721,11 @@ def setup_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Max number of validation dataset items processed. By default, validation will run the entire validation dataset / 処理される検証データセット項目の最大数。デフォルトでは、検証は検証データセット全体を実行します"
+    )
+    parser.add_argument(
+        "--validation_at_start",
+        action="store_true",
+        help="Calculate validation loss at run start"
     )
     return parser
 


### PR DESCRIPTION
I am creating this PR to implement a number of additional enhancements to the base validation loss implementation. These include:

**High Effort**
- Implement for finetuning
- Capture loss calculation state to reduce variance of calculation
- Add test set loss calculation

**Medium Effort**
- Add multiple noise/timestep iterations per sample

**Lower Effort**
- Add specific validation sample count in addition to current % based selection
- Add relative loss (loss / initial loss value)
- (Complete)  Calc validation at start with `--validation_at_start` argument
- (Complete)  Clean up progress bars so the validation one sits neatly above the global one and is not recreated each time

**Bug Fixes**
- Make it so it doesn't recalculate train latents every run
- (Complete) Correct bug for not working for Flux LoRA training if latents are not cached