### PR TITLE
Big image quality improvement! Kahan summation for Adafactor-optimized Flux FFT

### DIFF
--- a/flux_train.py
+++ b/flux_train.py
@@ -381,9 +381,24 @@ def train(args):
             raise ValueError("Schedule-free optimizer is not supported with blockwise fused optimizers")
         optimizer_train_fn = lambda: None  # dummy function
         optimizer_eval_fn = lambda: None  # dummy function
+
+        if args.optimizer_type == "adafactor" and args.full_bf16:
+            logger.warning("Use of --blockwise_fused_optimizers with Adafactor optimizer prevents stochastic/kahan weight updates.")
     else:
         _, _, optimizer = train_util.get_optimizer(args, trainable_params=params_to_optimize)
         optimizer_train_fn, optimizer_eval_fn = train_util.get_optimizer_train_eval_fn(optimizer, args)
+
+    # Pass any Kahan summation arg to the optimizer
+    if args.kahan_summation:
+        # Self check parameter compatibility
+        if args.optimizer_type != "adafactor":
+            logger.warning("Kahan summation has been requested, but currently this is only supported by the supplied Adafactor optimizer.")
+        if not args.full_bf16:
+            logger.warning("Kahan summation require --full_bf16")
+        if args.blockwise_fused_optimizers:
+            logger.warning("Kahan summation has been requested, but it is incompatible with --blockwise_fused_optimizer. "\
+                           "Perhaps try --fused_backward_pass instead.")
+    optimizer.use_kahan_summation = args.kahan_summation
 
     # prepare dataloader
     # strategies are set here because they cannot be referenced in another process. Copy them with the dataset
@@ -816,6 +831,12 @@ def setup_parser() -> argparse.ArgumentParser:
         help="enable blockwise optimizers for fused backward pass and optimizer step / fused backward passとoptimizer step のためブロック単位のoptimizerを有効にする",
     )
     parser.add_argument(
+        "--kahan-summation",
+        action="store_true",
+        help="Offloads to CPU the float parts lost during bf16 quantization, and re-adds them to the next step / "\
+            "bf16 量子化中に失われた浮動小数点部分を CPU にオフロードし、次のステップに再度追加します",
+    )
+    parser.add_argument(
         "--skip_latents_validity_check",
         action="store_true",
         help="[Deprecated] use 'skip_cache_check' instead / 代わりに 'skip_cache_check' を使用してください",
@@ -838,13 +859,3 @@ def setup_parser() -> argparse.ArgumentParser:
         help="[EXPERIMENTAL] enable offloading of tensors to CPU during checkpointing / チェックポイント時にテンソルをCPUにオフロードする",
     )
     return parser
-
-
-if __name__ == "__main__":
-    parser = setup_parser()
-
-    args = parser.parse_args()
-    train_util.verify_command_line_training_args(args)
-    args = train_util.read_config_from_file(args, parser)
-
-    train(args)


### PR DESCRIPTION
If you've been doing full fine tuning with Flux, you've likely seen the image quality improvements that the stochastic rounding feature (available when using `--fused_backward-pass` with the supplied Adafactor optimizer`) can offer. That feature improves the casting of the f32 'weight + gradient update' values back to bf16 during each training step by randomly moving the value either up or down to the next rounded bfloat16 value, depending on the distance the f32 value is between the two adjacent quantized bf16 values.

But although stochastic rounding offers a large improvement to bf16 training, its randomness doesn't always produce ideal results. As the "Revisiting BFloat16 Training" paper - https://arxiv.org/pdf/2010.06192 - notes:

> "using stochastic rounding alone could not fully match 32-bit training on all models."

This same paper then goes on to note a different technique - **Kahan summation** - that does match the performance of 32-bit training:

> "To address this, we show that Kahan summation for model weight updates closes remaining gaps on all the models we consider"

Kahan summation is a technique where the f32 values are rounded to the nearest bf16 value, and then the offset between the original f32 and the quantized bf16 value is recorded. This offset is then sent back to the CPU so it doesn't use up VRAM past that point. Then, on the next training step, instead of just taking the bf16 weight value plus the gradient update for that step, the offset that was lost from the previous step is added back on as well. And then that process is repeated.

It means that a bf16 value that is updating by (e.g.) 20% of the distance between that bf16 value and the next adjacent bf16 value will go up once in every 5 training steps, rather than stochastic rounding's random approximation of once in every 5 steps. Stochastic rounded values bounce up and down fairly unpredictably, but the Kahan summed values are more stable.

The technique comes at a price: training steps take nearly twice as long in my tests so far. (I'm training at batch size 5 on a 5090 RTX card). So it's probably best to use stochastic rounding for most of the training, and then switch to Kahan summation with `--kahan-summation` for the final polish phase. The slowdown comes from copying the values from the GPU to main memory and back again on each step.

Now I've implemented Kahan summation in sd-scripts, the quality improvements that it achieves are impressive. Flux.dev training does seem to be one of the cases where Kahan summation significantly exceeds stochastic rounding in terms of image quality. Very low LRs such as 2e-7 (which suffer quantization randomness with stochastic rounding) work great with Kahan summation.

If you (e.g. @kohya-ss) want to see what this feature can do, then why not grab this branch ,switch on `--kahan-summation`, set the LR to 2e-7 and the batch size to 5, and then try running a final polish pass on an already-trained FFT model that you have? The quality improvements are almost immediate, as it allows the weights to 'settle' into a more stable pattern.