### PR TITLE
Fix: try aligning dtype of matrixes when training with deepspeed and mixed-precision is set to bf16 or fp16

### DIFF
--- a/library/deepspeed_utils.py
+++ b/library/deepspeed_utils.py
@@ -123,7 +123,10 @@ def prepare_deepspeed_model(args: argparse.Namespace, **models):
     class DeepSpeedWrapper(torch.nn.Module):
         def __init__(self, **kw_models) -> None:
             super().__init__()
+            
             self.models = torch.nn.ModuleDict()
+            
+            warp_model_forward_with_torch_autocast = args.mixed_precision is not "no"
 
             for key, model in kw_models.items():
                 if isinstance(model, list):
@@ -132,8 +135,9 @@ def prepare_deepspeed_model(args: argparse.Namespace, **models):
                 assert isinstance(
                     model, torch.nn.Module
                 ), f"model must be an instance of torch.nn.Module, but got {key} is {type(model)}"
-                
-                model = self.__warp_with_torch_autocast(model)  
+
+                if warp_model_forward_with_torch_autocast:
+                    model = self.__warp_with_torch_autocast(model)  
                 
                 self.models.update(torch.nn.ModuleDict({key: model}))
 

--- a/library/deepspeed_utils.py
+++ b/library/deepspeed_utils.py
@@ -156,7 +156,8 @@ def prepare_deepspeed_model(args: argparse.Namespace, **models):
             forward_fn = model.forward
             
             def forward(*args, **kwargs):
-                with torch.autocast(device_type="cuda"):
+                device_type= "cuda" if torch.cuda.is_available() else "cpu"
+                with torch.autocast(device_type=device_type):
                     return forward_fn(*args, **kwargs)
             model.forward = forward    
             

--- a/library/deepspeed_utils.py
+++ b/library/deepspeed_utils.py
@@ -94,6 +94,7 @@ def prepare_deepspeed_plugin(args: argparse.Namespace):
     deepspeed_plugin.deepspeed_config["train_batch_size"] = (
         args.train_batch_size * args.gradient_accumulation_steps * int(os.environ["WORLD_SIZE"])
     )
+    
     deepspeed_plugin.set_mixed_precision(args.mixed_precision)
     if args.mixed_precision.lower() == "fp16":
         deepspeed_plugin.deepspeed_config["fp16"]["initial_scale_power"] = 0  # preventing overflow.
@@ -127,13 +128,39 @@ def prepare_deepspeed_model(args: argparse.Namespace, **models):
             for key, model in kw_models.items():
                 if isinstance(model, list):
                     model = torch.nn.ModuleList(model)
+                                            
                 assert isinstance(
                     model, torch.nn.Module
                 ), f"model must be an instance of torch.nn.Module, but got {key} is {type(model)}"
+                
+                model = self.__warp_with_torch_autocast(model)  
+                
                 self.models.update(torch.nn.ModuleDict({key: model}))
 
+        def __warp_with_torch_autocast(self, model):
+            if isinstance(model, torch.nn.ModuleList):
+                for i in range(len(model)):
+                    model[i] = self.__warp_model_forward_with_torch_autocast(model[i])
+            else:
+                model = self.__warp_model_forward_with_torch_autocast(model)
+            return model
+
+        def __warp_model_forward_with_torch_autocast(self, model):
+            
+            assert hasattr(model, "forward"), f"model must have a forward method."
+
+            forward_fn = model.forward
+            
+            def forward(*args, **kwargs):
+                with torch.autocast(device_type="cuda"):
+                    return forward_fn(*args, **kwargs)
+            model.forward = forward    
+            
+            return model
+        
         def get_models(self):
             return self.models
+        
 
     ds_model = DeepSpeedWrapper(**models)
     return ds_model

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -5495,7 +5495,6 @@ def load_target_model(args, weight_dtype, accelerator, unet_use_linear_projectio
 
 
 def patch_accelerator_for_fp16_training(accelerator):
-    # patch for fp16 training
     
     from accelerate import DistributedType
     if accelerator.distributed_type == DistributedType.DEEPSPEED:

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -5495,6 +5495,12 @@ def load_target_model(args, weight_dtype, accelerator, unet_use_linear_projectio
 
 
 def patch_accelerator_for_fp16_training(accelerator):
+    # patch for fp16 training
+    
+    from accelerate import DistributedType
+    if accelerator.distributed_type == DistributedType.DEEPSPEED:
+        return
+    
     org_unscale_grads = accelerator.scaler._unscale_grads_
 
     def _unscale_grads_replacer(optimizer, inv_scale, found_inf, allow_fp16):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 accelerate==0.33.0
 transformers==4.44.0
-diffusers[torch]==0.25.0
+diffusers==0.25.0
+deepspeed==0.16.7
 ftfy==6.1.1
 # albumentations==1.3.0
 opencv-python==4.8.1.78


### PR DESCRIPTION
**What problem is going to solve in this PR?**

This PR is mainly trying fixing the problem subscribed in issue #1871 
When I tried to do some training with script`flux_train.py`, I met the same error as the issue above.
When I removed `--deepspeed` and run with low `train_batch_size` which makes training slow.

**Solution** 
I tried adding a wrapper in `deepspeed_utils.py` to wrap models' forward function with [`torch.autocast` which provides convenience methods for mixed precision](https://pytorch.org/docs/stable/amp.html).

**Changes detailed**
1. Add `__warp_with_torch_autocast` to class `DeepSpeedWrapper` in `deepspeed_utils.py`.
2. Add `deepspeed==0.16.7` requirements.
3. Remove `[torch]` from `diffusers[torch]==0.25.0` which will update torch version from the version we install manually(such as 2.4.0 here) to the latest(2.6.0 now) version  automatically.
4. Do nothing when `accelerator.distributed_type == DistributedType.DEEPSPEED` in function `patch_accelerator_for_fp16_training` of script `train_util.py` because deepspeed internally handles loss scaling for mixed precision training then `accelerator.scaler` would be None which results in the same error as [issue 476](https://github.com/bmaltais/kohya_ss/issues/476)

After these changes, the dtype error disappeared and `train_batch_size` increased from 2(without deepspeed) to 12(with deepspeed and mixed-precision) running on `8x Nvidia A100 GPUs`(81GB memory each) with command above:
```shell
accelerate launch \
  --num_cpu_threads_per_process=8 \
  --multi_gpu \
  --mixed_precision=fp16 \
  --rdzv_backend=c10d \
  "flux_train.py" \
  --output_dir="output" \
  --logging_dir="logs" \
  --max_train_epochs=60 \
  --learning_rate=2e-5 \
  --output_name=flux_test \
  --save_every_n_epochs=10 \
  --save_precision=fp16 \
  --seed=4242 \
  --max_token_length=225 \
  --caption_extension=.txt \
  --vae_batch_size=4 \
  --deepspeed \
  --zero_stage=3 \
  --ddp_timeout=120 \
  --ddp_gradient_as_bucket_view \
  --ddp_static_graph \
  --mem_eff_save \
  --clip_l="model/clip/ViT-L-14-TEXT-detail-improved-hiT-GmP-TE-only-HF.safetensors" \
  --t5xxl="model/clip/t5xxl_fp16.safetensors" \
  --apply_t5_attn_mask \
  --discrete_flow_shift=3.185 \
  --timestep_sampling=flux_shift \
  --sigmoid_scale=1 \
  --model_prediction_type=raw \
  --guidance_scale=1 \
  --ae="model/flux/ae.safetensors" \
  --cache_text_encoder_outputs \
  --cache_text_encoder_outputs_to_disk \
  --sdpa \
  --train_data_dir="data" \
  --train_batch_size=12 \
  --resolution=1024,1024 \
  --enable_bucket \
  --min_bucket_reso=256 \
  --max_bucket_reso=2048 \
  --bucket_no_upscale \
  --pretrained_model_name_or_path="model/flux/flux1-dev.safetensors" \
  --save_model_as=safetensors \
  --clip_skip=2 \
  --persistent_data_loader_workers \
  --cache_latents \
  --cache_latents_to_disk \
  --gradient_checkpointing \
  --use_8bit_adam \
  --keep_tokens=1 \
  --keep_tokens_separator="|||" \
  --secondary_separator=";;;" \
  --sample_every_n_epochs=200 \
  --sample_sampler=euler_a \
  --full_fp16 \
  --mixed_precision=fp16 \
  --gradient_accumulation_steps=1 \
  --lr_scheduler=warmup_stable_decay \
  --lr_scheduler_num_cycles=1 \
  --lr_decay_steps=0.25 \
  --lr_scheduler_min_lr_ratio=0.1

```
