### PR TITLE
Overhaul of Regularization Image Loading Logic

### DIFF
--- a/library/config_util.py
+++ b/library/config_util.py
@@ -576,9 +576,10 @@ def generate_dataset_group_by_blueprint(dataset_group_blueprint: DatasetGroupBlu
     seed = random.randint(0, 2**31)  # actual seed is seed + epoch_no
     for i, dataset in enumerate(datasets):
         logger.info(f"[Dataset {i}]")
-        dataset.make_buckets()
         dataset.set_seed(seed)
-
+        dataset.incremental_reg_load()
+        dataset.make_buckets()
+        
     return DatasetGroup(datasets)
 
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1616,6 +1616,7 @@ class DreamBoothDataset(BaseDataset):
         self.latents_cache = None
         self.reg_infos: Dict[str, Tuple[ImageInfo, DreamBoothSubset]] = {}
         self.reg_infos_index: List[str] = []
+        self.reg_infos_index_traverser = 0
 
         self.enable_bucket = enable_bucket
         if self.enable_bucket:
@@ -1790,6 +1791,7 @@ class DreamBoothDataset(BaseDataset):
 
         logger.info(f"{num_reg_images} reg images.")
         self.num_reg_images = num_reg_images
+        self.reg_infos_index_traverser = 0
 
     def set_reg_randomize(self, reg_randomize = False):
         self.reg_randomize = reg_randomize

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1765,11 +1765,7 @@ class DreamBoothDataset(BaseDataset):
                 continue
 
             if subset.is_reg:
-                if subset.num_repeats > 1:
-                    info.num_repeats = 1
-                    self.reg_infos[info.image_key] = (info, subset)
-                    for i in range(subset.num_repeats):
-                        self.reg_infos_index.append(info.image_key)
+                num_reg_images += subset.num_repeats * len(img_paths)
             else:
                 num_train_images += subset.num_repeats * len(img_paths)
 
@@ -1778,7 +1774,11 @@ class DreamBoothDataset(BaseDataset):
                 if size is not None:
                     info.image_size = size
                 if subset.is_reg:
-                    reg_infos.append((info, subset))
+                    if subset.num_repeats > 1:
+                        info.num_repeats = 1
+                        self.reg_infos[info.image_key] = (info, subset)
+                        for i in range(subset.num_repeats):
+                            self.reg_infos_index.append(info.image_key)
                 else:
                     self.register_image(info, subset)
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1207,9 +1207,9 @@ class BaseDataset(torch.utils.data.Dataset):
                     if info.image_key in self.reg_infos:
                         self.reg_infos[info.image_key][0].text_encoder_outputs_npz = te_out_npz
                         self.reg_infos[info.image_key][0].te_cache_checked = True
-                        self.reg_infos[info.image_key][0]. = info.text_encoder_outputs1 = hidden_state1
-                        self.reg_infos[info.image_key][0]. = info.text_encoder_outputs2 = hidden_state2
-                        self.reg_infos[info.image_key][0]. = info.text_encoder_pool2 = pool2
+                        self.reg_infos[info.image_key][0].text_encoder_outputs1 = info.text_encoder_outputs1
+                        self.reg_infos[info.image_key][0].text_encoder_outputs2 = info.text_encoder_outputs2
+                        self.reg_infos[info.image_key][0].text_encoder_pool2 = info.text_encoder_pool2
 
     def get_image_size(self, image_path):
         return imagesize.get(image_path)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1766,7 +1766,7 @@ class DreamBoothDataset(BaseDataset):
 
             if subset.is_reg:
                 if subset.num_repeats > 1:
-                        info.num_repeats = 1
+                    info.num_repeats = 1
                     self.reg_infos[info.image_key] = (info, subset)
                     for i in range(subset.num_repeats):
                         self.reg_infos_index.append(info.image_key)

--- a/train_network.py
+++ b/train_network.py
@@ -210,13 +210,12 @@ class NetworkTrainer:
         current_step = Value("i", 0)
         
         if args.incremental_reg_reload:
-
-            train_dataset_group.set_reg_reload(args.incremental_reg_reload)
             if args.persistent_data_loader_workers:
                 logger.warning("persistent_data_loader_workers has been set to False because incremental_reg_reload is enabled.")
                 args.persistent_data_loader_workers = False
         if args.randomized_regularization_image:
             # train_dataset_group.set_reg_randomize() triggers a reload to initial state with randomized regularization images. Ensure that this occurs before initial caching to prevent data mismatch
+            logger.info("Reloading sequentially loaded regularization images to replace with randomly selected regularization images...")
             train_dataset_group.set_reg_randomize(args.randomized_regularization_image)
 
         if args.debug_dataset:
@@ -378,9 +377,6 @@ class NetworkTrainer:
 
         # dataloaderを準備する
         # DataLoaderのプロセス数：0 は persistent_workers が使えないので注意
-        if args.incremental_reg_reload:
-            logger.warning("incremental_reg_reload = True. Incremental reloading of Regularization Images requires persistent_data_loader_workers = false, overriding.")
-            args.persistent_data_loader_workers = False
             
         n_workers = min(args.max_data_loader_n_workers, os.cpu_count())  # cpu_count or max_data_loader_n_workers
 

--- a/train_network.py
+++ b/train_network.py
@@ -858,7 +858,6 @@ class NetworkTrainer:
             )
 
         loss_recorder = train_util.LossRecorder()
-        del train_dataset_group
 
         # callback for step start
         if hasattr(accelerator.unwrap_model(network), "on_step_start"):

--- a/train_network.py
+++ b/train_network.py
@@ -8,6 +8,7 @@ import time
 import json
 from multiprocessing import Value
 import toml
+import copy
 
 from tqdm import tqdm
 
@@ -135,6 +136,11 @@ class NetworkTrainer:
         train_util.sample_images(accelerator, args, epoch, global_step, device, vae, tokenizer, text_encoder, unet)
 
     def train(self, args):
+        # acceleratorを準備する
+        logger.info("preparing accelerator")
+        accelerator = train_util.prepare_accelerator(args)
+        is_main_process = accelerator.is_main_process
+
         session_id = random.randint(0, 2**32)
         training_started_at = time.time()
         train_util.verify_training_args(args)
@@ -202,8 +208,16 @@ class NetworkTrainer:
 
         current_epoch = Value("i", 0)
         current_step = Value("i", 0)
-        ds_for_collator = train_dataset_group if args.max_data_loader_n_workers == 0 else None
-        collator = train_util.collator_class(current_epoch, current_step, ds_for_collator)
+        
+        if args.incremental_reg_reload:
+
+            train_dataset_group.set_reg_reload(args.incremental_reg_reload)
+            if args.persistent_data_loader_workers:
+                logger.warning("persistent_data_loader_workers has been set to False because incremental_reg_reload is enabled.")
+                args.persistent_data_loader_workers = False
+        if args.randomized_regularization_image:
+            # train_dataset_group.set_reg_randomize() triggers a reload to initial state with randomized regularization images. Ensure that this occurs before initial caching to prevent data mismatch
+            train_dataset_group.set_reg_randomize(args.randomized_regularization_image)
 
         if args.debug_dataset:
             train_util.debug_dataset(train_dataset_group)
@@ -220,11 +234,6 @@ class NetworkTrainer:
             ), "when caching latents, either color_aug or random_crop cannot be used / latentをキャッシュするときはcolor_augとrandom_cropは使えません"
 
         self.assert_extra_args(args, train_dataset_group)
-
-        # acceleratorを準備する
-        logger.info("preparing accelerator")
-        accelerator = train_util.prepare_accelerator(args)
-        is_main_process = accelerator.is_main_process
 
         # mixed precisionに対応した型を用意しておき適宜castする
         weight_dtype, save_dtype = train_util.prepare_dtype(args)
@@ -263,23 +272,24 @@ class NetworkTrainer:
 
             accelerator.print(f"all weights merged: {', '.join(args.base_weights)}")
 
-        # 学習を準備する
-        if cache_latents:
-            vae.to(accelerator.device, dtype=vae_dtype)
-            vae.requires_grad_(False)
-            vae.eval()
-            with torch.no_grad():
-                train_dataset_group.cache_latents(vae, args.vae_batch_size, args.cache_latents_to_disk, accelerator.is_main_process)
-            vae.to("cpu")
-            clean_memory_on_device(accelerator.device)
 
-            accelerator.wait_for_everyone()
-
-        # 必要ならテキストエンコーダーの出力をキャッシュする: Text Encoderはcpuまたはgpuへ移される
-        # cache text encoder outputs if needed: Text Encoder is moved to cpu or gpu
-        self.cache_text_encoder_outputs_if_needed(
-            args, accelerator, unet, vae, tokenizers, text_encoders, train_dataset_group, weight_dtype
-        )
+        '''
+        Replacing cache latents and cache text encoder outputs here with code to simulate running through self.cache_text_encoder_outputs_if_needed().
+        Reduces unnecessary caching by avoiding caching until data loaded into train_dataset_group has been finalized.
+        This step is required to ensure text_encoders are loaded onto the correct device for the training.
+        Possibly should replace with method that can be overridden for different handling of TE for different models.
+        '''
+        if args.cache_text_encoder_outputs and self.is_sdxl:
+            # When TE is not be trained, it will not be prepared so we need to use explicit autocast
+            for t_enc in text_encoders:
+                t_enc.to("cpu", dtype=torch.float32) # Text Encoder doesn't work with fp16 on CPU
+        else:
+            # Text Encoderから毎回出力を取得するので、GPUに乗せておく
+            if not self.is_sdxl:
+                accelerator.print("Text Encoder caching not supported. Overriding args.cache_text_encoder_output to False")
+                args.cache_text_encoder_outputs = False
+            for t_enc in text_encoders:
+                t_enc.to(accelerator.device, dtype=weight_dtype)
 
         # prepare network
         net_kwargs = {}
@@ -368,8 +378,15 @@ class NetworkTrainer:
 
         # dataloaderを準備する
         # DataLoaderのプロセス数：0 は persistent_workers が使えないので注意
+        if args.incremental_reg_reload:
+            logger.warning("incremental_reg_reload = True. Incremental reloading of Regularization Images requires persistent_data_loader_workers = false, overriding.")
+            args.persistent_data_loader_workers = False
+            
         n_workers = min(args.max_data_loader_n_workers, os.cpu_count())  # cpu_count or max_data_loader_n_workers
 
+        ds_for_collator = train_dataset_group if args.max_data_loader_n_workers == 0 else None
+        collator = train_util.collator_class(current_epoch, current_step, ds_for_collator)
+        
         train_dataloader = torch.utils.data.DataLoader(
             train_dataset_group,
             batch_size=1,
@@ -885,6 +902,8 @@ class NetworkTrainer:
             for skip_epoch in range(epoch_to_start):  # skip epochs
                 logger.info(f"skipping epoch {skip_epoch+1} because initial_step (multiplied) is {initial_step}")
                 initial_step -= len(train_dataloader)
+                if args.incremental_reg_reload:
+                    train_dataset_group.incremental_reg_load(True) # Updates the loaded dataset to the next epoch
             global_step = initial_step
 
         for epoch in range(epoch_to_start, num_train_epochs):
@@ -892,6 +911,39 @@ class NetworkTrainer:
             current_epoch.value = epoch + 1
 
             metadata["ss_epoch"] = str(epoch + 1)
+
+            if epoch == epoch_to_start or args.incremental_reg_reload:
+                if cache_latents:
+                    vae.to(accelerator.device, dtype=vae_dtype)
+                    vae.requires_grad_(False)
+                    vae.eval()
+                    with torch.no_grad():
+                        train_dataset_group.cache_latents(vae, args.vae_batch_size, args.cache_latents_to_disk, accelerator.is_main_process)
+                    vae.to("cpu")
+                    clean_memory_on_device(accelerator.device)
+
+                    accelerator.wait_for_everyone()
+
+                    # 必要ならテキストエンコーダーの出力をキャッシュする: Text Encoderはcpuまたはgpuへ移される
+                    # cache text encoder outputs if needed: Text Encoder is moved to cpu or gpu
+                self.cache_text_encoder_outputs_if_needed(
+                    args, accelerator, unet, vae, tokenizers, text_encoders, train_dataset_group, weight_dtype
+                )
+                accelerator.wait_for_everyone() # Ensure all processes sync after potential dataset/cache changes in initial_step block
+
+                ds_for_collator = train_dataset_group if args.max_data_loader_n_workers == 0 else None
+                collator = train_util.collator_class(current_epoch, current_step, ds_for_collator)
+
+                train_dataloader = torch.utils.data.DataLoader(
+                    train_dataset_group, # This is the updated train_dataset_group
+                    batch_size=1, 
+                    shuffle=True, 
+                    collate_fn=collator,
+                    num_workers=n_workers, # Ensure n_workers is available
+                    persistent_workers=args.persistent_data_loader_workers,
+                )
+                accelerator.wait_for_everyone()
+                train_dataloader = accelerator.prepare(train_dataloader)
 
             accelerator.unwrap_model(network).on_epoch_start(text_encoder, unet)
 
@@ -1091,6 +1143,9 @@ class NetworkTrainer:
                         train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
             self.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
+            # Load next batch of regularization images if necessary
+            if args.incremental_reg_reload and epoch + 1 < num_train_epochs:
+                train_dataset_group.incremental_reg_load(True)
 
             # end of epoch
 


### PR DESCRIPTION
In the original implementation of the regularization image loading, the code will load the first N regularization images, where N is number of training images * number of repeats.

this leads to a couple of edge cases where there could be suboptimal results for training when considering use cases for training on free resources such as google colab which limits the number of hours training can run per day. when the number of regularization images is not equal to N. When N is greater, due to the first few images consistently having additional repeats added to the dataset can, over extended training over muliple epochs and/or resumed training, lead to them having stronger influence on the training model.

When N is lessor than the number of regularization images available, this means that some training strategies which make use of the regularization images to simultaneously improve the overall quality by adding additional ground truth images would not be able to fully utilize all the prepared regularization images and captions. 

Additionally use of multiple subsets to organize categories of regularization images may result in training being weighted unintentionally by user to specific concepts based on the order the subsets are loaded.

This pull request intends to migitate this by implementing two training strategies:-
1. Randomized loading of regularization images
 - This shuffles the order by which regularization images are loaded, resulting in more even distribution of available regularization images being loaded.
2. Incremental loading of regularization images
  - This option causes the dataset to reload the regularization images, walking down the list (and looping back to the start when the list is exhausted) and loading the next N regularization images on each epoch

Both strategies can by activated separately, together and turned off completely (returning to the original loading strategy by default) using the arguements `--incremental_reg_load` and `--randomized_regularization_image`

Points to consider:
- If using  `--incremental_reg_load`, the length of the dataloader will vary between epochs, especially when using buckets due to possible different number of batchs available.
- If using  `--incremental_reg_load`, persistent dataloader workers would not work as the dataloaders have to be recreated at the start of each epoch in order to correctly update the number of batches available.
- Attempts at bypassing this by triggering the reloads in the set_current_epoch method in the BaseDataset class have failed, due to inability to propogate updated `__len__()` values to enclosing DatasetGroup class.
- The use of multiprocessing dataloader workers also complicates syncing data back to the mainthread, resulting in unexpected behaivour.
- To implement a more efficient caching strategy of only caching images that are going to be trained, the `cache_text_encoder_outputs_if_needed()` function had to be moved to just before training starts for the epoch.
- To ensure the text encoders are in the correct device, placeholder code to move the models following the logic of `cache_text_encoder_outputs_if_needed()` was put in place as [here](https://github.com/DKnight54/sd-scripts/blob/6fff6cc33e62e69d79edf6184c81da6fb917cde4/train_network.py#L281-L291).

As this is a proof of concept only, it is implemented only in the LoRA training script for SD1.5 and SDXL.

Please let me know if you have any questions