### PR TITLE
Fix validation dataset documentation to not use subsets

### DIFF
--- a/docs/flux_train_network.md
+++ b/docs/flux_train_network.md
@@ -577,7 +577,7 @@ validation_split = 1.0 # Will use this full subset as a validation subset.
 **Notes:**
 
 * Validation loss calculation uses fixed timestep sampling and random seeds to reduce loss variation due to randomness for more stable evaluation.
-* Currently, validation loss is not supported when using `--blocks_to_swap` or Schedule-Free optimizers (`AdamWScheduleFree`, `RAdamScheduleFree`, `ProdigyScheduleFree`).
+* Currently, validation loss is not supported when using Schedule-Free optimizers (`AdamWScheduleFree`, `RAdamScheduleFree`, `ProdigyScheduleFree`).
 
 <details>
 <summary>日本語</summary>


### PR DESCRIPTION
Subsets are not yet supported for validation_split so updating the documentation to show how to organize the validation splits. 

Related #2190 