### PR TITLE
Fix NaN in inpainting sample generation under fp16 autocast

### DIFF
--- a/library/lpw_stable_diffusion.py
+++ b/library/lpw_stable_diffusion.py
@@ -902,15 +902,23 @@ class StableDiffusionLongPromptWeightingPipeline(StableDiffusionPipeline):
         if inpaint_image is not None and inpaint_mask is not None:
             import numpy as np
             SD15_VAE_SCALE_FACTOR = 0.18215
+            # Cast inpaint inputs to self.vae.dtype rather than the UNet dtype, so
+            # that VAE encode operates in its own precision regardless of mixed
+            # precision settings (mirrors the existing decode path).
             img_np = np.array(inpaint_image.convert("RGB")).astype(np.float32) / 127.5 - 1.0
-            img_t = torch.from_numpy(img_np).permute(2, 0, 1)[None].to(device=device, dtype=dtype)
+            img_t = torch.from_numpy(img_np).permute(2, 0, 1)[None].to(device=device, dtype=self.vae.dtype)
             mask_np = np.array(inpaint_mask.convert("L")).astype(np.float32) / 255.0
             mask_np = (mask_np >= 0.5).astype(np.float32)
-            mask_t = torch.from_numpy(mask_np)[None, None].to(device=device, dtype=dtype)
+            mask_t = torch.from_numpy(mask_np)[None, None].to(device=device, dtype=self.vae.dtype)
             masked_img_t = img_t * (1.0 - mask_t)
-            inpaint_masked_image_latent = (
-                self.vae.encode(masked_img_t).latent_dist.sample() * SD15_VAE_SCALE_FACTOR
-            )
+            # Disable autocast: under fp16 autocast (set by accelerator.autocast() in
+            # the caller), conv kernels run in fp16 even when weights/inputs are fp32,
+            # which can produce NaN in the VAE encode. Mirrors how decode_latents()
+            # runs outside the autocast block in the caller.
+            with torch.autocast(device_type=device.type, enabled=False):
+                inpaint_masked_image_latent = (
+                    self.vae.encode(masked_img_t).latent_dist.sample() * SD15_VAE_SCALE_FACTOR
+                )
             inpaint_mask_latent = torch.nn.functional.interpolate(
                 mask_t, size=(height // 8, width // 8)
             )

--- a/library/sdxl_lpw_stable_diffusion.py
+++ b/library/sdxl_lpw_stable_diffusion.py
@@ -929,16 +929,25 @@ class SdxlStableDiffusionLongPromptWeightingPipeline:
         inpaint_masked_image_latent = None
         if inpaint_image is not None and inpaint_mask is not None:
             import numpy as np
-            # Encode masked image: image * (1 - mask)
+            # Encode masked image: image * (1 - mask).
+            # The VAE may run in a different dtype than the UNet (e.g. fp32 with
+            # --no_half_vae, or bf16 to avoid SDXL's fp16 VAE NaN issue), so cast
+            # to self.vae.dtype here — mirroring the existing decode_latents path
+            # (`self.vae.decode(latents.to(self.vae.dtype))`).
             img_np = np.array(inpaint_image.convert("RGB")).astype(np.float32) / 127.5 - 1.0
-            img_t = torch.from_numpy(img_np).permute(2, 0, 1)[None].to(device=device, dtype=dtype)
+            img_t = torch.from_numpy(img_np).permute(2, 0, 1)[None].to(device=device, dtype=self.vae.dtype)
             mask_np = np.array(inpaint_mask.convert("L")).astype(np.float32) / 255.0
             mask_np = (mask_np >= 0.5).astype(np.float32)
-            mask_t = torch.from_numpy(mask_np)[None, None].to(device=device, dtype=dtype)
+            mask_t = torch.from_numpy(mask_np)[None, None].to(device=device, dtype=self.vae.dtype)
             masked_img_t = img_t * (1.0 - mask_t)
-            inpaint_masked_image_latent = (
-                self.vae.encode(masked_img_t).latent_dist.sample() * sdxl_model_util.VAE_SCALE_FACTOR
-            )
+            # Disable autocast: under fp16 autocast (set by accelerator.autocast() in
+            # train_util.sample_image_inference), conv kernels run in fp16 even when
+            # weights/inputs are fp32 — and SDXL VAE produces NaN in fp16. This mirrors
+            # how decode_latents() runs *outside* the autocast block in the caller.
+            with torch.autocast(device_type=device.type, enabled=False):
+                inpaint_masked_image_latent = (
+                    self.vae.encode(masked_img_t).latent_dist.sample() * sdxl_model_util.VAE_SCALE_FACTOR
+                )
             inpaint_mask_latent = torch.nn.functional.interpolate(
                 mask_t, size=(height // 8, width // 8)
             )


### PR DESCRIPTION
## Summary

Bug fix for inpainting sample generation following PR #2309. With `--mixed_precision fp16` (with or without `--no_half_vae`), the SDXL training-time inpainting sample generation produces NaN latents on the very first sample, leading to `RuntimeWarning: invalid value encountered in cast` and a black image. With `bf16`, sampling works.

Two related issues in the lpw inpaint encode path, both surfacing under the `accelerator.autocast()` block in `train_util.sample_image_inference`:

1. **Wrong dtype for VAE inputs.** Inpaint inputs were cast to `dtype = unet.dtype` (UNet dtype), not `self.vae.dtype`. Under `--no_half_vae` (vae=fp32, unet=fp16) this fed mismatched precision into `self.vae.encode`. Mirrors the existing pattern used in `decode_latents()` (`self.vae.decode(latents.to(self.vae.dtype))`).
2. **Autocast forcing fp16 conv kernels.** Even after fixing (1), fp16 autocast forces conv kernels to fp16 regardless of input/weight dtype, and SDXL VAE produces NaN in fp16. The existing `decode_latents()` happens to be called *outside* the caller's `accelerator.autocast()` block, so it was unaffected — but inpaint encode runs inside `pipeline()` and hit this.

Fix wraps the inpaint encode in `torch.autocast(device_type=device.type, enabled=False)` so the encode runs in the VAE's actual precision.

Same change applied to `lpw_stable_diffusion.py` (SD1.5). SD1.5 VAE is more fp16-tolerant so the bug was latent there, but the path is structurally identical and worth keeping consistent.

## Test plan

Verified by @kohya-ss:
- [x] **SDXL + `--mixed_precision fp16 --no_half_vae`** — was NaN, now produces valid samples
- [x] **SDXL + `--mixed_precision bf16`** — no regression
- [x] **SD1.5** — no regression

## Notes

- This PR is independent of #2321 (cleanup PR); they touch disjoint files (`library/lpw_stable_diffusion.py`, `library/sdxl_lpw_stable_diffusion.py` here vs. `train_util.py` / `sdxl_train.py` / `model_util.py` / docs / `inpainting_minimal_inference.py` in #2321), so they can be merged in either order.
- The remaining SDXL fp16-without-no_half_vae case (vae=fp16=NaN) is the well-known SDXL VAE fp16 instability, not addressed here. Recommended workaround stays the same: use bf16 or `--no_half_vae`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)