### PR TITLE
Add flexibility to block swapping for Flex model

### DIFF
--- a/library/flux_models.py
+++ b/library/flux_models.py
@@ -969,7 +969,7 @@ class Flux(nn.Module):
     def enable_block_swap(self, num_blocks: int, device: torch.device):
         self.blocks_to_swap = num_blocks
         double_blocks_to_swap = min(self.num_double_blocks - 2, num_blocks // 2)
-        single_blocks_to_swap = (num_blocks - double_blocks_to_swap) * 2
+        single_blocks_to_swap = (num_blocks - (num_blocks // 2)) * 2
 
         assert double_blocks_to_swap <= self.num_double_blocks - 2 and single_blocks_to_swap <= self.num_single_blocks - 2, (
             f"Cannot swap more than {self.num_double_blocks - 2} double blocks and {self.num_single_blocks - 2} single blocks. "

--- a/library/flux_models.py
+++ b/library/flux_models.py
@@ -968,7 +968,7 @@ class Flux(nn.Module):
 
     def enable_block_swap(self, num_blocks: int, device: torch.device):
         self.blocks_to_swap = num_blocks
-        double_blocks_to_swap = num_blocks // 2
+        double_blocks_to_swap = min(self.num_double_blocks - 2, num_blocks // 2)
         single_blocks_to_swap = (num_blocks - double_blocks_to_swap) * 2
 
         assert double_blocks_to_swap <= self.num_double_blocks - 2 and single_blocks_to_swap <= self.num_single_blocks - 2, (


### PR DESCRIPTION
Flex has 8 double blocks vs 19 on Flux. This prevents us from being able to block swap the to the maximum amount for flex as it would only allow 6. This fix allows the full number of block swaps and keeps functionality the same otherwise. 