### PR TITLE
Add gradient noise scale logging

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4125,6 +4125,7 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         default=None,
         help="tags for model metadata, separated by comma / メタデータに書き込まれるモデルタグ、カンマ区切り",
     )
+    parser.add_argument("--gradient_noise_scale", action="store_true", default=False, help="Calculate the gradient noise scale")
 
     if support_dreambooth:
         # DreamBooth training

--- a/train_network.py
+++ b/train_network.py
@@ -1418,6 +1418,8 @@ class NetworkTrainer:
                             network.update_grad_norms()
                         if hasattr(network, "update_norms"):
                             network.update_norms()
+                        if args.gradient_noise_scale and hasattr(network, "accumulate_grad"):
+                            network.accumulate_grad()
 
                     optimizer.step()
                     lr_scheduler.step()
@@ -1491,6 +1493,8 @@ class NetworkTrainer:
                         mean_grad_norm,
                         mean_combined_norm,
                     )
+                    if args.gradient_noise_scale and hasattr(network, "gradient_noise_scale"):
+                        logs = {**logs, "grad/noise_scale": self.gradient_noise_scale()}
                     self.step_logging(accelerator, logs, global_step, epoch + 1)
 
                 # VALIDATION PER STEP: global_step is already incremented


### PR DESCRIPTION
https://arxiv.org/abs/1812.06162

> In this paper, we demonstrate that a simple and easy-to-measure statistic called the gradient noise scale predicts the largest useful batch size across many domains and applications, including a number of supervised learning datasets (MNIST, SVHN, CIFAR-10, ImageNet, Billion Word), reinforcement learning domains (Atari and Dota), and even generative model training (autoencoders on SVHN). We find that the noise scale increases as the loss decreases over a training run and depends on the model size primarily through improved model performance. 

| Larger batch sizes | Simple noise scale |
|--------|--------|
| ![Screenshot 2025-03-30 at 14-38-44 1812 06162v1 pdf](https://github.com/user-attachments/assets/93f7094a-ad52-4b58-a01e-72b1627cc095) | ![Screenshot 2025-03-30 at 14-36-57 1812 06162v1 pdf](https://github.com/user-attachments/assets/1d37c2c3-27ce-48e6-97e1-c6d7ee0ad61c) |  

Because we accumulate the gradient for all gradients in the LoRA network, we would want to limit the number of batches (steps) but we can associate the loss and the gradient noise scale to find the optimal batch size according to the paper. 
