### PR TITLE
Fix alphas cumprod after add_noise for DDIMScheduler

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -6008,6 +6008,8 @@ def get_noise_noisy_latents_and_timesteps(
     else:
         noisy_latents = noise_scheduler.add_noise(latents, noise, timesteps)
 
+    noise_scheduler.alphas_cumprod = noise_scheduler.alphas_cumprod.cpu()
+
     return noise, noisy_latents, timesteps
 
 


### PR DESCRIPTION
Fixes #2102 

The issue is 

https://github.com/kohya-ss/sd-scripts/blob/7c075a9c8d234fccf8e0d66b9538a0b17bf4b13f/library/train_util.py#L5977-L6011

noise_scheduler.add_noise() moves the alphas_cumprod to the GPU

And you can see it how it is working in the DDIMScheduler

https://github.com/huggingface/diffusers/blob/a4df8dbc40e170ff828f8d8f79c2c861c9f1748d/src/diffusers/schedulers/scheduling_ddim.py#L474-L498

So this issue is for sd and sdxl models specifically. We can move the alphas_cumprod back to the CPU after. 