### PR TITLE
refactor(phase4b): loss / noise scheduling helpers を library/loss.py に分離

### DIFF
--- a/anima_train.py
+++ b/anima_train.py
@@ -24,6 +24,7 @@ from library import deepspeed_utils, anima_models, anima_train_utils, anima_util
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -571,8 +572,8 @@ def train(args):
                 )
 
                 # Loss
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, None)
-                loss = train_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, None)
+                loss = loss_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
                     loss = apply_masked_loss(loss, batch)
                 loss = loss.mean([1, 2, 3])  # (B, C, H, W) -> (B,)

--- a/anima_train_control_net_lllite.py
+++ b/anima_train_control_net_lllite.py
@@ -37,6 +37,7 @@ from library import (
 )
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.config_util as config_util
 from library.config_util import ConfigSanitizer, BlueprintGenerator
 from library.custom_train_functions import apply_masked_loss, add_custom_train_arguments
@@ -672,8 +673,8 @@ def train(args):
                 weighting = anima_train_utils.compute_loss_weighting_for_anima(
                     weighting_scheme=args.weighting_scheme, sigmas=sigmas
                 )
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, None)
-                loss = train_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, None)
+                loss = loss_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
                     loss = apply_masked_loss(loss, batch)
                 loss = loss.mean([1, 2, 3])

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -395,7 +396,7 @@ def train(args):
 
                 # Sample noise, sample a random timestep for each image, and add noise to the latents,
                 # with noise offset and/or multires noise if specified
-                noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
+                noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
 
                 if batch["masks"] is not None:
                     # Concatenate the noised latents with the mask and the masked latents
@@ -411,10 +412,10 @@ def train(args):
                 else:
                     target = noise
 
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
                 if args.min_snr_gamma or args.scale_v_pred_loss_like_noise_pred or args.debiased_estimation_loss:
                     # do not mean over batch dimension for snr weight or scale v-pred loss
-                    loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                    loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                     loss = loss.mean([1, 2, 3])
 
                     if args.min_snr_gamma:
@@ -426,7 +427,7 @@ def train(args):
 
                     loss = loss.mean()  # mean over batch dimension
                 else:
-                    loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "mean", huber_c)
+                    loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "mean", huber_c)
 
                 accelerator.backward(loss)
                 if accelerator.sync_gradients and args.max_grad_norm != 0.0:

--- a/flux_train.py
+++ b/flux_train.py
@@ -35,6 +35,7 @@ from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -668,8 +669,8 @@ def train(args):
                 target = noise - latents
 
                 # calculate loss
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                loss = train_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                loss = loss_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 if weighting is not None:
                     loss = loss * weighting
                 if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):

--- a/flux_train_control_net.py
+++ b/flux_train_control_net.py
@@ -33,6 +33,7 @@ from accelerate.utils import set_seed
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.sai_model_spec as sai_model_spec
 from library import (
     deepspeed_utils,
@@ -693,7 +694,7 @@ def train(args):
                 target = noise - latents
 
                 # calculate loss
-                loss = train_util.conditional_loss(
+                loss = loss_util.conditional_loss(
                     model_pred.float(), target.float(), reduction="none", loss_type=args.loss_type, huber_c=None
                 )
                 if weighting is not None:

--- a/library/loss.py
+++ b/library/loss.py
@@ -1,0 +1,130 @@
+"""Loss / noise scheduling helpers extracted from ``library.train_util``.
+
+This module hosts the per-step loss building blocks shared by every
+trainer:
+
+- :func:`get_timesteps` — sample diffusion timesteps for a batch.
+- :func:`get_noise_noisy_latents_and_timesteps` — sample noise + timestep
+  and produce noisy latents (with noise-offset / multires-noise / IP-noise
+  variants applied).
+- :func:`get_huber_threshold_if_needed` — per-timestep Huber/Smooth-L1
+  threshold schedule (exponential / SNR / constant).
+- :func:`conditional_loss` — dispatch over ``l2 / l1 / huber / smooth_l1``.
+
+These used to live in ``library.train_util`` and are still re-exported
+from there for backward compatibility. New code should import from this
+module.
+"""
+
+import math
+from typing import Optional, Tuple
+
+import torch
+
+from library import custom_train_functions
+
+
+def get_timesteps(min_timestep: int, max_timestep: int, b_size: int, device: torch.device) -> torch.Tensor:
+    if min_timestep < max_timestep:
+        timesteps = torch.randint(min_timestep, max_timestep, (b_size,), device="cpu")
+    else:
+        timesteps = torch.full((b_size,), max_timestep, device="cpu")
+    timesteps = timesteps.long().to(device)
+    return timesteps
+
+
+def get_noise_noisy_latents_and_timesteps(
+    args, noise_scheduler, latents: torch.FloatTensor
+) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.IntTensor]:
+    # Sample noise that we'll add to the latents
+    noise = torch.randn_like(latents, device=latents.device)
+    if args.noise_offset:
+        if args.noise_offset_random_strength:
+            noise_offset = torch.rand(1, device=latents.device) * args.noise_offset
+        else:
+            noise_offset = args.noise_offset
+        noise = custom_train_functions.apply_noise_offset(latents, noise, noise_offset, args.adaptive_noise_scale)
+    if args.multires_noise_iterations:
+        noise = custom_train_functions.pyramid_noise_like(
+            noise, latents.device, args.multires_noise_iterations, args.multires_noise_discount
+        )
+
+    # Sample a random timestep for each image
+    b_size = latents.shape[0]
+    min_timestep = 0 if args.min_timestep is None else args.min_timestep
+    max_timestep = noise_scheduler.config.num_train_timesteps if args.max_timestep is None else args.max_timestep
+    timesteps = get_timesteps(min_timestep, max_timestep, b_size, latents.device)
+
+    # Add noise to the latents according to the noise magnitude at each timestep
+    # (this is the forward diffusion process)
+    if args.ip_noise_gamma:
+        if args.ip_noise_gamma_random_strength:
+            strength = torch.rand(1, device=latents.device) * args.ip_noise_gamma
+        else:
+            strength = args.ip_noise_gamma
+        noisy_latents = noise_scheduler.add_noise(latents, noise + strength * torch.randn_like(latents), timesteps)
+    else:
+        noisy_latents = noise_scheduler.add_noise(latents, noise, timesteps)
+
+    # This moves the alphas_cumprod back to the CPU after it is moved in noise_scheduler.add_noise
+    noise_scheduler.alphas_cumprod = noise_scheduler.alphas_cumprod.cpu()
+
+    return noise, noisy_latents, timesteps
+
+
+def get_huber_threshold_if_needed(args, timesteps: torch.Tensor, noise_scheduler) -> Optional[torch.Tensor]:
+    if not (args.loss_type == "huber" or args.loss_type == "smooth_l1"):
+        return None
+
+    b_size = timesteps.shape[0]
+    if args.huber_schedule == "exponential":
+        alpha = -math.log(args.huber_c) / noise_scheduler.config.num_train_timesteps
+        result = torch.exp(-alpha * timesteps) * args.huber_scale
+    elif args.huber_schedule == "snr":
+        if not hasattr(noise_scheduler, "alphas_cumprod"):
+            raise NotImplementedError("Huber schedule 'snr' is not supported with the current model.")
+        alphas_cumprod = torch.index_select(noise_scheduler.alphas_cumprod, 0, timesteps.cpu())
+        sigmas = ((1.0 - alphas_cumprod) / alphas_cumprod) ** 0.5
+        result = (1 - args.huber_c) / (1 + sigmas) ** 2 + args.huber_c
+        result = result.to(timesteps.device)
+    elif args.huber_schedule == "constant":
+        result = torch.full((b_size,), args.huber_c * args.huber_scale, device=timesteps.device)
+    else:
+        raise NotImplementedError(f"Unknown Huber loss schedule {args.huber_schedule}!")
+
+    return result
+
+
+def conditional_loss(
+    model_pred: torch.Tensor, target: torch.Tensor, loss_type: str, reduction: str, huber_c: Optional[torch.Tensor] = None
+):
+    """
+    NOTE: if you're using the scheduled version, huber_c has to depend on the timesteps already
+    """
+    if loss_type == "l2":
+        loss = torch.nn.functional.mse_loss(model_pred, target, reduction=reduction)
+    elif loss_type == "l1":
+        loss = torch.nn.functional.l1_loss(model_pred, target, reduction=reduction)
+    elif loss_type == "huber":
+        if huber_c is None:
+            raise NotImplementedError("huber_c not implemented correctly")
+        # Reshape huber_c to broadcast with model_pred (supports 4D and 5D tensors)
+        huber_c = huber_c.view(-1, *([1] * (model_pred.ndim - 1)))
+        loss = 2 * huber_c * (torch.sqrt((model_pred - target) ** 2 + huber_c**2) - huber_c)
+        if reduction == "mean":
+            loss = torch.mean(loss)
+        elif reduction == "sum":
+            loss = torch.sum(loss)
+    elif loss_type == "smooth_l1":
+        if huber_c is None:
+            raise NotImplementedError("huber_c not implemented correctly")
+        # Reshape huber_c to broadcast with model_pred (supports 4D and 5D tensors)
+        huber_c = huber_c.view(-1, *([1] * (model_pred.ndim - 1)))
+        loss = 2 * (torch.sqrt((model_pred - target) ** 2 + huber_c**2) - huber_c)
+        if reduction == "mean":
+            loss = torch.mean(loss)
+        elif reduction == "sum":
+            loss = torch.sum(loss)
+    else:
+        raise NotImplementedError(f"Unsupported Loss Type: {loss_type}")
+    return loss

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -733,110 +733,15 @@ def save_sd_model_on_train_end_common(
             huggingface_util.upload(args, out_dir, "/" + model_name, force_sync_upload=True)
 
 
-def get_timesteps(min_timestep: int, max_timestep: int, b_size: int, device: torch.device) -> torch.Tensor:
-    if min_timestep < max_timestep:
-        timesteps = torch.randint(min_timestep, max_timestep, (b_size,), device="cpu")
-    else:
-        timesteps = torch.full((b_size,), max_timestep, device="cpu")
-    timesteps = timesteps.long().to(device)
-    return timesteps
-
-
-def get_noise_noisy_latents_and_timesteps(
-    args, noise_scheduler, latents: torch.FloatTensor
-) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.IntTensor]:
-    # Sample noise that we'll add to the latents
-    noise = torch.randn_like(latents, device=latents.device)
-    if args.noise_offset:
-        if args.noise_offset_random_strength:
-            noise_offset = torch.rand(1, device=latents.device) * args.noise_offset
-        else:
-            noise_offset = args.noise_offset
-        noise = custom_train_functions.apply_noise_offset(latents, noise, noise_offset, args.adaptive_noise_scale)
-    if args.multires_noise_iterations:
-        noise = custom_train_functions.pyramid_noise_like(
-            noise, latents.device, args.multires_noise_iterations, args.multires_noise_discount
-        )
-
-    # Sample a random timestep for each image
-    b_size = latents.shape[0]
-    min_timestep = 0 if args.min_timestep is None else args.min_timestep
-    max_timestep = noise_scheduler.config.num_train_timesteps if args.max_timestep is None else args.max_timestep
-    timesteps = get_timesteps(min_timestep, max_timestep, b_size, latents.device)
-
-    # Add noise to the latents according to the noise magnitude at each timestep
-    # (this is the forward diffusion process)
-    if args.ip_noise_gamma:
-        if args.ip_noise_gamma_random_strength:
-            strength = torch.rand(1, device=latents.device) * args.ip_noise_gamma
-        else:
-            strength = args.ip_noise_gamma
-        noisy_latents = noise_scheduler.add_noise(latents, noise + strength * torch.randn_like(latents), timesteps)
-    else:
-        noisy_latents = noise_scheduler.add_noise(latents, noise, timesteps)
-
-    # This moves the alphas_cumprod back to the CPU after it is moved in noise_scheduler.add_noise
-    noise_scheduler.alphas_cumprod = noise_scheduler.alphas_cumprod.cpu()
-
-    return noise, noisy_latents, timesteps
-
-
-def get_huber_threshold_if_needed(args, timesteps: torch.Tensor, noise_scheduler) -> Optional[torch.Tensor]:
-    if not (args.loss_type == "huber" or args.loss_type == "smooth_l1"):
-        return None
-
-    b_size = timesteps.shape[0]
-    if args.huber_schedule == "exponential":
-        alpha = -math.log(args.huber_c) / noise_scheduler.config.num_train_timesteps
-        result = torch.exp(-alpha * timesteps) * args.huber_scale
-    elif args.huber_schedule == "snr":
-        if not hasattr(noise_scheduler, "alphas_cumprod"):
-            raise NotImplementedError("Huber schedule 'snr' is not supported with the current model.")
-        alphas_cumprod = torch.index_select(noise_scheduler.alphas_cumprod, 0, timesteps.cpu())
-        sigmas = ((1.0 - alphas_cumprod) / alphas_cumprod) ** 0.5
-        result = (1 - args.huber_c) / (1 + sigmas) ** 2 + args.huber_c
-        result = result.to(timesteps.device)
-    elif args.huber_schedule == "constant":
-        result = torch.full((b_size,), args.huber_c * args.huber_scale, device=timesteps.device)
-    else:
-        raise NotImplementedError(f"Unknown Huber loss schedule {args.huber_schedule}!")
-
-    return result
-
-
-def conditional_loss(
-    model_pred: torch.Tensor, target: torch.Tensor, loss_type: str, reduction: str, huber_c: Optional[torch.Tensor] = None
-):
-    """
-    NOTE: if you're using the scheduled version, huber_c has to depend on the timesteps already
-    """
-    if loss_type == "l2":
-        loss = torch.nn.functional.mse_loss(model_pred, target, reduction=reduction)
-    elif loss_type == "l1":
-        loss = torch.nn.functional.l1_loss(model_pred, target, reduction=reduction)
-    elif loss_type == "huber":
-        if huber_c is None:
-            raise NotImplementedError("huber_c not implemented correctly")
-        # Reshape huber_c to broadcast with model_pred (supports 4D and 5D tensors)
-        huber_c = huber_c.view(-1, *([1] * (model_pred.ndim - 1)))
-        loss = 2 * huber_c * (torch.sqrt((model_pred - target) ** 2 + huber_c**2) - huber_c)
-        if reduction == "mean":
-            loss = torch.mean(loss)
-        elif reduction == "sum":
-            loss = torch.sum(loss)
-    elif loss_type == "smooth_l1":
-        if huber_c is None:
-            raise NotImplementedError("huber_c not implemented correctly")
-        # Reshape huber_c to broadcast with model_pred (supports 4D and 5D tensors)
-        huber_c = huber_c.view(-1, *([1] * (model_pred.ndim - 1)))
-        loss = 2 * (torch.sqrt((model_pred - target) ** 2 + huber_c**2) - huber_c)
-        if reduction == "mean":
-            loss = torch.mean(loss)
-        elif reduction == "sum":
-            loss = torch.sum(loss)
-    else:
-        raise NotImplementedError(f"Unsupported Loss Type: {loss_type}")
-    return loss
+# Loss / noise scheduling helpers have moved to library.loss;
+# re-exported here for backward compatibility.
+# New code should import from library.loss directly.
+from library.loss import (  # noqa: F401
+    get_timesteps,
+    get_noise_noisy_latents_and_timesteps,
+    get_huber_threshold_if_needed,
+    conditional_loss,
+)
 
 
 

--- a/lumina_train.py
+++ b/lumina_train.py
@@ -37,6 +37,7 @@ from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -765,10 +766,10 @@ def train(args):
                 target = latents - noise
 
                 # calculate loss
-                huber_c = train_util.get_huber_threshold_if_needed(
+                huber_c = loss_util.get_huber_threshold_if_needed(
                     args, 1000 - timesteps, noise_scheduler
                 )
-                loss = train_util.conditional_loss(
+                loss = loss_util.conditional_loss(
                     model_pred.float(), target.float(), args.loss_type, "none", huber_c
                 )
                 if weighting is not None:

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -29,6 +29,7 @@ from library.sdxl_train_util import match_mixed_precision
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -849,8 +850,8 @@ def train(args):
                 #     1,
                 # )
                 # calculate loss
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, dummy_scheduler)
-                loss = train_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, dummy_scheduler)
+                loss = loss_util.conditional_loss(model_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
                     loss = apply_masked_loss(loss, batch)
                 loss = loss.mean([1, 2, 3])

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -21,6 +21,7 @@ from library import deepspeed_utils, sdxl_model_util, strategy_base, strategy_sd
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -697,7 +698,7 @@ def train(args):
 
                 # Sample noise, sample a random timestep for each image, and add noise to the latents,
                 # with noise offset and/or multires noise if specified
-                noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
+                noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
 
                 noisy_latents = noisy_latents.to(weight_dtype)  # TODO check why noisy_latents is not weight_dtype
 
@@ -724,7 +725,7 @@ def train(args):
                 else:
                     target = noise
 
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
                 if (
                     args.min_snr_gamma
                     or args.scale_v_pred_loss_like_noise_pred
@@ -733,7 +734,7 @@ def train(args):
                     or args.masked_loss
                 ):
                     # do not mean over batch dimension for snr weight or scale v-pred loss
-                    loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                    loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                     if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
                         loss = apply_masked_loss(loss, batch)
                     loss = loss.mean([1, 2, 3])
@@ -749,7 +750,7 @@ def train(args):
 
                     loss = loss.mean()  # mean over batch dimension
                 else:
-                    loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "mean", huber_c)
+                    loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "mean", huber_c)
 
                 accelerator.backward(loss)
 

--- a/sdxl_train_control_net.py
+++ b/sdxl_train_control_net.py
@@ -30,6 +30,7 @@ from library import (
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -514,7 +515,7 @@ def train(args):
 
                 # Sample noise, sample a random timestep for each image, and add noise to the latents,
                 # with noise offset and/or multires noise if specified
-                noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
+                noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
 
                 controlnet_image = batch["conditioning_images"].to(dtype=weight_dtype)
 
@@ -533,8 +534,8 @@ def train(args):
                 else:
                     target = noise
 
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 loss = loss.mean([1, 2, 3])
 
                 loss_weights = batch["loss_weights"]  # 各sampleごとのweight

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -38,6 +38,7 @@ from library import (
 import library.model_util as model_util
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -466,7 +467,7 @@ def train(args):
 
                 # Sample noise, sample a random timestep for each image, and add noise to the latents,
                 # with noise offset and/or multires noise if specified
-                noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
+                noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
 
                 noisy_latents = noisy_latents.to(weight_dtype)  # TODO check why noisy_latents is not weight_dtype
 
@@ -485,8 +486,8 @@ def train(args):
                 else:
                     target = noise
 
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 loss = loss.mean([1, 2, 3])
 
                 loss_weights = batch["loss_weights"]  # 各sampleごとのweight

--- a/train_control_net.py
+++ b/train_control_net.py
@@ -25,6 +25,7 @@ from safetensors.torch import load_file
 import library.model_util as model_util
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -471,7 +472,7 @@ def train(args):
                     )
 
                 # Sample a random timestep for each image
-                timesteps = train_util.get_timesteps(0, noise_scheduler.config.num_train_timesteps, b_size, latents.device)
+                timesteps = loss_util.get_timesteps(0, noise_scheduler.config.num_train_timesteps, b_size, latents.device)
 
                 # Add noise to the latents according to the noise magnitude at each timestep
                 # (this is the forward diffusion process)
@@ -503,8 +504,8 @@ def train(args):
                 else:
                     target = noise
 
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 loss = loss.mean([1, 2, 3])
 
                 loss_weights = batch["loss_weights"]  # 各sampleごとのweight

--- a/train_db.py
+++ b/train_db.py
@@ -22,6 +22,7 @@ from diffusers import DDPMScheduler
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -386,7 +387,7 @@ def train(args):
 
                 # Sample noise, sample a random timestep for each image, and add noise to the latents,
                 # with noise offset and/or multires noise if specified
-                noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
+                noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
 
                 if batch["masks"] is not None:
                   # Concatenate the noised latents with the mask and the masked latents
@@ -402,8 +403,8 @@ def train(args):
                 else:
                     target = noise
 
-                huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                 if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
                     loss = apply_masked_loss(loss, batch)
                 loss = loss.mean([1, 2, 3])

--- a/train_network.py
+++ b/train_network.py
@@ -29,6 +29,7 @@ from library import deepspeed_utils, model_util, sai_model_spec, strategy_base, 
 
 import library.train_util as train_util
 import library.logging_util as logging_util
+import library.loss as loss_util
 from library.train_util import DreamBoothDataset
 import library.config_util as config_util
 from library.config_util import (
@@ -257,7 +258,7 @@ class NetworkTrainer:
     ):
         # Sample noise, sample a random timestep for each image, and add noise to the latents,
         # with noise offset and/or multires noise if specified
-        noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
+        noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)
 
         # ensure the hidden state will require grad
         if args.gradient_checkpointing:
@@ -463,8 +464,8 @@ class NetworkTrainer:
             is_train=is_train,
         )
 
-        huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-        loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+        huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+        loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
         if weighting is not None:
             loss = loss * weighting
         if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -19,6 +19,7 @@ from transformers import CLIPTokenizer
 from library import deepspeed_utils, model_util, strategy_base, strategy_sd, sai_model_spec
 
 import library.train_util as train_util
+import library.loss as loss_util
 import library.huggingface_util as huggingface_util
 import library.config_util as config_util
 from library.config_util import (
@@ -600,7 +601,7 @@ class TextualInversionTrainer:
 
                     # Sample noise, sample a random timestep for each image, and add noise to the latents,
                     # with noise offset and/or multires noise if specified
-                    noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(
+                    noise, noisy_latents, timesteps = loss_util.get_noise_noisy_latents_and_timesteps(
                         args, noise_scheduler, latents
                     )
                     if batch["masks"] is not None:
@@ -619,8 +620,8 @@ class TextualInversionTrainer:
                     else:
                         target = noise
 
-                    huber_c = train_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
-                    loss = train_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
+                    huber_c = loss_util.get_huber_threshold_if_needed(args, timesteps, noise_scheduler)
+                    loss = loss_util.conditional_loss(noise_pred.float(), target.float(), args.loss_type, "none", huber_c)
                     if args.masked_loss or ("alpha_masks" in batch and batch["alpha_masks"] is not None):
                         loss = apply_masked_loss(loss, batch)
                     loss = loss.mean([1, 2, 3])


### PR DESCRIPTION
## Summary

train_util.py 解体リファクタの PR-4b。loss / noise scheduling 系 4 関数を `library/loss.py` に切り出します。

- 新規モジュール `library/loss.py`（130 行）
  - `get_timesteps` — バッチ単位の diffusion timestep サンプリング
  - `get_noise_noisy_latents_and_timesteps` — noise offset / multires noise / IP noise 適用後のノイズ付き latents 生成
  - `get_huber_threshold_if_needed` — Huber / Smooth-L1 用の per-timestep threshold スケジュール (exponential / snr / constant)
  - `conditional_loss` — l2 / l1 / huber / smooth_l1 のディスパッチャ
- `library/train_util.py` は re-export shim を維持（fork 互換）
- 当リポジトリ内 14 ファイルの呼び出しを `loss_util.*` (alias) への直接参照に切替

## 変更点

- `library/loss.py`: 新規 130 行
- `library/train_util.py`: -104 行（本体削除、re-export 化）
- 呼び出し側 14 ファイル: `import library.loss as loss_util` を追加し `train_util.{get_timesteps, get_noise_noisy_latents_and_timesteps, get_huber_threshold_if_needed, conditional_loss}` を `loss_util.*` に置換
  - `loss` というローカル変数名と衝突するため alias は `loss_util`
  - 対象: fine_tune.py / train_db.py / train_network.py / train_textual_inversion.py / train_control_net.py / sdxl_train.py / sdxl_train_control_net.py / sdxl_train_control_net_lllite.py / sd3_train.py / flux_train.py / flux_train_control_net.py / lumina_train.py / anima_train.py / anima_train_control_net_lllite.py

## Test plan

- [x] \`python -m pytest tests/\` → 150 passed, 2 skipped
- [x] 移動した 4 シンボルが新旧パスで同一オブジェクト（shim 経由）
- [x] 14 スクリプトの import smoke
- [x] kohya-ss 側スモーク（学習 1 step）

🤖 Generated with [Claude Code](https://claude.com/claude-code)