### PR TITLE
refactor(phase3c): accelerator setup を library/accelerator_setup.py に分離

### DIFF
--- a/library/accelerator_setup.py
+++ b/library/accelerator_setup.py
@@ -1,0 +1,186 @@
+"""Accelerator / dtype / dataset-args setup helpers.
+
+Hosts the routines that prepare the Accelerator (incl. DeepSpeed plugin and
+DDP options), resolve mixed-precision dtypes, normalise dataset-related
+arguments, patch the fp16 grad scaler, and toggle the ``HIGH_VRAM`` mode flag.
+``HIGH_VRAM`` is a mutable module-level flag toggled by ``enable_high_vram``
+and read from ``library.caching`` / ``library.dataset`` / the strategy
+modules. Extracted from ``library.train_util`` and re-exported there for
+backward compatibility (the legacy ``train_util.HIGH_VRAM`` attribute is
+served via a module-level ``__getattr__`` shim).
+"""
+
+import argparse
+import datetime
+import logging
+import os
+
+import torch
+from accelerate import Accelerator, DistributedDataParallelKwargs, InitProcessGroupKwargs
+from packaging.version import Version
+
+import library.deepspeed_utils as deepspeed_utils
+from library.utils import setup_logging
+
+setup_logging()
+
+logger = logging.getLogger(__name__)
+
+
+# Mutable module-level flag toggled by enable_high_vram(). Read from caching /
+# dataset / strategy modules to skip per-step CUDA cache clears on big-VRAM rigs.
+HIGH_VRAM = False
+
+
+def enable_high_vram(args: argparse.Namespace):
+    if args.highvram:
+        logger.info("highvram is enabled / highvramが有効です")
+        global HIGH_VRAM
+        HIGH_VRAM = True
+
+
+def prepare_dataset_args(args: argparse.Namespace, support_metadata: bool):
+    # backward compatibility
+    if args.caption_extention is not None:
+        args.caption_extension = args.caption_extention
+        args.caption_extention = None
+
+    # assert args.resolution is not None, f"resolution is required / resolution（解像度）を指定してください"
+    if args.resolution is not None:
+        args.resolution = tuple([int(r) for r in args.resolution.split(",")])
+        if len(args.resolution) == 1:
+            args.resolution = (args.resolution[0], args.resolution[0])
+        assert (
+            len(args.resolution) == 2
+        ), f"resolution must be 'size' or 'width,height' / resolution（解像度）は'サイズ'または'幅','高さ'で指定してください: {args.resolution}"
+
+    if args.skip_image_resolution is not None:
+        args.skip_image_resolution = tuple([int(r) for r in args.skip_image_resolution.split(",")])
+        if len(args.skip_image_resolution) == 1:
+            args.skip_image_resolution = (args.skip_image_resolution[0], args.skip_image_resolution[0])
+        assert (
+            len(args.skip_image_resolution) == 2
+        ), f"skip_image_resolution must be 'size' or 'width,height' / skip_image_resolutionは'サイズ'または'幅','高さ'で指定してください: {args.skip_image_resolution}"
+
+    if args.face_crop_aug_range is not None:
+        args.face_crop_aug_range = tuple([float(r) for r in args.face_crop_aug_range.split(",")])
+        assert (
+            len(args.face_crop_aug_range) == 2 and args.face_crop_aug_range[0] <= args.face_crop_aug_range[1]
+        ), f"face_crop_aug_range must be two floats / face_crop_aug_rangeは'下限,上限'で指定してください: {args.face_crop_aug_range}"
+    else:
+        args.face_crop_aug_range = None
+
+    if support_metadata:
+        if args.in_json is not None and (args.color_aug or args.random_crop):
+            logger.warning(
+                f"latents in npz is ignored when color_aug or random_crop is True / color_augまたはrandom_cropを有効にした場合、npzファイルのlatentsは無視されます"
+            )
+
+
+def prepare_accelerator(args: argparse.Namespace):
+    """
+    this function also prepares deepspeed plugin
+    """
+    import time
+
+    if args.logging_dir is None:
+        logging_dir = None
+    else:
+        log_prefix = "" if args.log_prefix is None else args.log_prefix
+        logging_dir = args.logging_dir + "/" + log_prefix + time.strftime("%Y%m%d%H%M%S", time.localtime())
+
+    if args.log_with is None:
+        if logging_dir is not None:
+            log_with = "tensorboard"
+        else:
+            log_with = None
+    else:
+        log_with = args.log_with
+        if log_with in ["tensorboard", "all"]:
+            if logging_dir is None:
+                raise ValueError(
+                    "logging_dir is required when log_with is tensorboard / Tensorboardを使う場合、logging_dirを指定してください"
+                )
+        if log_with in ["wandb", "all"]:
+            try:
+                import wandb
+            except ImportError:
+                raise ImportError("No wandb / wandb がインストールされていないようです")
+            if logging_dir is not None:
+                os.makedirs(logging_dir, exist_ok=True)
+                os.environ["WANDB_DIR"] = logging_dir
+            if args.wandb_api_key is not None:
+                wandb.login(key=args.wandb_api_key)
+
+    # torch.compile のオプション。 NO の場合は torch.compile は使わない
+    dynamo_backend = "NO"
+    if args.torch_compile:
+        dynamo_backend = args.dynamo_backend
+
+    kwargs_handlers = [
+        (
+            InitProcessGroupKwargs(
+                backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
+                init_method=(
+                    "env://?use_libuv=False" if os.name == "nt" and Version(torch.__version__) >= Version("2.4.0") else None
+                ),
+                timeout=datetime.timedelta(minutes=args.ddp_timeout) if args.ddp_timeout else None,
+            )
+            if torch.cuda.device_count() > 1
+            else None
+        ),
+        (
+            DistributedDataParallelKwargs(
+                gradient_as_bucket_view=args.ddp_gradient_as_bucket_view, static_graph=args.ddp_static_graph
+            )
+            if args.ddp_gradient_as_bucket_view or args.ddp_static_graph
+            else None
+        ),
+    ]
+    kwargs_handlers = [i for i in kwargs_handlers if i is not None]
+    deepspeed_plugin = deepspeed_utils.prepare_deepspeed_plugin(args)
+
+    accelerator = Accelerator(
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        mixed_precision=args.mixed_precision,
+        log_with=log_with,
+        project_dir=logging_dir,
+        kwargs_handlers=kwargs_handlers,
+        dynamo_backend=dynamo_backend,
+        deepspeed_plugin=deepspeed_plugin,
+    )
+    print("accelerator device:", accelerator.device)
+    return accelerator
+
+
+def prepare_dtype(args: argparse.Namespace):
+    weight_dtype = torch.float32
+    if args.mixed_precision == "fp16":
+        weight_dtype = torch.float16
+    elif args.mixed_precision == "bf16":
+        weight_dtype = torch.bfloat16
+
+    save_dtype = None
+    if args.save_precision == "fp16":
+        save_dtype = torch.float16
+    elif args.save_precision == "bf16":
+        save_dtype = torch.bfloat16
+    elif args.save_precision == "float":
+        save_dtype = torch.float32
+
+    return weight_dtype, save_dtype
+
+
+def patch_accelerator_for_fp16_training(accelerator):
+
+    from accelerate import DistributedType
+
+    if accelerator.distributed_type == DistributedType.DEEPSPEED:
+        return
+
+    org_unscale_grads = accelerator.scaler._unscale_grads_
+
+    def _unscale_grads_replacer(optimizer, inv_scale, found_inf, allow_fp16):
+        return org_unscale_grads(optimizer, inv_scale, found_inf, True)
+
+    accelerator.scaler._unscale_grads_ = _unscale_grads_replacer

--- a/library/args.py
+++ b/library/args.py
@@ -795,9 +795,7 @@ def verify_training_args(args: argparse.Namespace):
     Verify training arguments. Also reflect highvram option to global variable
     学習用引数を検証する。あわせて highvram オプションの指定をグローバル変数に反映する
     """
-    # enable_high_vram は accelerator 系のためまだ train_util.py に残っている。
-    # 循環 import 回避のため遅延 import する。
-    from library.train_util import enable_high_vram
+    from library.accelerator_setup import enable_high_vram
 
     enable_high_vram(args)
 

--- a/library/caching.py
+++ b/library/caching.py
@@ -6,12 +6,12 @@ between memory and ``.npz`` files on disk. Used both during the explicit
 the fly inside ``BaseDataset``.
 
 ``BucketManager`` / ``load_image`` / ``IMAGE_TRANSFORMS`` (and ``ImageInfo`` for
-type checks) live in ``library.dataset``; ``HIGH_VRAM`` still lives in
-``library.train_util``. Both modules import ``library.caching`` at top level for
-the dataset and re-export use cases, so this module pulls those symbols in
-lazily through ``_ds()`` / ``_tu()`` to avoid an import cycle.
-``get_hidden_states_sdxl`` lives in ``library.hidden_states`` and has no cycle
-with this module, so it is imported directly.
+type checks) live in ``library.dataset``; ``library.dataset`` imports
+``library.caching`` at top level so we pull the dataset symbols in lazily
+through ``_ds()`` to avoid an import cycle.
+``HIGH_VRAM`` lives in ``library.accelerator_setup`` and ``get_hidden_states_sdxl``
+in ``library.hidden_states``; neither has a cycle with this module so they are
+imported directly.
 """
 
 import logging
@@ -23,7 +23,7 @@ import numpy as np
 import torch
 from diffusers import AutoencoderKL
 
-from library import sd3_utils
+from library import accelerator_setup, sd3_utils
 from library.device_utils import clean_memory_on_device
 from library.hidden_states import get_hidden_states_sdxl
 from library.utils import resize_image  # noqa: F401  (kept for symmetry / debugging)
@@ -35,12 +35,6 @@ if TYPE_CHECKING:
 def _ds():
     """Late-bound ``library.dataset`` accessor (BucketManager / load_image / IMAGE_TRANSFORMS)."""
     import library.dataset as m
-    return m
-
-
-def _tu():
-    """Late-bound ``library.train_util`` accessor (HIGH_VRAM)."""
-    import library.train_util as m
     return m
 
 
@@ -245,7 +239,7 @@ def cache_batch_latents(
                 info.latents_flipped = flipped_latent
             info.alpha_mask = alpha_mask
 
-    if not _tu().HIGH_VRAM:
+    if not accelerator_setup.HIGH_VRAM:
         clean_memory_on_device(vae.device)
 
 

--- a/library/dataset.py
+++ b/library/dataset.py
@@ -15,9 +15,9 @@ This module owns the data-loading side of training:
 
 The DreamBooth / FineTuning / ControlNet specializations of ``BaseDataset`` live
 in ``library.train_util`` for now and will move to dedicated modules in PR-1d.
-``HIGH_VRAM`` (a mutable module-level flag toggled by ``enable_high_vram``)
-remains in ``library.train_util``; this module accesses it lazily via the
-``_tu()`` helper to avoid an import cycle.
+``HIGH_VRAM`` (a mutable module-level flag toggled by ``enable_high_vram``) lives
+in ``library.accelerator_setup``; that module has no cycle with this one so it
+is imported directly.
 """
 
 import glob
@@ -43,6 +43,7 @@ from tqdm import tqdm
 from transformers import CLIPTokenizer
 
 import library.model_util as model_util
+from library import accelerator_setup
 from library.caching import (
     cache_batch_latents,
     cache_batch_text_encoder_outputs,
@@ -67,16 +68,6 @@ from library.utils import resize_image, setup_logging, validate_interpolation_fn
 
 setup_logging()
 logger = logging.getLogger(__name__)
-
-
-def _tu():
-    """Late-bound ``library.train_util`` accessor (used for ``HIGH_VRAM``).
-
-    ``HIGH_VRAM`` is mutated by ``train_util.enable_high_vram`` and read in a
-    BaseDataset method; we cannot bind it at module load time.
-    """
-    import library.train_util as m
-    return m
 
 
 IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp", ".bmp", ".PNG", ".JPG", ".JPEG", ".WEBP", ".BMP"]
@@ -911,7 +902,7 @@ class BaseDataset(torch.utils.data.Dataset):
                 if len(batch) > 0 and current_condition != condition:
                     submit_batch(batch, current_condition)
                     batch = []
-                if condition != current_condition and _tu().HIGH_VRAM:  # even with high VRAM, if shape is changed
+                if condition != current_condition and accelerator_setup.HIGH_VRAM:  # even with high VRAM, if shape is changed
                     clean_memory_on_device(accelerator.device)
 
                 if info.image is None:

--- a/library/strategy_anima.py
+++ b/library/strategy_anima.py
@@ -1,4 +1,4 @@
-# Anima Strategy Classes
+﻿# Anima Strategy Classes
 
 import os
 import random
@@ -298,5 +298,5 @@ class AnimaLatentsCachingStrategy(LatentsCachingStrategy):
             encode_by_vae, vae_device, vae_dtype, image_infos, flip_aug, alpha_mask, random_crop, multi_resolution=True
         )
 
-        if not train_util.HIGH_VRAM:
+        if not accelerator_setup.HIGH_VRAM:
             train_util.clean_memory_on_device(vae_device)

--- a/library/strategy_flux.py
+++ b/library/strategy_flux.py
@@ -1,4 +1,4 @@
-import os
+﻿import os
 import glob
 from typing import Any, List, Optional, Tuple, Union
 import torch
@@ -229,7 +229,7 @@ class FluxLatentsCachingStrategy(LatentsCachingStrategy):
             encode_by_vae, vae_device, vae_dtype, image_infos, flip_aug, alpha_mask, random_crop, multi_resolution=True
         )
 
-        if not train_util.HIGH_VRAM:
+        if not accelerator_setup.HIGH_VRAM:
             train_util.clean_memory_on_device(vae.device)
 
 

--- a/library/strategy_hunyuan_image.py
+++ b/library/strategy_hunyuan_image.py
@@ -1,4 +1,4 @@
-import os
+﻿import os
 from typing import Any, List, Optional, Tuple, Union
 import torch
 import numpy as np
@@ -214,5 +214,5 @@ class HunyuanImageLatentsCachingStrategy(LatentsCachingStrategy):
             encode_by_vae, vae_device, vae_dtype, image_infos, flip_aug, alpha_mask, random_crop, multi_resolution=True
         )
 
-        if not train_util.HIGH_VRAM:
+        if not accelerator_setup.HIGH_VRAM:
             train_util.clean_memory_on_device(vae.device)

--- a/library/strategy_lumina.py
+++ b/library/strategy_lumina.py
@@ -1,10 +1,10 @@
-import glob
+﻿import glob
 import os
 from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from transformers import AutoTokenizer, AutoModel, Gemma2Model, GemmaTokenizerFast
-from library import train_util
+from library import accelerator_setup, train_util
 from library.strategy_base import (
     LatentsCachingStrategy,
     TokenizeStrategy,
@@ -371,5 +371,5 @@ class LuminaLatentsCachingStrategy(LatentsCachingStrategy):
             multi_resolution=True,
         )
 
-        if not train_util.HIGH_VRAM:
+        if not accelerator_setup.HIGH_VRAM:
             train_util.clean_memory_on_device(model.device)

--- a/library/strategy_sd.py
+++ b/library/strategy_sd.py
@@ -1,11 +1,11 @@
-import glob
+﻿import glob
 import os
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 from transformers import CLIPTokenizer
-from library import train_util
+from library import accelerator_setup, train_util
 from library.strategy_base import LatentsCachingStrategy, TokenizeStrategy, TextEncodingStrategy
 from library.utils import setup_logging
 
@@ -175,5 +175,5 @@ class SdSdxlLatentsCachingStrategy(LatentsCachingStrategy):
             encode_by_vae, vae_device, vae_dtype, image_infos, flip_aug, alpha_mask, random_crop, multi_resolution=True
         )
 
-        if not train_util.HIGH_VRAM:
+        if not accelerator_setup.HIGH_VRAM:
             train_util.clean_memory_on_device(vae.device)

--- a/library/strategy_sd3.py
+++ b/library/strategy_sd3.py
@@ -1,4 +1,4 @@
-import os
+﻿import os
 import glob
 import random
 from typing import Any, List, Optional, Tuple, Union
@@ -416,5 +416,5 @@ class Sd3LatentsCachingStrategy(LatentsCachingStrategy):
             encode_by_vae, vae_device, vae_dtype, image_infos, flip_aug, alpha_mask, random_crop, multi_resolution=True
         )
 
-        if not train_util.HIGH_VRAM:
+        if not accelerator_setup.HIGH_VRAM:
             train_util.clean_memory_on_device(vae.device)

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -84,7 +84,26 @@ logger = logging.getLogger(__name__)
 # from library.hypernetwork import replace_attentions_for_hypernetwork
 from library.original_unet import UNet2DConditionModel
 
-HIGH_VRAM = False
+# Accelerator setup helpers have moved to library.accelerator_setup;
+# re-exported here for backward compatibility.
+# New code should import from library.accelerator_setup directly.
+# HIGH_VRAM is mutated by enable_high_vram(); for legacy ``train_util.HIGH_VRAM``
+# attribute reads we forward through a module-level __getattr__ below.
+from library.accelerator_setup import (  # noqa: F401
+    enable_high_vram,
+    prepare_dataset_args,
+    prepare_accelerator,
+    prepare_dtype,
+    patch_accelerator_for_fp16_training,
+)
+
+
+def __getattr__(name):
+    if name == "HIGH_VRAM":
+        from library import accelerator_setup
+        return accelerator_setup.HIGH_VRAM
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # checkpointファイル名
 EPOCH_STATE_NAME = "{}-{:06d}-state"
@@ -386,12 +405,6 @@ from library.args import (  # noqa: F401
     resume_from_local_or_hf_if_specified,
 )
 
-
-def enable_high_vram(args: argparse.Namespace):
-    if args.highvram:
-        logger.info("highvram is enabled / highvramが有効です")
-        global HIGH_VRAM
-        HIGH_VRAM = True
 
 # endregion
 
@@ -975,153 +988,6 @@ def get_scheduler_fix(args, optimizer: Optimizer, num_processes: int):
         **lr_scheduler_kwargs,
     )
 
-
-def prepare_dataset_args(args: argparse.Namespace, support_metadata: bool):
-    # backward compatibility
-    if args.caption_extention is not None:
-        args.caption_extension = args.caption_extention
-        args.caption_extention = None
-
-    # assert args.resolution is not None, f"resolution is required / resolution（解像度）を指定してください"
-    if args.resolution is not None:
-        args.resolution = tuple([int(r) for r in args.resolution.split(",")])
-        if len(args.resolution) == 1:
-            args.resolution = (args.resolution[0], args.resolution[0])
-        assert (
-            len(args.resolution) == 2
-        ), f"resolution must be 'size' or 'width,height' / resolution（解像度）は'サイズ'または'幅','高さ'で指定してください: {args.resolution}"
-
-    if args.skip_image_resolution is not None:
-        args.skip_image_resolution = tuple([int(r) for r in args.skip_image_resolution.split(",")])
-        if len(args.skip_image_resolution) == 1:
-            args.skip_image_resolution = (args.skip_image_resolution[0], args.skip_image_resolution[0])
-        assert (
-            len(args.skip_image_resolution) == 2
-        ), f"skip_image_resolution must be 'size' or 'width,height' / skip_image_resolutionは'サイズ'または'幅','高さ'で指定してください: {args.skip_image_resolution}"
-
-    if args.face_crop_aug_range is not None:
-        args.face_crop_aug_range = tuple([float(r) for r in args.face_crop_aug_range.split(",")])
-        assert (
-            len(args.face_crop_aug_range) == 2 and args.face_crop_aug_range[0] <= args.face_crop_aug_range[1]
-        ), f"face_crop_aug_range must be two floats / face_crop_aug_rangeは'下限,上限'で指定してください: {args.face_crop_aug_range}"
-    else:
-        args.face_crop_aug_range = None
-
-    if support_metadata:
-        if args.in_json is not None and (args.color_aug or args.random_crop):
-            logger.warning(
-                f"latents in npz is ignored when color_aug or random_crop is True / color_augまたはrandom_cropを有効にした場合、npzファイルのlatentsは無視されます"
-            )
-
-
-def prepare_accelerator(args: argparse.Namespace):
-    """
-    this function also prepares deepspeed plugin
-    """
-
-    if args.logging_dir is None:
-        logging_dir = None
-    else:
-        log_prefix = "" if args.log_prefix is None else args.log_prefix
-        logging_dir = args.logging_dir + "/" + log_prefix + time.strftime("%Y%m%d%H%M%S", time.localtime())
-
-    if args.log_with is None:
-        if logging_dir is not None:
-            log_with = "tensorboard"
-        else:
-            log_with = None
-    else:
-        log_with = args.log_with
-        if log_with in ["tensorboard", "all"]:
-            if logging_dir is None:
-                raise ValueError(
-                    "logging_dir is required when log_with is tensorboard / Tensorboardを使う場合、logging_dirを指定してください"
-                )
-        if log_with in ["wandb", "all"]:
-            try:
-                import wandb
-            except ImportError:
-                raise ImportError("No wandb / wandb がインストールされていないようです")
-            if logging_dir is not None:
-                os.makedirs(logging_dir, exist_ok=True)
-                os.environ["WANDB_DIR"] = logging_dir
-            if args.wandb_api_key is not None:
-                wandb.login(key=args.wandb_api_key)
-
-    # torch.compile のオプション。 NO の場合は torch.compile は使わない
-    dynamo_backend = "NO"
-    if args.torch_compile:
-        dynamo_backend = args.dynamo_backend
-
-    kwargs_handlers = [
-        (
-            InitProcessGroupKwargs(
-                backend="gloo" if os.name == "nt" or not torch.cuda.is_available() else "nccl",
-                init_method=(
-                    "env://?use_libuv=False" if os.name == "nt" and Version(torch.__version__) >= Version("2.4.0") else None
-                ),
-                timeout=datetime.timedelta(minutes=args.ddp_timeout) if args.ddp_timeout else None,
-            )
-            if torch.cuda.device_count() > 1
-            else None
-        ),
-        (
-            DistributedDataParallelKwargs(
-                gradient_as_bucket_view=args.ddp_gradient_as_bucket_view, static_graph=args.ddp_static_graph
-            )
-            if args.ddp_gradient_as_bucket_view or args.ddp_static_graph
-            else None
-        ),
-    ]
-    kwargs_handlers = [i for i in kwargs_handlers if i is not None]
-    deepspeed_plugin = deepspeed_utils.prepare_deepspeed_plugin(args)
-
-    accelerator = Accelerator(
-        gradient_accumulation_steps=args.gradient_accumulation_steps,
-        mixed_precision=args.mixed_precision,
-        log_with=log_with,
-        project_dir=logging_dir,
-        kwargs_handlers=kwargs_handlers,
-        dynamo_backend=dynamo_backend,
-        deepspeed_plugin=deepspeed_plugin,
-    )
-    print("accelerator device:", accelerator.device)
-    return accelerator
-
-
-def prepare_dtype(args: argparse.Namespace):
-    weight_dtype = torch.float32
-    if args.mixed_precision == "fp16":
-        weight_dtype = torch.float16
-    elif args.mixed_precision == "bf16":
-        weight_dtype = torch.bfloat16
-
-    save_dtype = None
-    if args.save_precision == "fp16":
-        save_dtype = torch.float16
-    elif args.save_precision == "bf16":
-        save_dtype = torch.bfloat16
-    elif args.save_precision == "float":
-        save_dtype = torch.float32
-
-    return weight_dtype, save_dtype
-
-
-
-
-def patch_accelerator_for_fp16_training(accelerator):
-
-    from accelerate import DistributedType
-
-    if accelerator.distributed_type == DistributedType.DEEPSPEED:
-        return
-
-    org_unscale_grads = accelerator.scaler._unscale_grads_
-
-    def _unscale_grads_replacer(optimizer, inv_scale, found_inf, allow_fp16):
-        return org_unscale_grads(optimizer, inv_scale, found_inf, True)
-
-    accelerator.scaler._unscale_grads_ = _unscale_grads_replacer
 
 
 # Text encoder hidden-state helpers have moved to library.hidden_states;


### PR DESCRIPTION
## Summary

PR-3 の 3 番目のサブ PR（PR-3c）。train_util.py から accelerator/dtype/dataset-args の準備系 5 関数 + `HIGH_VRAM` フラグを `library/accelerator_setup.py` に分離します。

**移動した内容:**
- `HIGH_VRAM` (mutable module-level flag)
- `enable_high_vram`
- `prepare_dataset_args`
- `prepare_accelerator` (DeepSpeed plugin / DDP / wandb の初期化を含む)
- `prepare_dtype`
- `patch_accelerator_for_fp16_training`

**HIGH_VRAM の互換性:**

`train_util.HIGH_VRAM` 形式の属性アクセスを引き続き有効にするため、`train_util.py` に module-level `__getattr__` を追加し、`accelerator_setup.HIGH_VRAM` へ動的転送します。値は `enable_high_vram()` で書き換えられた後でも常に最新値が読めます。

**リポジトリ内コードを直接参照に切替**（shim 非依存方針）:
- `library/args.py`: `verify_training_args` 内の関数内 import 先を更新
- `library/caching.py`: `_tu().HIGH_VRAM` → `accelerator_setup.HIGH_VRAM`（`_tu()` ヘルパー削除）
- `library/dataset.py`: 同上（`_tu()` ヘルパー削除）
- `library/strategy_{sd,flux,sd3,lumina,anima,hunyuan_image}.py` 6 ファイル: `train_util.HIGH_VRAM` → `accelerator_setup.HIGH_VRAM`

なお strategy_*.py に残っている `train_util.clean_memory_on_device` / `train_util.ImageInfo` の shim 依存はスコープ外（別途整理）。

**規模:**
- `library/train_util.py`: 2,103 → 1,969 行
- `library/accelerator_setup.py`: 186 行（新規）
- 累計 6,888 → 1,969 行（71% 削減）

## Test plan
- [x] `python -m py_compile` 全 train スクリプト + tools/cache_*.py 通過
- [x] `pytest tests/` 全 150 件 pass / 2 skip
- [x] shim 関数同一性 + `HIGH_VRAM` の動的転送（`A.HIGH_VRAM = True` 後の `tu.HIGH_VRAM` 読み取り）
- [x] `verify_training_args(--highvram)` 経由の HIGH_VRAM 反映確認
- [x] kohya-ss 側で代表的な学習コマンドのスモーク（特に `--highvram` 指定時の挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)