### PR TITLE
feat: Stability with fp16 for anima

### DIFF
--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -864,6 +864,10 @@ class Block(nn.Module):
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         extra_per_block_pos_emb: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if x_B_T_H_W_D.dtype == torch.float16:
+            # Cast to float32 for better numerical stability in residual connections. Each module will cast back to float16 by enclosing autocast context.
+            x_B_T_H_W_D = x_B_T_H_W_D.float()
+
         if extra_per_block_pos_emb is not None:
             x_B_T_H_W_D = x_B_T_H_W_D + extra_per_block_pos_emb
 


### PR DESCRIPTION
This pull request introduces an improvement to the `_forward` method in `library/anima_models.py` to enhance numerical stability during computations involving residual connections.

Numerical stability improvements:

* In the `_forward` method, input tensor `x_B_T_H_W_D` is now cast to `float32` if its original type is `float16`, ensuring better numerical stability in residual connections. Each module will handle casting back to `float16` as needed using an autocast context.

---

Address the issue described in #2274.