### PR TITLE
Add IVON optimizer support

### DIFF
--- a/library/network_utils.py
+++ b/library/network_utils.py
@@ -1,0 +1,15 @@
+def maybe_sample_params(optimizer):
+    """
+    Returns parameter sampling context for IVON optimizers, otherwise returns no-op context.
+
+    pip install ivon-opt
+
+    Args:
+        optimizer: PyTorch optimizer instance.
+
+    Returns:
+        Context manager for parameter sampling if optimizer supports it, otherwise nullcontext().
+    """
+    from contextlib import nullcontext
+
+    return optimizer.sampled_params(train=True) if hasattr(optimizer, "sampled_params") else nullcontext()


### PR DESCRIPTION
https://arxiv.org/abs/2506.14280
https://github.com/team-approx-bayes/ivon
https://arxiv.org/abs/2402.17641

I'm just trying it out so I dunno if it's good or not. 

Requires `ivon-opt` but only works with my branch because of device, mixed precision, and gradient accumulation issues. 

 ```
pip install git+https://github.com/rockerBOO/ivon@gradient-accumulation
```

```
unet_lr = 1e-4 # Same LR you'd use for Adam
optimizer_type = "ivon.IVON"
optimizer_args = [
    "ess=400" # ess should be the number of items in your dataset. Maybe just the number of items per epoch?
]
```

Default parameters:

```python
        ess: float,
        hess_init: float = 1.0,
        beta1: float = 0.9,
        beta2: float = 0.99999,
        weight_decay: float = 1e-4,
        mc_samples: int = 1,
        hess_approx: str = 'price',
        clip_radius: float = float("inf"),
        sync: bool = False,
        debias: bool = True,
        rescale_lr: bool = True
```