### PR TITLE
Fix AttributeError for UNet2DConditionModel with newer diffusers versions

### DIFF
--- a/sdxl_gen_img.py
+++ b/sdxl_gen_img.py
@@ -15,6 +15,12 @@ import random
 import re
 
 import diffusers
+
+# Compatible import for diffusers old/new UNet path
+try:
+    from diffusers.models.unet_2d_condition import UNet2DConditionModel
+except ImportError:
+    from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel
 import numpy as np
 
 import torch
@@ -80,7 +86,7 @@ CLIP_VISION_MODEL = "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k"
 """
 
 
-def replace_unet_modules(unet: diffusers.models.unet_2d_condition.UNet2DConditionModel, mem_eff_attn, xformers, sdpa):
+def replace_unet_modules(unet: UNet2DConditionModel, mem_eff_attn, xformers, sdpa):
     if mem_eff_attn:
         logger.info("Enable memory efficient attention for U-Net")
 


### PR DESCRIPTION
Recent versions of diffusers moved UNet2DConditionModel to:
diffusers.models.unets.unet_2d_condition

This change fixes the following error that occurs when using newer diffusers versions
(e.g. diffusers[torch]==0.32.1):

AttributeError: module 'diffusers.models' has no attribute 'unet_2d_condition'

It also adds a backward-compatible import fallback so that sdxl_gen_img.py
works with both older and newer diffusers versions.

Tested with diffusers 0.24.x and 0.32.x.
