### PR TITLE
refactor(phase4a): logging / tracker helpers を library/logging_util.py に分離

### DIFF
--- a/anima_train.py
+++ b/anima_train.py
@@ -23,6 +23,7 @@ from accelerate.utils import set_seed
 from library import deepspeed_utils, anima_models, anima_train_utils, anima_utils, strategy_base, strategy_anima, sai_model_spec
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -472,7 +473,7 @@ def train(args):
     if vae is not None:
         logger.info(f"vae device: {vae.device}")
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     epoch = 0
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")

--- a/anima_train_control_net_lllite.py
+++ b/anima_train_control_net_lllite.py
@@ -36,6 +36,7 @@ from library import (
     sai_model_spec,
 )
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.config_util as config_util
 from library.config_util import ConfigSanitizer, BlueprintGenerator
 from library.custom_train_functions import apply_masked_loss, add_custom_train_arguments
@@ -584,7 +585,7 @@ def train(args):
             if os.path.exists(old_ckpt):
                 os.remove(old_ckpt)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     epoch = 0
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -26,6 +26,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -346,7 +347,7 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")
         current_epoch.value = epoch + 1

--- a/flux_train.py
+++ b/flux_train.py
@@ -34,6 +34,7 @@ from library import deepspeed_utils, flux_train_utils, flux_utils, strategy_base
 from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -578,7 +579,7 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     epoch = 0  # avoid error when max_train_steps is 0
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")

--- a/flux_train_control_net.py
+++ b/flux_train_control_net.py
@@ -32,6 +32,7 @@ init_ipex()
 from accelerate.utils import set_seed
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.sai_model_spec as sai_model_spec
 from library import (
     deepspeed_utils,
@@ -587,7 +588,7 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     epoch = 0  # avoid error when max_train_steps is 0
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")

--- a/library/logging_util.py
+++ b/library/logging_util.py
@@ -1,0 +1,77 @@
+"""Logging / experiment-tracker helpers extracted from ``library.train_util``.
+
+This module hosts:
+
+- :func:`init_trackers` — initialise accelerate experiment trackers
+  (W&B / TensorBoard / etc.) with our own conventions.
+- :class:`LossRecorder` — running moving-average loss accumulator used by
+  the training loops for progress display.
+
+Both used to live in ``library.train_util`` and are still re-exported from
+there for backward compatibility. New code should import from this module.
+"""
+
+import argparse
+from typing import List
+
+import toml
+from accelerate import Accelerator
+
+from library.args import get_sanitized_config_or_none
+from library.utils import setup_logging
+
+setup_logging()
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def init_trackers(accelerator: Accelerator, args: argparse.Namespace, default_tracker_name: str):
+    """
+    Initialize experiment trackers with tracker specific behaviors
+    """
+    if accelerator.is_main_process:
+        init_kwargs = {}
+        if args.wandb_run_name:
+            init_kwargs["wandb"] = {"name": args.wandb_run_name}
+        if args.log_tracker_config is not None:
+            init_kwargs = toml.load(args.log_tracker_config)
+        accelerator.init_trackers(
+            default_tracker_name if args.log_tracker_name is None else args.log_tracker_name,
+            config=get_sanitized_config_or_none(args),
+            init_kwargs=init_kwargs,
+        )
+
+        if "wandb" in [tracker.name for tracker in accelerator.trackers]:
+            import wandb
+
+            wandb_tracker = accelerator.get_tracker("wandb", unwrap=True)
+
+            # Define specific metrics to handle validation and epochs "steps"
+            wandb_tracker.define_metric("epoch", hidden=True)
+            wandb_tracker.define_metric("val_step", hidden=True)
+
+            wandb_tracker.define_metric("global_step", hidden=True)
+
+
+class LossRecorder:
+    def __init__(self):
+        self.loss_list: List[float] = []
+        self.loss_total: float = 0.0
+
+    def add(self, *, epoch: int, step: int, loss: float) -> None:
+        if epoch == 0:
+            self.loss_list.append(loss)
+        else:
+            while len(self.loss_list) <= step:
+                self.loss_list.append(0.0)
+            self.loss_total -= self.loss_list[step]
+            self.loss_list[step] = loss
+        self.loss_total += loss
+
+    @property
+    def moving_average(self) -> float:
+        losses = len(self.loss_list)
+        if losses == 0:
+            return 0
+        return self.loss_total / losses

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1277,32 +1277,10 @@ def sample_image_inference(
         wandb_tracker.log({f"sample_{i}": wandb.Image(image, caption=prompt)}, commit=False)  # positive prompt as a caption
 
 
-def init_trackers(accelerator: Accelerator, args: argparse.Namespace, default_tracker_name: str):
-    """
-    Initialize experiment trackers with tracker specific behaviors
-    """
-    if accelerator.is_main_process:
-        init_kwargs = {}
-        if args.wandb_run_name:
-            init_kwargs["wandb"] = {"name": args.wandb_run_name}
-        if args.log_tracker_config is not None:
-            init_kwargs = toml.load(args.log_tracker_config)
-        accelerator.init_trackers(
-            default_tracker_name if args.log_tracker_name is None else args.log_tracker_name,
-            config=get_sanitized_config_or_none(args),
-            init_kwargs=init_kwargs,
-        )
-
-        if "wandb" in [tracker.name for tracker in accelerator.trackers]:
-            import wandb
-
-            wandb_tracker = accelerator.get_tracker("wandb", unwrap=True)
-
-            # Define specific metrics to handle validation and epochs "steps"
-            wandb_tracker.define_metric("epoch", hidden=True)
-            wandb_tracker.define_metric("val_step", hidden=True)
-
-            wandb_tracker.define_metric("global_step", hidden=True)
+# Logging / tracker helpers have moved to library.logging_util;
+# re-exported here for backward compatibility.
+# New code should import from library.logging_util directly.
+from library.logging_util import init_trackers  # noqa: F401, E402
 
 
 # endregion
@@ -1356,24 +1334,7 @@ class collator_class:
         return examples[0]
 
 
-class LossRecorder:
-    def __init__(self):
-        self.loss_list: List[float] = []
-        self.loss_total: float = 0.0
-
-    def add(self, *, epoch: int, step: int, loss: float) -> None:
-        if epoch == 0:
-            self.loss_list.append(loss)
-        else:
-            while len(self.loss_list) <= step:
-                self.loss_list.append(0.0)
-            self.loss_total -= self.loss_list[step]
-            self.loss_list[step] = loss
-        self.loss_total += loss
-
-    @property
-    def moving_average(self) -> float:
-        losses = len(self.loss_list)
-        if losses == 0:
-            return 0
-        return self.loss_total / losses
+# LossRecorder has moved to library.logging_util;
+# re-exported here for backward compatibility.
+# New code should import from library.logging_util directly.
+from library.logging_util import LossRecorder  # noqa: F401, E402

--- a/lumina_train.py
+++ b/lumina_train.py
@@ -36,6 +36,7 @@ from library import (
 from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -671,7 +672,7 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     epoch = 0  # avoid error when max_train_steps is 0
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -28,6 +28,7 @@ from library.sdxl_train_util import match_mixed_precision
 # , sdxl_model_util
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -732,7 +733,7 @@ def train(args):
         else "vae is None"
     )
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     epoch = 0  # avoid error when max_train_steps is 0
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -20,6 +20,7 @@ from diffusers import DDPMScheduler
 from library import deepspeed_utils, sdxl_model_util, strategy_base, strategy_sd, strategy_sdxl, sai_model_spec
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -622,7 +623,7 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")
         current_epoch.value = epoch + 1

--- a/sdxl_train_control_net.py
+++ b/sdxl_train_control_net.py
@@ -29,6 +29,7 @@ from library import (
 )
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -409,7 +410,7 @@ def train(args):
             init_kwargs=init_kwargs,
         )
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     del train_dataset_group
 
     # function for saving/removing

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -37,6 +37,7 @@ from library import (
 
 import library.model_util as model_util
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -384,7 +385,7 @@ def train(args):
             init_kwargs=init_kwargs,
         )
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     del train_dataset_group
 
     # function for saving/removing

--- a/sdxl_train_leco.py
+++ b/sdxl_train_leco.py
@@ -11,7 +11,7 @@ from library.device_utils import init_ipex, clean_memory_on_device
 
 init_ipex()
 
-from library import custom_train_functions, sdxl_model_util, sdxl_train_util, strategy_sdxl, train_util
+from library import custom_train_functions, logging_util, sdxl_model_util, sdxl_train_util, strategy_sdxl, train_util
 from library.custom_train_functions import apply_snr_weight, prepare_scheduler_for_custom_training
 from library.leco_train_util import (
     PromptEmbedsCache,
@@ -206,7 +206,7 @@ def main():
 
     optimizer_train_fn, _ = train_util.get_optimizer_train_eval_fn(optimizer, args)
     optimizer_train_fn()
-    train_util.init_trackers(accelerator, args, "sdxl_leco_train")
+    logging_util.init_trackers(accelerator, args, "sdxl_leco_train")
 
     progress_bar = tqdm(total=args.max_train_steps, disable=not accelerator.is_local_main_process, desc="steps")
     global_step = 0

--- a/train_control_net.py
+++ b/train_control_net.py
@@ -24,6 +24,7 @@ from safetensors.torch import load_file
 
 import library.model_util as model_util
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -394,7 +395,7 @@ def train(args):
             init_kwargs=init_kwargs,
         )
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     del train_dataset_group
 
     # function for saving/removing

--- a/train_db.py
+++ b/train_db.py
@@ -21,6 +21,7 @@ from accelerate.utils import set_seed
 from diffusers import DDPMScheduler
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -323,7 +324,7 @@ def train(args):
         # log empty object to commit the sample images to wandb
         accelerator.log({}, step=0)
 
-    loss_recorder = train_util.LossRecorder()
+    loss_recorder = logging_util.LossRecorder()
     for epoch in range(num_train_epochs):
         accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}")
         current_epoch.value = epoch + 1

--- a/train_leco.py
+++ b/train_leco.py
@@ -11,7 +11,7 @@ from library.device_utils import init_ipex, clean_memory_on_device
 
 init_ipex()
 
-from library import custom_train_functions, strategy_sd, train_util
+from library import custom_train_functions, logging_util, strategy_sd, train_util
 from library.custom_train_functions import apply_snr_weight, prepare_scheduler_for_custom_training
 from library.leco_train_util import (
     PromptEmbedsCache,
@@ -198,7 +198,7 @@ def main():
 
     optimizer_train_fn, _ = train_util.get_optimizer_train_eval_fn(optimizer, args)
     optimizer_train_fn()
-    train_util.init_trackers(accelerator, args, "leco_train")
+    logging_util.init_trackers(accelerator, args, "leco_train")
 
     progress_bar = tqdm(total=args.max_train_steps, disable=not accelerator.is_local_main_process, desc="steps")
     global_step = 0

--- a/train_network.py
+++ b/train_network.py
@@ -28,6 +28,7 @@ from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
 from library import deepspeed_utils, model_util, sai_model_spec, strategy_base, strategy_sd, sai_model_spec
 
 import library.train_util as train_util
+import library.logging_util as logging_util
 from library.train_util import DreamBoothDataset
 import library.config_util as config_util
 from library.config_util import (
@@ -1276,11 +1277,11 @@ class NetworkTrainer:
 
         noise_scheduler = self.get_noise_scheduler(args, accelerator.device)
 
-        train_util.init_trackers(accelerator, args, "network_train")
+        logging_util.init_trackers(accelerator, args, "network_train")
 
-        loss_recorder = train_util.LossRecorder()
-        val_step_loss_recorder = train_util.LossRecorder()
-        val_epoch_loss_recorder = train_util.LossRecorder()
+        loss_recorder = logging_util.LossRecorder()
+        val_step_loss_recorder = logging_util.LossRecorder()
+        val_epoch_loss_recorder = logging_util.LossRecorder()
 
         del train_dataset_group
         if val_dataset_group is not None:


### PR DESCRIPTION
## Summary

train_util.py 解体リファクタの PR-4a。`init_trackers` と `LossRecorder` を `library/logging_util.py` に切り出します。

- 新規モジュール `library/logging_util.py`（77 行）
  - `init_trackers` — accelerate experiment tracker 初期化（W&B / TensorBoard / etc.）
  - `LossRecorder` — 学習ループ表示用の移動平均ロス集計
- `library/train_util.py` は re-export shim を維持（fork 互換）
- 当リポジトリ内 15 ファイルの呼び出しを `logging_util.*` への直接参照に切替

## 変更点

- `library/logging_util.py`: 新規 77 行
- `library/train_util.py`: -42 行（本体削除、re-export 化）
- 呼び出し側 15 ファイル: `import library.logging_util as logging_util` を追加し `train_util.init_trackers` / `train_util.LossRecorder` を `logging_util.*` に置換
  - fine_tune.py / train_db.py / train_network.py / train_leco.py / train_control_net.py
  - sdxl_train.py / sdxl_train_leco.py / sdxl_train_control_net.py / sdxl_train_control_net_lllite.py
  - sd3_train.py / flux_train.py / flux_train_control_net.py
  - lumina_train.py / anima_train.py / anima_train_control_net_lllite.py

## Test plan

- [x] `python -m pytest tests/` → 150 passed, 2 skipped
- [x] 移動した 2 シンボルが新旧パスで同一オブジェクト（shim 経由）
- [x] 15 スクリプトの import smoke
- [x] kohya-ss 側スモーク（学習 1 step）

🤖 Generated with [Claude Code](https://claude.com/claude-code)