### PR TITLE
Fix masked-image VAE encode dtype in fine_tune and train_textual_inversion

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -366,8 +366,8 @@ def train(args):
                     
                     if batch["masks"] is not None:
                         masked_latents = vae.encode(
-                            batch["masked_images"].to(dtype=weight_dtype)
-                        ).latent_dist.sample()
+                            batch["masked_images"].to(dtype=vae_dtype)
+                        ).latent_dist.sample().to(weight_dtype)
                         masked_latents = masked_latents * 0.18215
                         # Resize the mask to latents shape as we concatenate the mask to the latents
                         mask = torch.nn.functional.interpolate(

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -581,8 +581,8 @@ class TextualInversionTrainer:
 
                         if batch["masks"] is not None:
                             masked_latents = vae.encode(
-                                batch["masked_images"].to(dtype=weight_dtype)
-                            ).latent_dist.sample()
+                                batch["masked_images"].to(dtype=vae_dtype)
+                            ).latent_dist.sample().to(dtype=weight_dtype)
                             masked_latents = masked_latents * self.vae_scale_factor
 
                             # Resize the mask to latents shape as we concatenate the mask to the latents


### PR DESCRIPTION
## Summary
- Follow-up to PR #2309 / #2319 — finding #3 from the inpainting review.
- In `fine_tune.py` and `train_textual_inversion.py`, the masked-image VAE encode path used `weight_dtype` for input and skipped the output cast, while the regular `latents` path encodes in `vae_dtype` and casts the sample to `weight_dtype`.
- Under `--no_half_vae` (VAE kept in fp32 while `weight_dtype` is fp16/bf16), this could cause a `torch.cat([noisy_latents, mask, masked_latents], dim=1)` dtype mismatch and VAE numerical instability.
- Fix aligns both scripts with the pattern already used in `sdxl_train.py` and the regular latents path: `.to(dtype=vae_dtype)` on input, `.latent_dist.sample().to(weight_dtype)` on output.
- `train_db.py` is internally consistent (both paths use `weight_dtype`) and is intentionally left out of this PR; its broader `vae_dtype`/`weight_dtype` handling is a pre-existing concern to be addressed separately.

## Test plan
- [x] Verified `--train_inpainting` runs on `fine_tune.py` after the change
- [x] Verified `--train_inpainting` runs on `train_textual_inversion.py` after the change
- [ ] (Optional) Spot-check with `--no_half_vae` + fp16/bf16 `--mixed_precision`

🤖 Generated with [Claude Code](https://claude.com/claude-code)