### PR TITLE
Fix validation split for subsets

### DIFF
--- a/library/config_util.py
+++ b/library/config_util.py
@@ -197,6 +197,7 @@ class ConfigSanitizer:
         "caption_prefix": str,
         "caption_suffix": str,
         "custom_attributes": dict,
+        "validation_split": float,
         "resize_interpolation": str,
     }
     # DO means DropOut


### PR DESCRIPTION
Subsets could not get a separate validation split but it is supported. Might also want to add `validation_seed` but I have not tested it. 