### PR TITLE
Chroma fix t5

### DIFF
--- a/flux_train_network.py
+++ b/flux_train_network.py
@@ -36,6 +36,7 @@ class FluxNetworkTrainer(train_network.NetworkTrainer):
         self.is_schnell: Optional[bool] = None
         self.is_swapping_blocks: bool = False
         self.model_type: Optional[str] = None
+        self.args = None
 
     def assert_extra_args(
         self,

--- a/train_network.py
+++ b/train_network.py
@@ -416,9 +416,6 @@ class NetworkTrainer:
         else:
             # For debugging
             logger.debug(f"text_encoder_outputs_list is None, batch keys: {list(batch.keys())}")
-        else:
-            # For debugging
-            print(f"text_encoder_outputs_list is None, batch keys: {list(batch.keys())}")
 
         # For Chroma, text_encoder_conds might be set up differently
         # Check if we need to encode text encoders

--- a/train_network.py
+++ b/train_network.py
@@ -427,7 +427,11 @@ class NetworkTrainer:
                         weights_list,
                     )
                 else:
-                    input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]
+                    # Handle Chroma case where CLIP-L tokens might be None
+                    input_ids = []
+                    for ids in batch["input_ids_list"]:
+                        if ids is not None:  # Skip None values (CLIP-L tokens for Chroma)
+                            input_ids.append(ids.to(accelerator.device))
                     encoded_text_encoder_conds = text_encoding_strategy.encode_tokens(
                         tokenize_strategy,
                         self.get_models_for_text_encoding(args, accelerator, text_encoders),

--- a/train_network.py
+++ b/train_network.py
@@ -480,6 +480,7 @@ class NetworkTrainer:
         return loss.mean()
 
     def train(self, args):
+        self.args = args  # store args for later use
         session_id = random.randint(0, 2**32)
         training_started_at = time.time()
         train_util.verify_training_args(args)


### PR DESCRIPTION
Hi, I was getting an error when trying to train chroma : 
```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/INTEL_SSD/github/fluxgym/sd-scripts/flux_train_network.py", line 547, in <module>
[rank1]:     trainer.train(args)
[rank1]:   File "/INTEL_SSD/github/fluxgym/sd-scripts/train_network.py", line 1403, in train
[rank1]:     loss = self.process_batch(
[rank1]:            ^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/INTEL_SSD/github/fluxgym/sd-scripts/train_network.py", line 430, in process_batch
[rank1]:     input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]
[rank1]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]: TypeError: 'NoneType' object is not iterable
[rank0]: Traceback (most recent call last):
[rank0]:   File "/INTEL_SSD/github/fluxgym/sd-scripts/flux_train_network.py", line 547, in <module>
[rank0]:     trainer.train(args)
[rank0]:   File "/INTEL_SSD/github/fluxgym/sd-scripts/train_network.py", line 1403, in train
[rank0]:     loss = self.process_batch(
[rank0]:            ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/INTEL_SSD/github/fluxgym/sd-scripts/train_network.py", line 430, in process_batch
[rank0]:     input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]
[rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: 'NoneType' object is not iterable
```
Command : 
```
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True accelerate launch \
  --mixed_precision bf16 \
  --num_cpu_threads_per_process 1 \
  /INTEL_SSD/github/fluxgym/sd-scripts/flux_train_network.py \
  --model_type chroma \
  --pretrained_model_name_or_path "/INTEL_SSD/github/fluxgym/models/unet/chroma_v10HD.safetensors" \
  --t5xxl "/INTEL_SSD/github/fluxgym/models/clip/t5xxl_fp16.safetensors" \
  --ae "/INTEL_SSD/github/fluxgym/models/vae/ae.sft" \
  --apply_t5_attn_mask \
  --cache_latents_to_disk \
  --cache_text_encoder_outputs \
  --cache_text_encoder_outputs_to_disk \
  --dataset_config "./dataset.toml" \
  --discrete_flow_shift 3.1582 \
  --fp8_base \
  --gradient_accumulation_steps 16 \
  --gradient_checkpointing \
  --guidance_scale 0.0 \
  --highvram \
  --learning_rate 5e-4 \
  --loss_type l2 \
  --max_data_loader_n_workers 2 \
  --max_train_epochs 15 \
  --mixed_precision bf16 \
  --model_prediction_type raw \
  --network_alpha 32 \
  --network_dim 64 \
  --network_module networks.lora_flux \
  --optimizer_type adamw8bit \
  --output_dir "../chroma" \
  --output_name chroma-busty-neo-lora \
  --sample_every_n_steps 10 \
  --sample_prompts "../sample_prompts_chroma.txt" \
  --save_every_n_epochs 1 \
  --save_every_n_steps 10 \
  --save_last_n_steps 15 \
  --save_model_as safetensors \
  --save_precision bf16 \
  --sdpa --persistent_data_loader_workers \
  --seed 42 \
  --network_args "ggpo_sigma=0.03" "ggpo_beta=0.01" "split_qkv=True" "target_module=models.layers"      \
  --timestep_sampling sigmoid
```
Tried `SD3` branch and `fix-chroma-training-withtout-te-cache` branch, both failed.

So I asked help from deepseek and got at this point in my investigation : 
-----------------------

Looking at the code, the issue is in the process_batch method in train_network.py at line 430. The problem is that Chroma doesn't use CLIP-L, but the code assumes both text encoders are present.                                                                                                                                                                                            

Here's the specific fix needed:                                                                                                                                                                                                                                                                                                                                                               

In train_network.py around line 430, modify the code to handle Chroma models differently:                                                                                                                                                                                                                                                                                                     

```python                                                                                                                                                                                                                                                                                                                                                                                              
# Replace this line:                                                                                                                                                                                                                                                                                                                                                                          
# input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                              
# With this:                                                                                                                                                                                                                                                                                                                                                                                  
if hasattr(self, 'model_type') and self.model_type == "chroma":                                                                                                                                                                                                                                                                                                                               
    # Chroma doesn't use CLIP-L, so we need to handle this differently                                                                                                                                                                                                                                                                                                                        
    # For Chroma, we should use T5 tokens instead                                                                                                                                                                                                                                                                                                                                             
    if "t5_input_ids" in batch and batch["t5_input_ids"] is not None:                                                                                                                                                                                                                                                                                                                         
        input_ids = [batch["t5_input_ids"].to(accelerator.device)]                                                                                                                                                                                                                                                                                                                            
    else:                                                                                                                                                                                                                                                                                                                                                                                     
        # Fallback: create empty list since CLIP-L isn't used                                                                                                                                                                                                                                                                                                                                 
        input_ids = []                                                                                                                                                                                                                                                                                                                                                                        
else:                                                                                                                                                                                                                                                                                                                                                                                         
    input_ids = [ids.to(accelerator.device) for ids in batch["input_ids_list"]]                                                                                                                                                                                                                                                                                                               
```                                                                                                                                                                                                                                                                                                                                                                                              

However, this is a deeper architectural issue. The real problem is that the dataset preparation for Chroma needs to be handled differently. Looking at the code structure:                                                                                                                                                                                                                    

 1 In flux_train_network.py, the FluxNetworkTrainer class needs to override the tokenization strategy for Chroma                                                                                                                                                                                                                                                                              
 2 The tokenization strategy should skip CLIP-L processing for Chroma models                                                                                                                                                                                                                                                                                                                  
 3 The dataset should provide T5 tokens instead of CLIP tokens for Chroma                                                                                                                                                                                                                                                                                                                     

Better solution: Modify the get_tokenize_strategy method in FluxNetworkTrainer to handle Chroma differently:                                                                                                                                                                                                                                                                                  

```python                                                                                                                                                                                                                                                                                                                                                                                              
def get_tokenize_strategy(self, args):                                                                                                                                                                                                                                                                                                                                                        
    if self.model_type == "chroma":                                                                                                                                                                                                                                                                                                                                                           
        # For Chroma, only use T5 tokenizer, skip CLIP-L                                                                                                                                                                                                                                                                                                                                      
        t5xxl_max_length = 512  # Chroma uses full T5 context                                                                                                                                                                                                                                                                                                                                 
        return strategy_flux.FluxTokenizeStrategy(t5xxl_max_length, args.tokenizer_cache_dir, use_clip_l=False)                                                                                                                                                                                                                                                                               
    else:                                                                                                                                                                                                                                                                                                                                                                                     
        # Original logic for FLUX models                                                                                                                                                                                                                                                                                                                                                      
        _, is_schnell, _, _ = flux_utils.analyze_checkpoint_state(args.pretrained_model_name_or_path)                                                                                                                                                                                                                                                                                         
        if args.t5xxl_max_token_length is None:                                                                                                                                                                                                                                                                                                                                               
            t5xxl_max_token_length = 256 if is_schnell else 512                                                                                                                                                                                                                                                                                                                               
        else:                                                                                                                                                                                                                                                                                                                                                                                 
            t5xxl_max_token_length = args.t5xxl_max_token_length                                                                                                                                                                                                                                                                                                                              
        return strategy_flux.FluxTokenizeStrategy(t5xxl_max_token_length, args.tokenizer_cache_dir)                                                                                                                                                                                                                                                                                           
 ```                                                                                                                                                                                                                                                                                                                                                                                             

You would also need to modify the FluxTokenizeStrategy to support use_clip_l=False for Chroma models, and ensure the dataset provides the correct tokenization outputs.                                                                                                                                                                                                                       

This is a fundamental architectural issue where Chroma support wasn't fully implemented in the training pipeline.                                                                                                                                                                                                                                                                             

------

So I went up with it's help to fix all issues.

I just started a training run. Seems to work !

Also, the major difference from Flux Dev is that with Chroma I can batch size `4` instead of `2` on 2x3090.
VRAM is at 23.787 

All images where cropped/scaled to 1024. Not sure it it makes a difference.

Not sure this code is up to standard or has not created other issues.
For now it trains, possible issues with quality due to code changes ?

Posting here to help others.