### PR TITLE
Bump `pytorch-optimizer` version to v3.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ einops==0.7.0
 bitsandbytes
 lion-pytorch==0.2.3
 schedulefree==1.4
-pytorch-optimizer==3.7.0
+pytorch-optimizer==3.9.0
 prodigy-plus-schedule-free==1.9.2
 prodigyopt==1.1.2
 tensorboard


### PR DESCRIPTION
## Note

related to https://github.com/kozistr/pytorch_optimizer/issues/462,

LoRA training in Kohya_ss could fail when module dropout was enabled together with `pytorch-optimizer` optimizers due to the lazy initialization scheme. This issue has been fixed and released in v3.9.0.

You can also check out the changelog [here](https://github.com/kozistr/pytorch_optimizer/releases)!

Thanks to @JHawkley for bringing this up!