### PR TITLE
fix: replace deprecated CLIPFeatureExtractor with CLIPImageProcessor for transformers 5.x compatibility

### DIFF
--- a/library/lpw_stable_diffusion.py
+++ b/library/lpw_stable_diffusion.py
@@ -9,7 +9,7 @@ import numpy as np
 import PIL.Image
 import torch
 from packaging import version
-from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer, CLIPVisionModelWithProjection
+from transformers import CLIPImageProcessor as CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer, CLIPVisionModelWithProjection
 
 import diffusers
 from diffusers import SchedulerMixin, StableDiffusionPipeline

--- a/library/sdxl_lpw_stable_diffusion.py
+++ b/library/sdxl_lpw_stable_diffusion.py
@@ -10,7 +10,7 @@ import PIL.Image
 import torch
 from packaging import version
 from tqdm import tqdm
-from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
+from transformers import CLIPImageProcessor as CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 
 from diffusers import SchedulerMixin, StableDiffusionPipeline
 from diffusers.models import AutoencoderKL


### PR DESCRIPTION
## Problem

`CLIPFeatureExtractor` was deprecated in transformers 4.x (renamed to `CLIPImageProcessor`) and **fully removed in transformers 5.0**. Users running sd-scripts with `transformers>=5.0.0` get the following error:

```
ImportError: cannot import name 'CLIPFeatureExtractor' from 'transformers'
```

This affects both `lpw_stable_diffusion.py` and `sdxl_lpw_stable_diffusion.py`.

## Fix

Replace the import with `CLIPImageProcessor` aliased as `CLIPFeatureExtractor` to maintain full backward compatibility while supporting transformers 5.x:

```python
# Before
from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer, ...

# After
from transformers import CLIPImageProcessor as CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer, ...
```

## Files changed

- `library/lpw_stable_diffusion.py`
- `library/sdxl_lpw_stable_diffusion.py`

## Testing

Verified working with:
- Python 3.13.11
- PyTorch 2.10.0+cu130
- transformers 5.3.0
- NVIDIA GeForce RTX 2060