### PR TITLE
Fix the 'off by 1' problem in dynamically resized LoRA rank

### DIFF
--- a/networks/resize_lora.py
+++ b/networks/resize_lora.py
@@ -78,7 +78,7 @@ def index_sv_fro(S, target):
 def index_sv_ratio(S, target):
     max_sv = S[0]
     min_sv = max_sv / target
-    index = int(torch.sum(S > min_sv).item())
+    index = int(torch.sum(S > min_sv).item()) - 1
     index = max(0, min(index, len(S) - 1))
 
     return index


### PR DESCRIPTION
If I understand correctly, the index returned by `index_sv_cumulative` and `index_sv_fro` is larger by 1 than it should be. For example, `torch.searchsorted` works like this:
```python3
>>> cumulative_sums = torch.tensor([0.9, 0.95, 1.0])
>>> print(torch.searchsorted(cumulative_sums, 0.94))
tensor(1)
>>> print(torch.searchsorted(cumulative_sums, 0.95))
tensor(1)
>>> print(torch.searchsorted(cumulative_sums, 0.96))
tensor(2)
```
If the user wants to keep 94% or 95% of `S`, then `index` should be 1 (and `new_rank` in the function `rank_resize` should be 2).

This problem is particularly visible when the new LoRA is rank 1 (I've seen many LoRAs on the internet that are almost rank 1). In the example above, if the user wants to keep 80% or 90% of `S`, then `index` should be 0, and `new_rank` should be 1.