### PR TITLE
Update workflows to read-all instead of write-all

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ on:
       - dev
       - sd3
 
+# CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
+permissions: read-all
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -40,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Pre-install torch to pin version (requirements.txt has dependencies like transformers which requires pytorch)
-          pip install dadaptation==3.2 torch==${{ matrix.pytorch-version }} torchvision==0.19.0 pytest==8.3.4
+          pip install dadaptation==3.2 torch==${{ matrix.pytorch-version }} torchvision pytest==8.3.4
           pip install -r requirements.txt
 
       - name: Test with pytest

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
       - reopened
 
+# CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Minor update to make less-permissive permissions. 

- Changed torchvision to not have a version which should align it with new pytorch versions (torchvision has a version for every pytorch version right now). 

```
uv tool run checkov -f .github/workflows/tests.yml
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/tests.yml
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/tests.yml
[ secrets framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/tests.ymlsts.yml
[ github_actions framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/tests.yml

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.2.426 

github_actions scan results:

Passed checks: 28, Failed checks: 0, Skipped checks: 0

Check: CKV_GHA_6: "Found artifact build without evidence of cosign sbom attestation in pipeline"
	PASSED for resource: jobs
	File: /.github/workflows/tests.yml:19-53
Check: CKV_GHA_5: "Found artifact build without evidence of cosign sign execution in pipeline"
	PASSED for resource: jobs
	File: /.github/workflows/tests.yml:19-53
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build)
	File: /.github/workflows/tests.yml:20-53
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build)
	File: /.github/workflows/tests.yml:20-53
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build)
	File: /.github/workflows/tests.yml:20-53
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build)
	File: /.github/workflows/tests.yml:20-53
Check: CKV_GHA_7: "The build output cannot be affected by user parameters other than the build entry point and the top-level source location. GitHub Actions workflow_dispatch inputs MUST be empty. "
	PASSED for resource: on(Test with pytest)
	File: /.github/workflows/tests.yml:4-17
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/tests.yml:28-34
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[2]
	File: /.github/workflows/tests.yml:33-39
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[3](Install and update pip, setuptools, wheel)
	File: /.github/workflows/tests.yml:38-44
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[4](Install dependencies)
	File: /.github/workflows/tests.yml:43-50
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[5](Test with pytest)
	File: /.github/workflows/tests.yml:49-53
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/tests.yml:28-34
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[2]
	File: /.github/workflows/tests.yml:33-39
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[3](Install and update pip, setuptools, wheel)
	File: /.github/workflows/tests.yml:38-44
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[4](Install dependencies)
	File: /.github/workflows/tests.yml:43-50
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[5](Test with pytest)
	File: /.github/workflows/tests.yml:49-53
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/tests.yml:28-34
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[2]
	File: /.github/workflows/tests.yml:33-39
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[3](Install and update pip, setuptools, wheel)
	File: /.github/workflows/tests.yml:38-44
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[4](Install dependencies)
	File: /.github/workflows/tests.yml:43-50
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[5](Test with pytest)
	File: /.github/workflows/tests.yml:49-53
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/tests.yml:28-34
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[2]
	File: /.github/workflows/tests.yml:33-39
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[3](Install and update pip, setuptools, wheel)
	File: /.github/workflows/tests.yml:38-44
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[4](Install dependencies)
	File: /.github/workflows/tests.yml:43-50
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[5](Test with pytest)
	File: /.github/workflows/tests.yml:49-53
Check: CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
	PASSED for resource: on(Test with pytest)
	File: /.github/workflows/tests.yml:15-16
```


```
uv tool run checkov -f .github/workflows/typos.yml
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/typos.yml
[ secrets framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/typos.yml
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/typos.yml
[ github_actions framework ]: 100%|████████████████████|[1/1], Current File Scanned=.github/workflows/typos.yml

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.2.426 

github_actions scan results:

Passed checks: 16, Failed checks: 0, Skipped checks: 0

Check: CKV_GHA_6: "Found artifact build without evidence of cosign sbom attestation in pipeline"
	PASSED for resource: jobs
	File: /.github/workflows/typos.yml:19-31
Check: CKV_GHA_5: "Found artifact build without evidence of cosign sign execution in pipeline"
	PASSED for resource: jobs
	File: /.github/workflows/typos.yml:19-31
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build)
	File: /.github/workflows/typos.yml:20-31
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build)
	File: /.github/workflows/typos.yml:20-31
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build)
	File: /.github/workflows/typos.yml:20-31
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build)
	File: /.github/workflows/typos.yml:20-31
Check: CKV_GHA_7: "The build output cannot be affected by user parameters other than the build entry point and the top-level source location. GitHub Actions workflow_dispatch inputs MUST be empty. "
	PASSED for resource: on(Typos)
	File: /.github/workflows/typos.yml:5-17
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/typos.yml:23-29
Check: CKV_GHA_3: "Suspicious use of curl with secrets"
	PASSED for resource: jobs(build).steps[2](typos-action)
	File: /.github/workflows/typos.yml:28-31
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/typos.yml:23-29
Check: CKV_GHA_4: "Suspicious use of netcat with IP address"
	PASSED for resource: jobs(build).steps[2](typos-action)
	File: /.github/workflows/typos.yml:28-31
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/typos.yml:23-29
Check: CKV_GHA_1: "Ensure ACTIONS_ALLOW_UNSECURE_COMMANDS isn't true on environment variables"
	PASSED for resource: jobs(build).steps[2](typos-action)
	File: /.github/workflows/typos.yml:28-31
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[1]
	File: /.github/workflows/typos.yml:23-29
Check: CKV_GHA_2: "Ensure run commands are not vulnerable to shell injection"
	PASSED for resource: jobs(build).steps[2](typos-action)
	File: /.github/workflows/typos.yml:28-31
Check: CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
	PASSED for resource: on(Typos)
	File: /.github/workflows/typos.yml:15-16
```