### PR TITLE
feat: add fp16 safe patch option for training on older GPUs to prevent NaNs for Anima model

### DIFF
--- a/anima_minimal_inference.py
+++ b/anima_minimal_inference.py
@@ -85,6 +85,7 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument("--fp8", action="store_true", help="use fp8 for DiT model")
     parser.add_argument("--fp8_scaled", action="store_true", help="use scaled fp8 for DiT, only for fp8")
+    parser.add_argument("--fp16_safe_patch", action="store_true", help="Apply fp16 safe patch for older GPUs to prevent NaNs by keeping residual stream in fp32")
 
     parser.add_argument("--text_encoder_cpu", action="store_true", help="Inference on CPU for Text Encoders")
     parser.add_argument(
@@ -263,6 +264,7 @@ def load_dit_model(
         args.fp8_scaled and not args.lycoris,
         lora_weights_list=lora_weights_list,
         lora_multipliers=args.lora_multiplier,
+        fp16_safe_patch=args.fp16_safe_patch,
     )
     if not args.fp8_scaled:
         # simple cast to dit_weight_dtype

--- a/anima_train.py
+++ b/anima_train.py
@@ -240,7 +240,7 @@ def train(args):
     # Load DiT (MiniTrainDIT + optional LLM Adapter)
     logger.info("Loading Anima DiT...")
     dit = anima_utils.load_anima_model(
-        "cpu", args.pretrained_model_name_or_path, args.attn_mode, args.split_attn, "cpu", dit_weight_dtype=None
+        "cpu", args.pretrained_model_name_or_path, args.attn_mode, args.split_attn, "cpu", dit_weight_dtype=None, fp16_safe_patch=args.fp16_safe_patch
     )
 
     if args.gradient_checkpointing:

--- a/anima_train_network.py
+++ b/anima_train_network.py
@@ -118,6 +118,7 @@ class AnimaNetworkTrainer(train_network.NetworkTrainer):
             loading_device,
             loading_dtype,
             args.fp8_scaled,
+            fp16_safe_patch=getattr(args, "fp16_safe_patch", False),
         )
 
         # Store unsloth preference so that when the base NetworkTrainer calls

--- a/library/anima_train_utils.py
+++ b/library/anima_train_utils.py
@@ -135,6 +135,11 @@ def add_anima_training_arguments(parser: argparse.ArgumentParser):
         help="Disable internal VAE caching mechanism to reduce memory usage. Encoding / decoding will also be faster, but this differs from official behavior."
         + " / VAEのメモリ使用量を減らすために内部のキャッシュ機構を無効にします。エンコード/デコードも速くなりますが、公式の動作とは異なります。",
     )
+    parser.add_argument(
+        "--fp16_safe_patch",
+        action="store_true",
+        help="Apply fp16 safe patch for older GPUs to prevent NaNs by keeping residual stream in fp32",
+    )
 
 
 # Loss weighting


### PR DESCRIPTION
This fixes NaN loss for GPUs without bf16 support by adding `fp16_safe_patch`, outputting black images even with `full_fp16 = true`, and/or `mixed_precision = "fp16"`. Just add `fp16_safe_patch = true` in config.toml. Confirmed it doesn't give black images during sampling while training and doesn't do NaN anymore.

This was inspired from https://huggingface.co/RicemanT/Loras_Collection/blob/main/anina_fp16_patch.py and with the help of gemini.