### PR TITLE
Added --blocks_to_swap_while_sampling, may allow faster sample image generation

### DIFF
--- a/library/flux_models.py
+++ b/library/flux_models.py
@@ -1000,11 +1000,11 @@ class Flux(nn.Module):
             self.double_blocks = save_double_blocks
             self.single_blocks = save_single_blocks
 
-    def prepare_block_swap_before_forward(self):
+    def prepare_block_swap_before_forward(self, override_blocks_to_swap = None):
         if self.blocks_to_swap is None or self.blocks_to_swap == 0:
             return
-        self.offloader_double.prepare_block_devices_before_forward(self.double_blocks)
-        self.offloader_single.prepare_block_devices_before_forward(self.single_blocks)
+        self.offloader_double.prepare_block_devices_before_forward(self.double_blocks, override_blocks_to_swap)
+        self.offloader_single.prepare_block_devices_before_forward(self.single_blocks, override_blocks_to_swap)
 
     def forward(
         self,


### PR DESCRIPTION
I've recently switched over to doing Flux full fine tuning instead of LoRA training. But I've found that sample image generation while training is very slow. I'm using `--blocks_to_swap 35` which lets me have a batch size of 5. This block-swapping persists during sample inference, increasing sample image generation time.

The reason that block swapping is useful while training is because it saves a lot of VRAM, allowing a larger batch size, and for the memory needed for the optimizer's structures, e.g. momentum. But these are not required when doing sample image inference. If I open up nvtop I can see that my VRAM is mostly unused during this time.

This new option allows the number of blocks to swap to be set to a lower number while generating sample images. This may allow faster image generation. e.g. On my current setup where I'm using 50 sampling steps per image, putting `--blocks_to_swap_while_sampling 2` reduces the time per image from around 3 minutes to around 1 minute 48 secs. That might not sound like a big difference at first, but if I generate around 100 images over a run, this saves around 2 hours in total.