### PR TITLE
Release 0.10.1

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -50,6 +50,11 @@ Stable Diffusion等の画像生成モデルの学習、モデルによる画像�
 
 ### 更新履歴
 
+- **Version 0.10.1 (2026-02-13):**
+  - [Anima Preview](https://huggingface.co/circlestone-labs/Anima)モデルのLoRA学習およびfine-tuningをサポートしました。[PR #2260](https://github.com/kohya-ss/sd-scripts/pull/2260) および[PR #2261](https://github.com/kohya-ss/sd-scripts/pull/2261)
+  - 素晴らしいモデルを公開された CircleStone Labs、および PR #2260を提出していただいたduongve13112002氏に深く感謝します。
+  - 詳細は[ドキュメント](./docs/anima_train_network.md)をご覧ください。
+
 - **Version 0.10.0 (2026-01-19):**
   - `sd3`ブランチを`main`ブランチにマージしました。このバージョンからFLUX.1およびSD3/SD3.5等のモデルが`main`ブランチでサポートされます。
   - ドキュメントにはまだ不備があるため、お気づきの点はIssue等でお知らせください。

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ If you find this project helpful, please consider supporting its development via
 
 ### Change History
 
+- **Version 0.10.1 (2026-02-13):**
+    - [Anima Preview](https://huggingface.co/circlestone-labs/Anima) model LoRA training and fine-tuning are now supported. See [PR #2260](https://github.com/kohya-ss/sd-scripts/pull/2260) and [PR #2261](https://github.com/kohya-ss/sd-scripts/pull/2261).
+    - Many thanks to CircleStone Labs for releasing this amazing model, and to duongve13112002 for submitting great PR #2260.
+    - For details, please refer to the [documentation](./docs/anima_train_network.md).
+
 - **Version 0.10.0 (2026-01-19):**
     - `sd3` branch is merged to `main` branch. From this version, FLUX.1 and SD3/SD3.5 etc. are supported in the `main` branch.
     - There are still some missing parts in the documentation, so please let us know if you find any issues via Issues etc.


### PR DESCRIPTION
This pull request updates both the English and Japanese `README` files to announce support for LoRA training and fine-tuning with the Anima Preview model, and acknowledges contributors and provides a link to relevant documentation.

Release notes update:

* Added a new entry for **Version 0.10.1 (2026-02-13)** in both `README.md` and `README-ja.md`, announcing support for LoRA training and fine-tuning with the [Anima Preview](https://huggingface.co/circlestone-labs/Anima) model. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R54) [[2]](diffhunk://#diff-6323ab8bbdb204fef907b113c1c602229d4baef7abcd9c499aba1dd23bfe531cR53-R57)
* Included acknowledgments for CircleStone Labs (model release) and duongve13112002 (PR submission), and linked to [PR #2260](https://github.com/kohya-ss/sd-scripts/pull/2260) and [PR #2261](https://github.com/kohya-ss/sd-scripts/pull/2261). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R54) [[2]](diffhunk://#diff-6323ab8bbdb204fef907b113c1c602229d4baef7abcd9c499aba1dd23bfe531cR53-R57)
* Added a reference to the [documentation](./docs/anima_train_network.md) for further details. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R54) [[2]](diffhunk://#diff-6323ab8bbdb204fef907b113c1c602229d4baef7abcd9c499aba1dd23bfe531cR53-R57)