### PR TITLE
Add Flash, cuDNN, Efficient attention for Flux

### DIFF
--- a/library/flux_models.py
+++ b/library/flux_models.py
@@ -18,6 +18,7 @@ import torch
 from einops import rearrange
 from torch import Tensor, nn
 from torch.utils.checkpoint import checkpoint
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from library import custom_offloading_utils
 
@@ -445,11 +446,13 @@ configs = {
 
 # region math
 
+kernels = [SDPBackend.FLASH_ATTENTION, SDPBackend.CUDNN_ATTENTION, SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
 
 def attention(q: Tensor, k: Tensor, v: Tensor, pe: Tensor, attn_mask: Optional[Tensor] = None) -> Tensor:
     q, k = apply_rope(q, k, pe)
 
-    x = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+    with sdpa_kernel(kernels, set_priority=True):
+        x = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
     x = rearrange(x, "B H L D -> B L (H D)")
 
     return x


### PR DESCRIPTION
Using `sdpa_kernel` it will pick the attention kernel based on what is available. `sdpa_kernel` is in beta still so would probably need some testing. I am currently trying flash attention 2.

Flash Attention does not support attention masks (`apply_t5_attn_mask = false`).
cuDNN may have issues but you can enable it via `TORCH_CUDNN_SDPA_ENABLED=1`.

Supported kernels may depend on your version of PyTorch and CUDA versions.

In priority order: 
```
FLASH_ATTENTION: The flash attention backend for scaled dot product attention.
CUDNN_ATTENTION: The cuDNN backend for scaled dot product attention.
EFFICIENT_ATTENTION: The efficient attention backend for scaled dot product attention.
MATH: The math backend for scaled dot product attention.
```

