### PR TITLE
Using --vae_batch_size to set batch size for dynamic latent generation

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -912,14 +912,22 @@ class NetworkTrainer:
                     if "latents" in batch and batch["latents"] is not None:
                         latents = batch["latents"].to(accelerator.device).to(dtype=weight_dtype)
                     else:
-                        with torch.no_grad():
-                            # latentに変換
-                            latents = vae.encode(batch["images"].to(dtype=vae_dtype)).latent_dist.sample().to(dtype=weight_dtype)
-
+                        if args.vae_batch_size is None or len(batch["images"]) <= args.vae_batch_size:
+                            with torch.no_grad():
+                                # latentに変換
+                                latents = vae.encode(batch["images"].to(dtype=vae_dtype)).latent_dist.sample().to(dtype=weight_dtype)
+                        else:
+                            chunks = [batch["images"][i:i + args.vae_batch_size] for i in range(0, len(batch["images"]), args.vae_batch_size)]
+                            list_latents = []
+                            for chunk in chunks:
+                                with torch.no_grad():
+                                # latentに変換
+                                    list_latents.append(vae.encode(chunk.to(dtype=vae_dtype)).latent_dist.sample().to(dtype=weight_dtype))
+                            latents = torch.cat(list_latents, dim=0)
                             # NaNが含まれていれば警告を表示し0に置き換える
-                            if torch.any(torch.isnan(latents)):
-                                accelerator.print("NaN found in latents, replacing with zeros")
-                                latents = torch.nan_to_num(latents, 0, out=latents)
+                        if torch.any(torch.isnan(latents)):
+                            accelerator.print("NaN found in latents, replacing with zeros")
+                            latents = torch.nan_to_num(latents, 0, out=latents)
                     latents = latents * self.vae_scale_factor
 
                     # get multiplier for each sample


### PR DESCRIPTION
A niche issue I ran into when training SDXL LoRAs on 16gb VRAM was that when using --color_aug and --random_crop, which requires dynamic runtime generation of latents, the maximum batch size was limited to 1 due to out of memory errors when generating the latents, even though higher batch sizes could be used when using cached latents.

This modification uses the --vae_batch_size arguement to set the batch size for generating latents using the VAE during runtime instead of defaulting to the same batch size used for training, and by setting it to 1, I was able to comfortably increase the batch size for training to 2 to 3, allowing slightly faster training.

While there is likely to be an impact on latent generation speed, and having the VAE batch size be the same as the training batch would probably be the most efficient in most cases, this modification seems beneficial in the limited niche scenario where large batch sizes would be limited by the VRAM required for dynamic latent generation