### PR TITLE
Fatser fix bug for SDXL super SD1.5 assert cant use 32

### DIFF
--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -18,7 +18,6 @@ class SdxlNetworkTrainer(train_network.NetworkTrainer):
         self.is_sdxl = True
 
     def assert_extra_args(self, args, train_dataset_group):
-        super().assert_extra_args(args, train_dataset_group)
         sdxl_train_util.verify_sdxl_training_args(args)
 
         if args.cache_text_encoder_outputs:


### PR DESCRIPTION
SDXL assert_extra_args super SD1.5 assert,
SD1.5 cant use 32
so remove super() SDXL just use train_dataset_group.verify_bucket_reso_steps(32)