### PR TITLE
Add URAE Ultra-Resolution Adaptation with Ease support

### DIFF
--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -380,7 +380,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         if not args.apply_t5_attn_mask:
             t5_attn_mask = None
 
-        def call_dit(img, img_ids, t5_out, txt_ids, l_pooled, timesteps, guidance_vec, t5_attn_mask, proportional_attention):
+        def call_dit(img, img_ids, t5_out, txt_ids, l_pooled, timesteps, guidance_vec, t5_attn_mask, proportional_attention, ntk_factor):
             # grad is enabled even if unet is not in train mode, because Text Encoder is in train mode
             with torch.set_grad_enabled(is_train), accelerator.autocast():
                 # YiYi notes: divide it by 1000 for now because we scale it by 1000 in the transformer model (we should not keep it but I want to keep the inputs same for the model for testing)
@@ -393,7 +393,8 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
                     timesteps=timesteps / 1000,
                     guidance=guidance_vec,
                     txt_attention_mask=t5_attn_mask,
-                    proportional_attention=proportional_attention
+                    proportional_attention=proportional_attention,
+                    ntk_factor=ntk_factor
                 )
             return model_pred
 
@@ -407,6 +408,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
             guidance_vec=guidance_vec,
             t5_attn_mask=t5_attn_mask,
             proportional_attention=args.proportional_attention,
+            ntk_factor=args.ntk_factor,
         )
 
         # unpack latents
@@ -439,6 +441,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
                         guidance_vec=guidance_vec[diff_output_pr_indices] if guidance_vec is not None else None,
                         t5_attn_mask=t5_attn_mask[diff_output_pr_indices] if t5_attn_mask is not None else None,
                         proportional_attention=args.proportional_attention,
+                        ntk_factor=args.ntk_factor,
                     )
                 network.set_multiplier(1.0)  # may be overwritten by "network_multipliers" in the next step
 

--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -380,7 +380,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         if not args.apply_t5_attn_mask:
             t5_attn_mask = None
 
-        def call_dit(img, img_ids, t5_out, txt_ids, l_pooled, timesteps, guidance_vec, t5_attn_mask):
+        def call_dit(img, img_ids, t5_out, txt_ids, l_pooled, timesteps, guidance_vec, t5_attn_mask, proportional_attention):
             # grad is enabled even if unet is not in train mode, because Text Encoder is in train mode
             with torch.set_grad_enabled(is_train), accelerator.autocast():
                 # YiYi notes: divide it by 1000 for now because we scale it by 1000 in the transformer model (we should not keep it but I want to keep the inputs same for the model for testing)
@@ -393,6 +393,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
                     timesteps=timesteps / 1000,
                     guidance=guidance_vec,
                     txt_attention_mask=t5_attn_mask,
+                    proportional_attention=proportional_attention
                 )
             return model_pred
 
@@ -405,6 +406,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
             timesteps=timesteps,
             guidance_vec=guidance_vec,
             t5_attn_mask=t5_attn_mask,
+            proportional_attention=args.proportional_attention,
         )
 
         # unpack latents
@@ -436,6 +438,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
                         timesteps=timesteps[diff_output_pr_indices],
                         guidance_vec=guidance_vec[diff_output_pr_indices] if guidance_vec is not None else None,
                         t5_attn_mask=t5_attn_mask[diff_output_pr_indices] if t5_attn_mask is not None else None,
+                        proportional_attention=args.proportional_attention,
                     )
                 network.set_multiplier(1.0)  # may be overwritten by "network_multipliers" in the next step
 


### PR DESCRIPTION
Add proportional_attention and ntk_factor to support large image sizes in training for better performance with very high resolution images. 

![Screenshot 2025-03-24 at 04-13-42 Ultra-Resolution Adaptation with Ease - 2503 16322v1 pdf](https://github.com/user-attachments/assets/c373bdad-7c01-458f-90df-e84ee714c18f)

https://arxiv.org/abs/2503.16322
https://github.com/Huage001/URAE

```
--proportional_attention --ntk_factor 1.0
```

NTK factor explained in more detail: 
https://blog.eleuther.ai/yarn/
https://arxiv.org/abs/2309.00071

Proportional attention tries to scale the attention according to the image sequence length. In this PR it is currently hard coded as the upstream implementation does this as well, but probably should get that to be something more accurate. 

They showcase parameter efficient using initialization implemented in #2001. 

And show you can distill large images from bigger teacher models (They use Flux.1 Pro to distill flux.1 dev) by making synthetic images where datasets can be hard to find.