### PR TITLE
Added warning for buckets without enough images to half fill a batch

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1060,6 +1060,21 @@ class BaseDataset(torch.utils.data.Dataset):
                     self.bucket_info["buckets"][i] = {"resolution": reso, "count": len(bucket)}
                     logger.info(f"bucket {i}: resolution {reso}, count: {len(bucket)}")
 
+            # Warn of any particularly small buckets compared to the current batch size
+            already_warned_underfilled_bucket = False
+            for i, bucket in enumerate(self.bucket_manager.buckets):
+                if len(bucket) < (self.batch_size / 2):
+
+                    if not already_warned_underfilled_bucket:
+                        logger.warning(f"These buckets have too few entries to even half fill the batch_size:")
+                        already_warned_underfilled_bucket = True
+
+                    img_filename = bucket[0]
+                    display_filename_len = 55
+                    if len(img_filename) > display_filename_len:
+                        img_filename = f"...{img_filename[-(display_filename_len - 3):]}"
+                    logger.warning(f"  Bucket {self.bucket_manager.resos[i]} e.g. '{img_filename}'")
+
             if len(img_ar_errors) == 0:
                 mean_img_ar_error = 0  # avoid NaN
             else:


### PR DESCRIPTION
Some people are using the `--train_batch_size` command line option without realizing that they are regularly doing training steps that have a batch size of (e.g.) just 1 due to image bucketing. It's likely that many people don't even know what image bucketing is, and are unaware that there's even a problem. Underfilled buckets can significantly damage batched training, reducing image quality.

This change introduces a clear warning if buckets are underfilled for the current batch size - defined as a bucket that's less than half of the batch size. e.g.:

![image](https://github.com/user-attachments/assets/adb9c047-b083-4e46-a7ea-d40886f78db8)

So for a batch size of 5, the buckets must have at least 3 images in them to not trigger the warning. For training that isn't using batches, the warning doesn't appear at all.

For those who don't know, batches can only be formed from images found in a single bucket at a time. If a bucket has a single image in it, the batch size will be 1 for that training step, irrespective of what the `--train_batch_size` is set to. (Gradient accumulation doesn't suffer from this limitation.)

This debug output is useful even for people who do know what buckets are, as it names (the end of) an example image filename from each bucket that's considered to be underfilled. This is because there are people who notice that they have a bucket with (e.g.) one image in it, but they don't know exactly which one it was. It's not even possible to trivially search by image size, as images are clipped down to multiples of the bucket resolution.