### PR TITLE
Remove super().assert_extra_args() call in sdxl_train

### DIFF
--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -18,7 +18,7 @@ class SdxlNetworkTrainer(train_network.NetworkTrainer):
         self.is_sdxl = True
 
     def assert_extra_args(self, args, train_dataset_group):
-        super().assert_extra_args(args, train_dataset_group)
+        # super().assert_extra_args(args, train_dataset_group)
         sdxl_train_util.verify_sdxl_training_args(args)
 
         if args.cache_text_encoder_outputs:

--- a/sdxl_train_textual_inversion.py
+++ b/sdxl_train_textual_inversion.py
@@ -19,7 +19,7 @@ class SdxlTextualInversionTrainer(train_textual_inversion.TextualInversionTraine
         self.is_sdxl = True
 
     def assert_extra_args(self, args, train_dataset_group):
-        super().assert_extra_args(args, train_dataset_group)
+        # super().assert_extra_args(args, train_dataset_group)
         sdxl_train_util.verify_sdxl_training_args(args, supportTextEncoderCaching=False)
 
         train_dataset_group.verify_bucket_reso_steps(32)


### PR DESCRIPTION
## Description
Fixes AssertionError when training SDXL LoRA models with `bucket_reso_steps=32`.

**Problem:**
- Parent class `train_network.py` [#L98](https://github.com/kohya-ss/sd-scripts/blob/dev/train_network.py#L98) enforced 
```
    def assert_extra_args(self, args, train_dataset_group):
        train_dataset_group.verify_bucket_reso_steps(64)
```
- SDXL subclass attempted to set `32` after parent validation, causing conflict

**Changes:**
1. In `sdxl_train_textual_inversion.py`,`sdxl_train_network.py` Removed `super().assert_extra_args()` in `SdxlNetworkTrainer.assert_extra_args`

**Verification:**
- Confirmed no more `bucket_reso_steps=32` assertion failures in SDXL mode