### PR TITLE
refactor(phase4c): checkpoint 保存系を library/checkpoint_io.py に分離

### DIFF
--- a/anima_train.py
+++ b/anima_train.py
@@ -25,6 +25,7 @@ from library import deepspeed_utils, anima_models, anima_train_utils, anima_util
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -696,7 +697,7 @@ def train(args):
     optimizer_eval_fn()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator
 

--- a/anima_train_control_net_lllite.py
+++ b/anima_train_control_net_lllite.py
@@ -38,6 +38,7 @@ from library import (
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.config_util as config_util
 from library.config_util import ConfigSanitizer, BlueprintGenerator
 from library.custom_train_functions import apply_masked_loss, add_custom_train_arguments
@@ -553,17 +554,17 @@ def train(args):
         accelerator.wait_for_everyone()
         if not accelerator.is_main_process:
             return
-        ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, global_step_)
+        ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, global_step_)
         os.makedirs(args.output_dir, exist_ok=True)
         ckpt_file = os.path.join(args.output_dir, ckpt_name)
         accelerator.print(f"\nsaving checkpoint: {ckpt_file}")
         _save_lllite(ckpt_file)
         if args.save_state:
-            train_util.save_and_remove_state_stepwise(args, accelerator, global_step_)
-        remove_step_no = train_util.get_remove_step_no(args, global_step_)
+            checkpoint_io.save_and_remove_state_stepwise(args, accelerator, global_step_)
+        remove_step_no = checkpoint_io.get_remove_step_no(args, global_step_)
         if remove_step_no is not None:
             old_ckpt = os.path.join(
-                args.output_dir, train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
+                args.output_dir, checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
             )
             if os.path.exists(old_ckpt):
                 os.remove(old_ckpt)
@@ -571,17 +572,17 @@ def train(args):
     def _save_epoch(epoch_no: int):
         if not accelerator.is_main_process:
             return
-        ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch_no)
+        ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch_no)
         os.makedirs(args.output_dir, exist_ok=True)
         ckpt_file = os.path.join(args.output_dir, ckpt_name)
         accelerator.print(f"\nsaving checkpoint: {ckpt_file}")
         _save_lllite(ckpt_file)
         if args.save_state:
-            train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch_no)
-        remove_epoch_no = train_util.get_remove_epoch_no(args, epoch_no)
+            checkpoint_io.save_and_remove_state_on_epoch_end(args, accelerator, epoch_no)
+        remove_epoch_no = checkpoint_io.get_remove_epoch_no(args, epoch_no)
         if remove_epoch_no is not None:
             old_ckpt = os.path.join(
-                args.output_dir, train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
+                args.output_dir, checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
             )
             if os.path.exists(old_ckpt):
                 os.remove(old_ckpt)
@@ -751,10 +752,10 @@ def train(args):
     optimizer_eval_fn()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     if is_main_process:
-        ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+        ckpt_name = checkpoint_io.get_last_ckpt_name(args, "." + args.save_model_as)
         os.makedirs(args.output_dir, exist_ok=True)
         ckpt_file = os.path.join(args.output_dir, ckpt_name)
         accelerator.print(f"\nsaving final checkpoint: {ckpt_file}")

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -454,7 +455,7 @@ def train(args):
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
-                        train_util.save_sd_model_on_epoch_end_or_stepwise(
+                        checkpoint_io.save_sd_model_on_epoch_end_or_stepwise(
                             args,
                             False,
                             accelerator,
@@ -493,7 +494,7 @@ def train(args):
         if args.save_every_n_epochs is not None:
             if accelerator.is_main_process:
                 src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
-                train_util.save_sd_model_on_epoch_end_or_stepwise(
+                checkpoint_io.save_sd_model_on_epoch_end_or_stepwise(
                     args,
                     True,
                     accelerator,
@@ -521,13 +522,13 @@ def train(args):
     accelerator.end_training()
 
     if is_main_process and (args.save_state or args.save_state_on_train_end):
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 
     if is_main_process:
         src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
-        train_util.save_sd_model_on_train_end(
+        checkpoint_io.save_sd_model_on_train_end(
             args, src_path, save_stable_diffusion_format, use_safetensors, save_dtype, epoch, global_step, text_encoder, unet, vae
         )
         logger.info("model saved.")

--- a/flux_train.py
+++ b/flux_train.py
@@ -36,6 +36,7 @@ from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -775,7 +776,7 @@ def train(args):
     optimizer_eval_fn()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 

--- a/flux_train_control_net.py
+++ b/flux_train_control_net.py
@@ -34,6 +34,7 @@ from accelerate.utils import set_seed
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.sai_model_spec as sai_model_spec
 from library import (
     deepspeed_utils,
@@ -809,7 +810,7 @@ def train(args):
     optimizer_eval_fn()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 

--- a/library/anima_train_utils.py
+++ b/library/anima_train_utils.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from PIL import Image
 
 from library.device_utils import init_ipex, clean_memory_on_device, synchronize_device
-from library import anima_models, anima_utils, train_util, qwen_image_autoencoder_kl
+from library import anima_models, anima_utils, checkpoint_io, train_util, qwen_image_autoencoder_kl
 
 init_ipex()
 
@@ -264,7 +264,7 @@ def save_anima_model_on_train_end(
         # Save with 'net.' prefix for ComfyUI compatibility
         anima_utils.save_anima_model(ckpt_file, dit_sd, sai_metadata, save_dtype)
 
-    train_util.save_sd_model_on_train_end_common(args, True, True, epoch, global_step, sd_saver, None)
+    checkpoint_io.save_sd_model_on_train_end_common(args, True, True, epoch, global_step, sd_saver, None)
 
 
 def save_anima_model_on_epoch_end_or_stepwise(
@@ -286,7 +286,7 @@ def save_anima_model_on_epoch_end_or_stepwise(
         dit_sd = dit.state_dict()
         anima_utils.save_anima_model(ckpt_file, dit_sd, sai_metadata, save_dtype)
 
-    train_util.save_sd_model_on_epoch_end_or_stepwise_common(
+    checkpoint_io.save_sd_model_on_epoch_end_or_stepwise_common(
         args,
         on_epoch_end,
         accelerator,

--- a/library/checkpoint_io.py
+++ b/library/checkpoint_io.py
@@ -1,0 +1,348 @@
+"""Checkpoint / state save & rotate helpers extracted from ``library.train_util``.
+
+This module hosts:
+
+- File-name template constants (``EPOCH_FILE_NAME``, ``STEP_STATE_NAME``, etc.)
+- :func:`get_epoch_ckpt_name` / :func:`get_step_ckpt_name` /
+  :func:`get_last_ckpt_name` — checkpoint filename builders.
+- :func:`get_remove_epoch_no` / :func:`get_remove_step_no` — compute the
+  epoch/step number whose checkpoint should be removed under the rotation
+  policy (``--save_last_n_epochs`` / ``--save_last_n_steps``).
+- :func:`save_sd_model_on_epoch_end_or_stepwise` /
+  :func:`save_sd_model_on_epoch_end_or_stepwise_common` /
+  :func:`save_sd_model_on_train_end` /
+  :func:`save_sd_model_on_train_end_common` — Stable Diffusion 1.x/2.x
+  checkpoint saving (with HF Hub upload + rotation).
+- :func:`save_and_remove_state_on_epoch_end` /
+  :func:`save_and_remove_state_stepwise` / :func:`save_state_on_train_end`
+  — accelerator state saving with HF Hub upload + rotation.
+
+These used to live in ``library.train_util`` and are still re-exported
+from there for backward compatibility. New code should import from this
+module.
+"""
+
+import argparse
+import os
+import shutil
+
+import torch
+
+import library.huggingface_util as huggingface_util
+import library.model_util as model_util
+from library.model_io import get_sai_model_spec
+from library.utils import setup_logging
+
+setup_logging()
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# checkpointファイル名
+EPOCH_STATE_NAME = "{}-{:06d}-state"
+EPOCH_FILE_NAME = "{}-{:06d}"
+EPOCH_DIFFUSERS_DIR_NAME = "{}-{:06d}"
+LAST_STATE_NAME = "{}-state"
+DEFAULT_EPOCH_NAME = "epoch"
+DEFAULT_LAST_OUTPUT_NAME = "last"
+
+DEFAULT_STEP_NAME = "at"
+STEP_STATE_NAME = "{}-step{:08d}-state"
+STEP_FILE_NAME = "{}-step{:08d}"
+STEP_DIFFUSERS_DIR_NAME = "{}-step{:08d}"
+
+
+def default_if_none(value, default):
+    return default if value is None else value
+
+
+def get_epoch_ckpt_name(args: argparse.Namespace, ext: str, epoch_no: int):
+    model_name = default_if_none(args.output_name, DEFAULT_EPOCH_NAME)
+    return EPOCH_FILE_NAME.format(model_name, epoch_no) + ext
+
+
+def get_step_ckpt_name(args: argparse.Namespace, ext: str, step_no: int):
+    model_name = default_if_none(args.output_name, DEFAULT_STEP_NAME)
+    return STEP_FILE_NAME.format(model_name, step_no) + ext
+
+
+def get_last_ckpt_name(args: argparse.Namespace, ext: str):
+    model_name = default_if_none(args.output_name, DEFAULT_LAST_OUTPUT_NAME)
+    return model_name + ext
+
+
+def get_remove_epoch_no(args: argparse.Namespace, epoch_no: int):
+    if args.save_last_n_epochs is None:
+        return None
+
+    remove_epoch_no = epoch_no - args.save_every_n_epochs * args.save_last_n_epochs
+    if remove_epoch_no < 0:
+        return None
+    return remove_epoch_no
+
+
+def get_remove_step_no(args: argparse.Namespace, step_no: int):
+    if args.save_last_n_steps is None:
+        return None
+
+    # last_n_steps前のstep_noから、save_every_n_stepsの倍数のstep_noを計算して削除する
+    # save_every_n_steps=10, save_last_n_steps=30の場合、50step目には30step分残し、10step目を削除する
+    remove_step_no = step_no - args.save_last_n_steps - 1
+    remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
+    if remove_step_no < 0:
+        return None
+    return remove_step_no
+
+
+# epochとstepの保存、メタデータにepoch/stepが含まれ引数が同じになるため、統合している
+# on_epoch_end: Trueならepoch終了時、Falseならstep経過時
+def save_sd_model_on_epoch_end_or_stepwise(
+    args: argparse.Namespace,
+    on_epoch_end: bool,
+    accelerator,
+    src_path: str,
+    save_stable_diffusion_format: bool,
+    use_safetensors: bool,
+    save_dtype: torch.dtype,
+    epoch: int,
+    num_train_epochs: int,
+    global_step: int,
+    text_encoder,
+    unet,
+    vae,
+):
+    def sd_saver(ckpt_file, epoch_no, global_step):
+        sai_metadata = get_sai_model_spec(None, args, False, False, False, is_stable_diffusion_ckpt=True)
+        model_util.save_stable_diffusion_checkpoint(
+            args.v2, ckpt_file, text_encoder, unet, src_path, epoch_no, global_step, sai_metadata, save_dtype, vae
+        )
+
+    def diffusers_saver(out_dir):
+        model_util.save_diffusers_checkpoint(
+            args.v2, out_dir, text_encoder, unet, src_path, vae=vae, use_safetensors=use_safetensors
+        )
+
+    save_sd_model_on_epoch_end_or_stepwise_common(
+        args,
+        on_epoch_end,
+        accelerator,
+        save_stable_diffusion_format,
+        use_safetensors,
+        epoch,
+        num_train_epochs,
+        global_step,
+        sd_saver,
+        diffusers_saver,
+    )
+
+
+def save_sd_model_on_epoch_end_or_stepwise_common(
+    args: argparse.Namespace,
+    on_epoch_end: bool,
+    accelerator,
+    save_stable_diffusion_format: bool,
+    use_safetensors: bool,
+    epoch: int,
+    num_train_epochs: int,
+    global_step: int,
+    sd_saver,
+    diffusers_saver,
+):
+    if on_epoch_end:
+        epoch_no = epoch + 1
+        saving = epoch_no % args.save_every_n_epochs == 0 and epoch_no < num_train_epochs
+        if not saving:
+            return
+
+        model_name = default_if_none(args.output_name, DEFAULT_EPOCH_NAME)
+        remove_no = get_remove_epoch_no(args, epoch_no)
+    else:
+        # 保存するか否かは呼び出し側で判断済み
+
+        model_name = default_if_none(args.output_name, DEFAULT_STEP_NAME)
+        epoch_no = epoch  # 例: 最初のepochの途中で保存したら0になる、SDモデルに保存される
+        remove_no = get_remove_step_no(args, global_step)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    if save_stable_diffusion_format:
+        ext = ".safetensors" if use_safetensors else ".ckpt"
+
+        if on_epoch_end:
+            ckpt_name = get_epoch_ckpt_name(args, ext, epoch_no)
+        else:
+            ckpt_name = get_step_ckpt_name(args, ext, global_step)
+
+        ckpt_file = os.path.join(args.output_dir, ckpt_name)
+        logger.info("")
+        logger.info(f"saving checkpoint: {ckpt_file}")
+        sd_saver(ckpt_file, epoch_no, global_step)
+
+        if args.huggingface_repo_id is not None:
+            huggingface_util.upload(args, ckpt_file, "/" + ckpt_name)
+
+        # remove older checkpoints
+        if remove_no is not None:
+            if on_epoch_end:
+                remove_ckpt_name = get_epoch_ckpt_name(args, ext, remove_no)
+            else:
+                remove_ckpt_name = get_step_ckpt_name(args, ext, remove_no)
+
+            remove_ckpt_file = os.path.join(args.output_dir, remove_ckpt_name)
+            if os.path.exists(remove_ckpt_file):
+                logger.info(f"removing old checkpoint: {remove_ckpt_file}")
+                os.remove(remove_ckpt_file)
+
+    else:
+        if on_epoch_end:
+            out_dir = os.path.join(args.output_dir, EPOCH_DIFFUSERS_DIR_NAME.format(model_name, epoch_no))
+        else:
+            out_dir = os.path.join(args.output_dir, STEP_DIFFUSERS_DIR_NAME.format(model_name, global_step))
+
+        logger.info("")
+        logger.info(f"saving model: {out_dir}")
+        diffusers_saver(out_dir)
+
+        if args.huggingface_repo_id is not None:
+            huggingface_util.upload(args, out_dir, "/" + model_name)
+
+        # remove older checkpoints
+        if remove_no is not None:
+            if on_epoch_end:
+                remove_out_dir = os.path.join(args.output_dir, EPOCH_DIFFUSERS_DIR_NAME.format(model_name, remove_no))
+            else:
+                remove_out_dir = os.path.join(args.output_dir, STEP_DIFFUSERS_DIR_NAME.format(model_name, remove_no))
+
+            if os.path.exists(remove_out_dir):
+                logger.info(f"removing old model: {remove_out_dir}")
+                shutil.rmtree(remove_out_dir)
+
+    if args.save_state:
+        if on_epoch_end:
+            save_and_remove_state_on_epoch_end(args, accelerator, epoch_no)
+        else:
+            save_and_remove_state_stepwise(args, accelerator, global_step)
+
+
+def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator, epoch_no):
+    model_name = default_if_none(args.output_name, DEFAULT_EPOCH_NAME)
+
+    logger.info("")
+    logger.info(f"saving state at epoch {epoch_no}")
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    state_dir = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, epoch_no))
+    accelerator.save_state(state_dir)
+    if args.save_state_to_huggingface:
+        logger.info("uploading state to huggingface.")
+        huggingface_util.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
+
+    last_n_epochs = args.save_last_n_epochs_state if args.save_last_n_epochs_state else args.save_last_n_epochs
+    if last_n_epochs is not None:
+        remove_epoch_no = epoch_no - args.save_every_n_epochs * last_n_epochs
+        state_dir_old = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, remove_epoch_no))
+        if os.path.exists(state_dir_old):
+            logger.info(f"removing old state: {state_dir_old}")
+            shutil.rmtree(state_dir_old)
+
+
+def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator, step_no):
+    model_name = default_if_none(args.output_name, DEFAULT_STEP_NAME)
+
+    logger.info("")
+    logger.info(f"saving state at step {step_no}")
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    state_dir = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, step_no))
+    accelerator.save_state(state_dir)
+    if args.save_state_to_huggingface:
+        logger.info("uploading state to huggingface.")
+        huggingface_util.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
+
+    last_n_steps = args.save_last_n_steps_state if args.save_last_n_steps_state else args.save_last_n_steps
+    if last_n_steps is not None:
+        # last_n_steps前のstep_noから、save_every_n_stepsの倍数のstep_noを計算して削除する
+        remove_step_no = step_no - last_n_steps - 1
+        remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
+
+        if remove_step_no > 0:
+            state_dir_old = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, remove_step_no))
+            if os.path.exists(state_dir_old):
+                logger.info(f"removing old state: {state_dir_old}")
+                shutil.rmtree(state_dir_old)
+
+
+def save_state_on_train_end(args: argparse.Namespace, accelerator):
+    model_name = default_if_none(args.output_name, DEFAULT_LAST_OUTPUT_NAME)
+
+    logger.info("")
+    logger.info("saving last state.")
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    state_dir = os.path.join(args.output_dir, LAST_STATE_NAME.format(model_name))
+    accelerator.save_state(state_dir)
+
+    if args.save_state_to_huggingface:
+        logger.info("uploading last state to huggingface.")
+        huggingface_util.upload(args, state_dir, "/" + LAST_STATE_NAME.format(model_name))
+
+
+def save_sd_model_on_train_end(
+    args: argparse.Namespace,
+    src_path: str,
+    save_stable_diffusion_format: bool,
+    use_safetensors: bool,
+    save_dtype: torch.dtype,
+    epoch: int,
+    global_step: int,
+    text_encoder,
+    unet,
+    vae,
+):
+    def sd_saver(ckpt_file, epoch_no, global_step):
+        sai_metadata = get_sai_model_spec(None, args, False, False, False, is_stable_diffusion_ckpt=True)
+        model_util.save_stable_diffusion_checkpoint(
+            args.v2, ckpt_file, text_encoder, unet, src_path, epoch_no, global_step, sai_metadata, save_dtype, vae
+        )
+
+    def diffusers_saver(out_dir):
+        model_util.save_diffusers_checkpoint(
+            args.v2, out_dir, text_encoder, unet, src_path, vae=vae, use_safetensors=use_safetensors
+        )
+
+    save_sd_model_on_train_end_common(
+        args, save_stable_diffusion_format, use_safetensors, epoch, global_step, sd_saver, diffusers_saver
+    )
+
+
+def save_sd_model_on_train_end_common(
+    args: argparse.Namespace,
+    save_stable_diffusion_format: bool,
+    use_safetensors: bool,
+    epoch: int,
+    global_step: int,
+    sd_saver,
+    diffusers_saver,
+):
+    model_name = default_if_none(args.output_name, DEFAULT_LAST_OUTPUT_NAME)
+
+    if save_stable_diffusion_format:
+        os.makedirs(args.output_dir, exist_ok=True)
+
+        ckpt_name = model_name + (".safetensors" if use_safetensors else ".ckpt")
+        ckpt_file = os.path.join(args.output_dir, ckpt_name)
+
+        logger.info(f"save trained model as StableDiffusion checkpoint to {ckpt_file}")
+        sd_saver(ckpt_file, epoch, global_step)
+
+        if args.huggingface_repo_id is not None:
+            huggingface_util.upload(args, ckpt_file, "/" + ckpt_name, force_sync_upload=True)
+    else:
+        out_dir = os.path.join(args.output_dir, model_name)
+        os.makedirs(out_dir, exist_ok=True)
+
+        logger.info(f"save trained model as Diffusers to {out_dir}")
+        diffusers_saver(out_dir)
+
+        if args.huggingface_repo_id is not None:
+            huggingface_util.upload(args, out_dir, "/" + model_name, force_sync_upload=True)

--- a/library/flux_train_utils.py
+++ b/library/flux_train_utils.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from PIL import Image
 from safetensors.torch import save_file
 
-from library import flux_models, flux_utils, strategy_base, train_util
+from library import flux_models, flux_utils, strategy_base, checkpoint_io, train_util
 from library.device_utils import init_ipex, clean_memory_on_device
 from library.safetensors_utils import mem_eff_save_file
 
@@ -578,7 +578,7 @@ def save_flux_model_on_train_end(
         sai_metadata = train_util.get_sai_model_spec(None, args, False, False, False, is_stable_diffusion_ckpt=True, flux="dev")
         save_models(ckpt_file, flux, sai_metadata, save_dtype, args.mem_eff_save)
 
-    train_util.save_sd_model_on_train_end_common(args, True, True, epoch, global_step, sd_saver, None)
+    checkpoint_io.save_sd_model_on_train_end_common(args, True, True, epoch, global_step, sd_saver, None)
 
 
 # epochとstepの保存、メタデータにepoch/stepが含まれ引数が同じになるため、統合している
@@ -597,7 +597,7 @@ def save_flux_model_on_epoch_end_or_stepwise(
         sai_metadata = train_util.get_sai_model_spec(None, args, False, False, False, is_stable_diffusion_ckpt=True, flux="dev")
         save_models(ckpt_file, flux, sai_metadata, save_dtype, args.mem_eff_save)
 
-    train_util.save_sd_model_on_epoch_end_or_stepwise_common(
+    checkpoint_io.save_sd_model_on_epoch_end_or_stepwise_common(
         args,
         on_epoch_end,
         accelerator,

--- a/library/leco_train_util.py
+++ b/library/leco_train_util.py
@@ -10,7 +10,7 @@ import torch
 import toml
 from torch.utils.checkpoint import checkpoint
 
-from library import train_util
+from library import checkpoint_io, train_util
 
 import logging
 
@@ -48,7 +48,7 @@ def save_weights(
 ) -> None:
     os.makedirs(args.output_dir, exist_ok=True)
     ext = get_save_extension(args)
-    ckpt_name = train_util.get_last_ckpt_name(args, ext) if last else train_util.get_step_ckpt_name(args, ext, global_step)
+    ckpt_name = checkpoint_io.get_last_ckpt_name(args, ext) if last else checkpoint_io.get_step_ckpt_name(args, ext, global_step)
     ckpt_file = os.path.join(args.output_dir, ckpt_name)
 
     metadata = None

--- a/library/lumina_train_util.py
+++ b/library/lumina_train_util.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from PIL import Image
 from safetensors.torch import save_file
 
-from library import lumina_models, strategy_base, strategy_lumina, train_util
+from library import lumina_models, strategy_base, strategy_lumina, checkpoint_io, train_util
 from library.flux_models import AutoEncoder
 from library.device_utils import init_ipex, clean_memory_on_device
 from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
@@ -962,7 +962,7 @@ def save_lumina_model_on_train_end(
         )
         save_models(ckpt_file, lumina, sai_metadata, save_dtype, args.mem_eff_save)
 
-    train_util.save_sd_model_on_train_end_common(
+    checkpoint_io.save_sd_model_on_train_end_common(
         args, True, True, epoch, global_step, sd_saver, None
     )
 
@@ -1005,7 +1005,7 @@ def save_lumina_model_on_epoch_end_or_stepwise(
         )
         save_models(ckpt_file, lumina, sai_metadata, save_dtype, args.mem_eff_save)
 
-    train_util.save_sd_model_on_epoch_end_or_stepwise_common(
+    checkpoint_io.save_sd_model_on_epoch_end_or_stepwise_common(
         args,
         on_epoch_end,
         accelerator,

--- a/library/sd3_train_utils.py
+++ b/library/sd3_train_utils.py
@@ -28,7 +28,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from library import sd3_models, sd3_utils, strategy_base, train_util
+from library import sd3_models, sd3_utils, strategy_base, checkpoint_io, train_util
 
 
 def save_models(
@@ -102,7 +102,7 @@ def save_sd3_model_on_train_end(
         )
         save_models(ckpt_file, mmdit, vae, clip_l, clip_g, t5xxl, sai_metadata, save_dtype)
 
-    train_util.save_sd_model_on_train_end_common(args, True, True, epoch, global_step, sd_saver, None)
+    checkpoint_io.save_sd_model_on_train_end_common(args, True, True, epoch, global_step, sd_saver, None)
 
 
 # epochとstepの保存、メタデータにepoch/stepが含まれ引数が同じになるため、統合している
@@ -127,7 +127,7 @@ def save_sd3_model_on_epoch_end_or_stepwise(
         )
         save_models(ckpt_file, mmdit, vae, clip_l, clip_g, t5xxl, sai_metadata, save_dtype)
 
-    train_util.save_sd_model_on_epoch_end_or_stepwise_common(
+    checkpoint_io.save_sd_model_on_epoch_end_or_stepwise_common(
         args,
         on_epoch_end,
         accelerator,

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -11,7 +11,7 @@ init_ipex()
 from accelerate import init_empty_weights
 from tqdm import tqdm
 from transformers import CLIPTokenizer
-from library import model_util, sdxl_model_util, train_util, sdxl_original_unet
+from library import model_util, sdxl_model_util, checkpoint_io, train_util, sdxl_original_unet
 from .utils import setup_logging
 
 setup_logging()
@@ -269,7 +269,7 @@ def save_sd_model_on_train_end(
             save_dtype=save_dtype,
         )
 
-    train_util.save_sd_model_on_train_end_common(
+    checkpoint_io.save_sd_model_on_train_end_common(
         args, save_stable_diffusion_format, use_safetensors, epoch, global_step, sd_saver, diffusers_saver
     )
 
@@ -322,7 +322,7 @@ def save_sd_model_on_epoch_end_or_stepwise(
             save_dtype=save_dtype,
         )
 
-    train_util.save_sd_model_on_epoch_end_or_stepwise_common(
+    checkpoint_io.save_sd_model_on_epoch_end_or_stepwise_common(
         args,
         on_epoch_end,
         accelerator,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -105,18 +105,21 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-# checkpointファイル名
-EPOCH_STATE_NAME = "{}-{:06d}-state"
-EPOCH_FILE_NAME = "{}-{:06d}"
-EPOCH_DIFFUSERS_DIR_NAME = "{}-{:06d}"
-LAST_STATE_NAME = "{}-state"
-DEFAULT_EPOCH_NAME = "epoch"
-DEFAULT_LAST_OUTPUT_NAME = "last"
-
-DEFAULT_STEP_NAME = "at"
-STEP_STATE_NAME = "{}-step{:08d}-state"
-STEP_FILE_NAME = "{}-step{:08d}"
-STEP_DIFFUSERS_DIR_NAME = "{}-step{:08d}"
+# Checkpoint filename templates and save / rotate helpers have moved to
+# library.checkpoint_io; re-exported here for backward compatibility.
+# New code should import from library.checkpoint_io directly.
+from library.checkpoint_io import (  # noqa: F401
+    EPOCH_STATE_NAME,
+    EPOCH_FILE_NAME,
+    EPOCH_DIFFUSERS_DIR_NAME,
+    LAST_STATE_NAME,
+    DEFAULT_EPOCH_NAME,
+    DEFAULT_LAST_OUTPUT_NAME,
+    DEFAULT_STEP_NAME,
+    STEP_STATE_NAME,
+    STEP_FILE_NAME,
+    STEP_DIFFUSERS_DIR_NAME,
+)
 
 # Dataset core has moved to library.dataset; re-exported here for backward compatibility.
 # New code should import from library.dataset directly.
@@ -438,299 +441,26 @@ from library.hidden_states import (  # noqa: F401
 )
 
 
-def default_if_none(value, default):
-    return default if value is None else value
+# Checkpoint save / rotate helpers have moved to library.checkpoint_io;
+# re-exported here for backward compatibility.
+# New code should import from library.checkpoint_io directly.
+from library.checkpoint_io import (  # noqa: F401
+    default_if_none,
+    get_epoch_ckpt_name,
+    get_step_ckpt_name,
+    get_last_ckpt_name,
+    get_remove_epoch_no,
+    get_remove_step_no,
+    save_sd_model_on_epoch_end_or_stepwise,
+    save_sd_model_on_epoch_end_or_stepwise_common,
+    save_and_remove_state_on_epoch_end,
+    save_and_remove_state_stepwise,
+    save_state_on_train_end,
+    save_sd_model_on_train_end,
+    save_sd_model_on_train_end_common,
+)
 
 
-def get_epoch_ckpt_name(args: argparse.Namespace, ext: str, epoch_no: int):
-    model_name = default_if_none(args.output_name, DEFAULT_EPOCH_NAME)
-    return EPOCH_FILE_NAME.format(model_name, epoch_no) + ext
-
-
-def get_step_ckpt_name(args: argparse.Namespace, ext: str, step_no: int):
-    model_name = default_if_none(args.output_name, DEFAULT_STEP_NAME)
-    return STEP_FILE_NAME.format(model_name, step_no) + ext
-
-
-def get_last_ckpt_name(args: argparse.Namespace, ext: str):
-    model_name = default_if_none(args.output_name, DEFAULT_LAST_OUTPUT_NAME)
-    return model_name + ext
-
-
-def get_remove_epoch_no(args: argparse.Namespace, epoch_no: int):
-    if args.save_last_n_epochs is None:
-        return None
-
-    remove_epoch_no = epoch_no - args.save_every_n_epochs * args.save_last_n_epochs
-    if remove_epoch_no < 0:
-        return None
-    return remove_epoch_no
-
-
-def get_remove_step_no(args: argparse.Namespace, step_no: int):
-    if args.save_last_n_steps is None:
-        return None
-
-    # last_n_steps前のstep_noから、save_every_n_stepsの倍数のstep_noを計算して削除する
-    # save_every_n_steps=10, save_last_n_steps=30の場合、50step目には30step分残し、10step目を削除する
-    remove_step_no = step_no - args.save_last_n_steps - 1
-    remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
-    if remove_step_no < 0:
-        return None
-    return remove_step_no
-
-
-# epochとstepの保存、メタデータにepoch/stepが含まれ引数が同じになるため、統合している
-# on_epoch_end: Trueならepoch終了時、Falseならstep経過時
-def save_sd_model_on_epoch_end_or_stepwise(
-    args: argparse.Namespace,
-    on_epoch_end: bool,
-    accelerator,
-    src_path: str,
-    save_stable_diffusion_format: bool,
-    use_safetensors: bool,
-    save_dtype: torch.dtype,
-    epoch: int,
-    num_train_epochs: int,
-    global_step: int,
-    text_encoder,
-    unet,
-    vae,
-):
-    def sd_saver(ckpt_file, epoch_no, global_step):
-        sai_metadata = get_sai_model_spec(None, args, False, False, False, is_stable_diffusion_ckpt=True)
-        model_util.save_stable_diffusion_checkpoint(
-            args.v2, ckpt_file, text_encoder, unet, src_path, epoch_no, global_step, sai_metadata, save_dtype, vae
-        )
-
-    def diffusers_saver(out_dir):
-        model_util.save_diffusers_checkpoint(
-            args.v2, out_dir, text_encoder, unet, src_path, vae=vae, use_safetensors=use_safetensors
-        )
-
-    save_sd_model_on_epoch_end_or_stepwise_common(
-        args,
-        on_epoch_end,
-        accelerator,
-        save_stable_diffusion_format,
-        use_safetensors,
-        epoch,
-        num_train_epochs,
-        global_step,
-        sd_saver,
-        diffusers_saver,
-    )
-
-
-def save_sd_model_on_epoch_end_or_stepwise_common(
-    args: argparse.Namespace,
-    on_epoch_end: bool,
-    accelerator,
-    save_stable_diffusion_format: bool,
-    use_safetensors: bool,
-    epoch: int,
-    num_train_epochs: int,
-    global_step: int,
-    sd_saver,
-    diffusers_saver,
-):
-    if on_epoch_end:
-        epoch_no = epoch + 1
-        saving = epoch_no % args.save_every_n_epochs == 0 and epoch_no < num_train_epochs
-        if not saving:
-            return
-
-        model_name = default_if_none(args.output_name, DEFAULT_EPOCH_NAME)
-        remove_no = get_remove_epoch_no(args, epoch_no)
-    else:
-        # 保存するか否かは呼び出し側で判断済み
-
-        model_name = default_if_none(args.output_name, DEFAULT_STEP_NAME)
-        epoch_no = epoch  # 例: 最初のepochの途中で保存したら0になる、SDモデルに保存される
-        remove_no = get_remove_step_no(args, global_step)
-
-    os.makedirs(args.output_dir, exist_ok=True)
-    if save_stable_diffusion_format:
-        ext = ".safetensors" if use_safetensors else ".ckpt"
-
-        if on_epoch_end:
-            ckpt_name = get_epoch_ckpt_name(args, ext, epoch_no)
-        else:
-            ckpt_name = get_step_ckpt_name(args, ext, global_step)
-
-        ckpt_file = os.path.join(args.output_dir, ckpt_name)
-        logger.info("")
-        logger.info(f"saving checkpoint: {ckpt_file}")
-        sd_saver(ckpt_file, epoch_no, global_step)
-
-        if args.huggingface_repo_id is not None:
-            huggingface_util.upload(args, ckpt_file, "/" + ckpt_name)
-
-        # remove older checkpoints
-        if remove_no is not None:
-            if on_epoch_end:
-                remove_ckpt_name = get_epoch_ckpt_name(args, ext, remove_no)
-            else:
-                remove_ckpt_name = get_step_ckpt_name(args, ext, remove_no)
-
-            remove_ckpt_file = os.path.join(args.output_dir, remove_ckpt_name)
-            if os.path.exists(remove_ckpt_file):
-                logger.info(f"removing old checkpoint: {remove_ckpt_file}")
-                os.remove(remove_ckpt_file)
-
-    else:
-        if on_epoch_end:
-            out_dir = os.path.join(args.output_dir, EPOCH_DIFFUSERS_DIR_NAME.format(model_name, epoch_no))
-        else:
-            out_dir = os.path.join(args.output_dir, STEP_DIFFUSERS_DIR_NAME.format(model_name, global_step))
-
-        logger.info("")
-        logger.info(f"saving model: {out_dir}")
-        diffusers_saver(out_dir)
-
-        if args.huggingface_repo_id is not None:
-            huggingface_util.upload(args, out_dir, "/" + model_name)
-
-        # remove older checkpoints
-        if remove_no is not None:
-            if on_epoch_end:
-                remove_out_dir = os.path.join(args.output_dir, EPOCH_DIFFUSERS_DIR_NAME.format(model_name, remove_no))
-            else:
-                remove_out_dir = os.path.join(args.output_dir, STEP_DIFFUSERS_DIR_NAME.format(model_name, remove_no))
-
-            if os.path.exists(remove_out_dir):
-                logger.info(f"removing old model: {remove_out_dir}")
-                shutil.rmtree(remove_out_dir)
-
-    if args.save_state:
-        if on_epoch_end:
-            save_and_remove_state_on_epoch_end(args, accelerator, epoch_no)
-        else:
-            save_and_remove_state_stepwise(args, accelerator, global_step)
-
-
-def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator, epoch_no):
-    model_name = default_if_none(args.output_name, DEFAULT_EPOCH_NAME)
-
-    logger.info("")
-    logger.info(f"saving state at epoch {epoch_no}")
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    state_dir = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, epoch_no))
-    accelerator.save_state(state_dir)
-    if args.save_state_to_huggingface:
-        logger.info("uploading state to huggingface.")
-        huggingface_util.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
-
-    last_n_epochs = args.save_last_n_epochs_state if args.save_last_n_epochs_state else args.save_last_n_epochs
-    if last_n_epochs is not None:
-        remove_epoch_no = epoch_no - args.save_every_n_epochs * last_n_epochs
-        state_dir_old = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, remove_epoch_no))
-        if os.path.exists(state_dir_old):
-            logger.info(f"removing old state: {state_dir_old}")
-            shutil.rmtree(state_dir_old)
-
-
-def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator, step_no):
-    model_name = default_if_none(args.output_name, DEFAULT_STEP_NAME)
-
-    logger.info("")
-    logger.info(f"saving state at step {step_no}")
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    state_dir = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, step_no))
-    accelerator.save_state(state_dir)
-    if args.save_state_to_huggingface:
-        logger.info("uploading state to huggingface.")
-        huggingface_util.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
-
-    last_n_steps = args.save_last_n_steps_state if args.save_last_n_steps_state else args.save_last_n_steps
-    if last_n_steps is not None:
-        # last_n_steps前のstep_noから、save_every_n_stepsの倍数のstep_noを計算して削除する
-        remove_step_no = step_no - last_n_steps - 1
-        remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
-
-        if remove_step_no > 0:
-            state_dir_old = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, remove_step_no))
-            if os.path.exists(state_dir_old):
-                logger.info(f"removing old state: {state_dir_old}")
-                shutil.rmtree(state_dir_old)
-
-
-def save_state_on_train_end(args: argparse.Namespace, accelerator):
-    model_name = default_if_none(args.output_name, DEFAULT_LAST_OUTPUT_NAME)
-
-    logger.info("")
-    logger.info("saving last state.")
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    state_dir = os.path.join(args.output_dir, LAST_STATE_NAME.format(model_name))
-    accelerator.save_state(state_dir)
-
-    if args.save_state_to_huggingface:
-        logger.info("uploading last state to huggingface.")
-        huggingface_util.upload(args, state_dir, "/" + LAST_STATE_NAME.format(model_name))
-
-
-def save_sd_model_on_train_end(
-    args: argparse.Namespace,
-    src_path: str,
-    save_stable_diffusion_format: bool,
-    use_safetensors: bool,
-    save_dtype: torch.dtype,
-    epoch: int,
-    global_step: int,
-    text_encoder,
-    unet,
-    vae,
-):
-    def sd_saver(ckpt_file, epoch_no, global_step):
-        sai_metadata = get_sai_model_spec(None, args, False, False, False, is_stable_diffusion_ckpt=True)
-        model_util.save_stable_diffusion_checkpoint(
-            args.v2, ckpt_file, text_encoder, unet, src_path, epoch_no, global_step, sai_metadata, save_dtype, vae
-        )
-
-    def diffusers_saver(out_dir):
-        model_util.save_diffusers_checkpoint(
-            args.v2, out_dir, text_encoder, unet, src_path, vae=vae, use_safetensors=use_safetensors
-        )
-
-    save_sd_model_on_train_end_common(
-        args, save_stable_diffusion_format, use_safetensors, epoch, global_step, sd_saver, diffusers_saver
-    )
-
-
-def save_sd_model_on_train_end_common(
-    args: argparse.Namespace,
-    save_stable_diffusion_format: bool,
-    use_safetensors: bool,
-    epoch: int,
-    global_step: int,
-    sd_saver,
-    diffusers_saver,
-):
-    model_name = default_if_none(args.output_name, DEFAULT_LAST_OUTPUT_NAME)
-
-    if save_stable_diffusion_format:
-        os.makedirs(args.output_dir, exist_ok=True)
-
-        ckpt_name = model_name + (".safetensors" if use_safetensors else ".ckpt")
-        ckpt_file = os.path.join(args.output_dir, ckpt_name)
-
-        logger.info(f"save trained model as StableDiffusion checkpoint to {ckpt_file}")
-        sd_saver(ckpt_file, epoch, global_step)
-
-        if args.huggingface_repo_id is not None:
-            huggingface_util.upload(args, ckpt_file, "/" + ckpt_name, force_sync_upload=True)
-    else:
-        out_dir = os.path.join(args.output_dir, model_name)
-        os.makedirs(out_dir, exist_ok=True)
-
-        logger.info(f"save trained model as Diffusers to {out_dir}")
-        diffusers_saver(out_dir)
-
-        if args.huggingface_repo_id is not None:
-            huggingface_util.upload(args, out_dir, "/" + model_name, force_sync_upload=True)
 
 
 # Loss / noise scheduling helpers have moved to library.loss;

--- a/lumina_train.py
+++ b/lumina_train.py
@@ -38,6 +38,7 @@ from library.sd3_train_utils import FlowMatchEulerDiscreteScheduler
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -897,7 +898,7 @@ def train(args):
     optimizer_eval_fn()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -30,6 +30,7 @@ from library.sdxl_train_util import match_mixed_precision
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -967,7 +968,7 @@ def train(args):
     optimizer_eval_fn()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -22,6 +22,7 @@ from library import deepspeed_utils, sdxl_model_util, strategy_base, strategy_sd
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 
 from library.utils import setup_logging, add_logging_arguments
 
@@ -879,7 +880,7 @@ def train(args):
     accelerator.end_training()
 
     if args.save_state or args.save_state_on_train_end:
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 

--- a/sdxl_train_control_net.py
+++ b/sdxl_train_control_net.py
@@ -31,6 +31,7 @@ from library import (
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -587,15 +588,15 @@ def train(args):
                 if args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
-                        ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
+                        ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
                         save_model(ckpt_name, unwrap_model(control_net))
 
                         if args.save_state:
-                            train_util.save_and_remove_state_stepwise(args, accelerator, global_step)
+                            checkpoint_io.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                        remove_step_no = train_util.get_remove_step_no(args, global_step)
+                        remove_step_no = checkpoint_io.get_remove_step_no(args, global_step)
                         if remove_step_no is not None:
-                            remove_ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
+                            remove_ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
                             remove_model(remove_ckpt_name)
 
             current_loss = loss.detach().item()
@@ -621,16 +622,16 @@ def train(args):
         if args.save_every_n_epochs is not None:
             saving = (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
             if is_main_process and saving:
-                ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
+                ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
                 save_model(ckpt_name, unwrap_model(control_net))
 
-                remove_epoch_no = train_util.get_remove_epoch_no(args, epoch + 1)
+                remove_epoch_no = checkpoint_io.get_remove_epoch_no(args, epoch + 1)
                 if remove_epoch_no is not None:
-                    remove_ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
+                    remove_ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
                     remove_model(remove_ckpt_name)
 
                 if args.save_state:
-                    train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                    checkpoint_io.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
         sdxl_train_util.sample_images(
             accelerator,
@@ -653,10 +654,10 @@ def train(args):
     accelerator.end_training()
 
     if is_main_process and (args.save_state or args.save_state_on_train_end):
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     if is_main_process:
-        ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+        ckpt_name = checkpoint_io.get_last_ckpt_name(args, "." + args.save_model_as)
         save_model(ckpt_name, control_net, force_sync_upload=True)
 
         logger.info("model saved.")

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -39,6 +39,7 @@ import library.model_util as model_util
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -524,15 +525,15 @@ def train(args):
                 if args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
-                        ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
+                        ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
                         save_model(ckpt_name, accelerator.unwrap_model(unet), global_step, epoch)
 
                         if args.save_state:
-                            train_util.save_and_remove_state_stepwise(args, accelerator, global_step)
+                            checkpoint_io.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                        remove_step_no = train_util.get_remove_step_no(args, global_step)
+                        remove_step_no = checkpoint_io.get_remove_step_no(args, global_step)
                         if remove_step_no is not None:
-                            remove_ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
+                            remove_ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
                             remove_model(remove_ckpt_name)
 
             current_loss = loss.detach().item()
@@ -558,16 +559,16 @@ def train(args):
         if args.save_every_n_epochs is not None:
             saving = (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
             if is_main_process and saving:
-                ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
+                ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
                 save_model(ckpt_name, accelerator.unwrap_model(unet), global_step, epoch + 1)
 
-                remove_epoch_no = train_util.get_remove_epoch_no(args, epoch + 1)
+                remove_epoch_no = checkpoint_io.get_remove_epoch_no(args, epoch + 1)
                 if remove_epoch_no is not None:
-                    remove_ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
+                    remove_ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
                     remove_model(remove_ckpt_name)
 
                 if args.save_state:
-                    train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                    checkpoint_io.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
         # self.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
@@ -579,10 +580,10 @@ def train(args):
     accelerator.end_training()
 
     if is_main_process and (args.save_state or args.save_state_on_train_end):
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     if is_main_process:
-        ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+        ckpt_name = checkpoint_io.get_last_ckpt_name(args, "." + args.save_model_as)
         save_model(ckpt_name, unet, global_step, num_train_epochs, force_sync_upload=True)
 
         logger.info("model saved.")

--- a/train_control_net.py
+++ b/train_control_net.py
@@ -26,6 +26,7 @@ import library.model_util as model_util
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -551,18 +552,18 @@ def train(args):
                 if args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
-                        ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
+                        ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
                         save_model(
                             ckpt_name,
                             accelerator.unwrap_model(controlnet),
                         )
 
                         if args.save_state:
-                            train_util.save_and_remove_state_stepwise(args, accelerator, global_step)
+                            checkpoint_io.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                        remove_step_no = train_util.get_remove_step_no(args, global_step)
+                        remove_step_no = checkpoint_io.get_remove_step_no(args, global_step)
                         if remove_step_no is not None:
-                            remove_ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
+                            remove_ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
                             remove_model(remove_ckpt_name)
 
             current_loss = loss.detach().item()
@@ -588,16 +589,16 @@ def train(args):
         if args.save_every_n_epochs is not None:
             saving = (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
             if is_main_process and saving:
-                ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
+                ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
                 save_model(ckpt_name, accelerator.unwrap_model(controlnet))
 
-                remove_epoch_no = train_util.get_remove_epoch_no(args, epoch + 1)
+                remove_epoch_no = checkpoint_io.get_remove_epoch_no(args, epoch + 1)
                 if remove_epoch_no is not None:
-                    remove_ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
+                    remove_ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
                     remove_model(remove_ckpt_name)
 
                 if args.save_state:
-                    train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                    checkpoint_io.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
         train_util.sample_images(
             accelerator,
@@ -619,12 +620,12 @@ def train(args):
     accelerator.end_training()
 
     if is_main_process and (args.save_state or args.save_state_on_train_end):
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     # del accelerator  # この後メモリを使うのでこれは消す→printで使うので消さずにおく
 
     if is_main_process:
-        ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+        ckpt_name = checkpoint_io.get_last_ckpt_name(args, "." + args.save_model_as)
         save_model(ckpt_name, controlnet, force_sync_upload=True)
 
         logger.info("model saved.")

--- a/train_db.py
+++ b/train_db.py
@@ -23,6 +23,7 @@ from diffusers import DDPMScheduler
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.config_util as config_util
 import library.sai_model_spec as sai_model_spec
 from library.config_util import (
@@ -447,7 +448,7 @@ def train(args):
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
-                        train_util.save_sd_model_on_epoch_end_or_stepwise(
+                        checkpoint_io.save_sd_model_on_epoch_end_or_stepwise(
                             args,
                             False,
                             accelerator,
@@ -487,7 +488,7 @@ def train(args):
             if accelerator.is_main_process:
                 # checking for saving is in util
                 src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
-                train_util.save_sd_model_on_epoch_end_or_stepwise(
+                checkpoint_io.save_sd_model_on_epoch_end_or_stepwise(
                     args,
                     True,
                     accelerator,
@@ -515,13 +516,13 @@ def train(args):
     accelerator.end_training()
 
     if is_main_process and (args.save_state or args.save_state_on_train_end):
-        train_util.save_state_on_train_end(args, accelerator)
+        checkpoint_io.save_state_on_train_end(args, accelerator)
 
     del accelerator  # この後メモリを使うのでこれは消す
 
     if is_main_process:
         src_path = src_stable_diffusion_ckpt if save_stable_diffusion_format else src_diffusers_model_path
-        train_util.save_sd_model_on_train_end(
+        checkpoint_io.save_sd_model_on_train_end(
             args, src_path, save_stable_diffusion_format, use_safetensors, save_dtype, epoch, global_step, text_encoder, unet, vae
         )
         logger.info("model saved.")

--- a/train_network.py
+++ b/train_network.py
@@ -30,6 +30,7 @@ from library import deepspeed_utils, model_util, sai_model_spec, strategy_base, 
 import library.train_util as train_util
 import library.logging_util as logging_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 from library.train_util import DreamBoothDataset
 import library.config_util as config_util
 from library.config_util import (
@@ -1499,15 +1500,15 @@ class NetworkTrainer:
                     if args.save_every_n_steps is not None and global_step % args.save_every_n_steps == 0:
                         accelerator.wait_for_everyone()
                         if accelerator.is_main_process:
-                            ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
+                            ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
                             save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch)
 
                             if args.save_state:
-                                train_util.save_and_remove_state_stepwise(args, accelerator, global_step)
+                                checkpoint_io.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                            remove_step_no = train_util.get_remove_step_no(args, global_step)
+                            remove_step_no = checkpoint_io.get_remove_step_no(args, global_step)
                             if remove_step_no is not None:
-                                remove_ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
+                                remove_ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
                                 remove_model(remove_ckpt_name)
                     optimizer_train_fn()
 
@@ -1695,16 +1696,16 @@ class NetworkTrainer:
             if args.save_every_n_epochs is not None:
                 saving = (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
                 if is_main_process and saving:
-                    ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
+                    ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
                     save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch + 1)
 
-                    remove_epoch_no = train_util.get_remove_epoch_no(args, epoch + 1)
+                    remove_epoch_no = checkpoint_io.get_remove_epoch_no(args, epoch + 1)
                     if remove_epoch_no is not None:
-                        remove_ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
+                        remove_ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
                         remove_model(remove_ckpt_name)
 
                     if args.save_state:
-                        train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                        checkpoint_io.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
             self.sample_images(accelerator, args, epoch + 1, global_step, accelerator.device, vae, tokenizers, text_encoder, unet)
             progress_bar.unpause()
@@ -1722,10 +1723,10 @@ class NetworkTrainer:
         optimizer_eval_fn()
 
         if is_main_process and (args.save_state or args.save_state_on_train_end):
-            train_util.save_state_on_train_end(args, accelerator)
+            checkpoint_io.save_state_on_train_end(args, accelerator)
 
         if is_main_process:
-            ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+            ckpt_name = checkpoint_io.get_last_ckpt_name(args, "." + args.save_model_as)
             save_model(ckpt_name, network, global_step, num_train_epochs, force_sync_upload=True)
 
             logger.info("model saved.")

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -20,6 +20,7 @@ from library import deepspeed_utils, model_util, strategy_base, strategy_sd, sai
 
 import library.train_util as train_util
 import library.loss as loss_util
+import library.checkpoint_io as checkpoint_io
 import library.huggingface_util as huggingface_util
 import library.config_util as config_util
 from library.config_util import (
@@ -693,15 +694,15 @@ class TextualInversionTrainer:
                                 )
                                 updated_embs_list.append(updated_embs)
 
-                            ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
+                            ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, global_step)
                             save_model(ckpt_name, updated_embs_list, global_step, epoch)
 
                             if args.save_state:
-                                train_util.save_and_remove_state_stepwise(args, accelerator, global_step)
+                                checkpoint_io.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                            remove_step_no = train_util.get_remove_step_no(args, global_step)
+                            remove_step_no = checkpoint_io.get_remove_step_no(args, global_step)
                             if remove_step_no is not None:
-                                remove_ckpt_name = train_util.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
+                                remove_ckpt_name = checkpoint_io.get_step_ckpt_name(args, "." + args.save_model_as, remove_step_no)
                                 remove_model(remove_ckpt_name)
 
                 current_loss = loss.detach().item()
@@ -737,16 +738,16 @@ class TextualInversionTrainer:
             if args.save_every_n_epochs is not None:
                 saving = (epoch + 1) % args.save_every_n_epochs == 0 and (epoch + 1) < num_train_epochs
                 if accelerator.is_main_process and saving:
-                    ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
+                    ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, epoch + 1)
                     save_model(ckpt_name, updated_embs_list, epoch + 1, global_step)
 
-                    remove_epoch_no = train_util.get_remove_epoch_no(args, epoch + 1)
+                    remove_epoch_no = checkpoint_io.get_remove_epoch_no(args, epoch + 1)
                     if remove_epoch_no is not None:
-                        remove_ckpt_name = train_util.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
+                        remove_ckpt_name = checkpoint_io.get_epoch_ckpt_name(args, "." + args.save_model_as, remove_epoch_no)
                         remove_model(remove_ckpt_name)
 
                     if args.save_state:
-                        train_util.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                        checkpoint_io.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
 
             self.sample_images(
                 accelerator,
@@ -772,10 +773,10 @@ class TextualInversionTrainer:
         accelerator.end_training()
 
         if is_main_process and (args.save_state or args.save_state_on_train_end):
-            train_util.save_state_on_train_end(args, accelerator)
+            checkpoint_io.save_state_on_train_end(args, accelerator)
 
         if is_main_process:
-            ckpt_name = train_util.get_last_ckpt_name(args, "." + args.save_model_as)
+            ckpt_name = checkpoint_io.get_last_ckpt_name(args, "." + args.save_model_as)
             save_model(ckpt_name, updated_embs_list, global_step, num_train_epochs, force_sync_upload=True)
 
             logger.info("model saved.")


### PR DESCRIPTION
## Summary

train_util.py 解体リファクタの PR-4c。チェックポイント / state 保存周りを `library/checkpoint_io.py` に切り出します。

- 新規モジュール `library/checkpoint_io.py`（348 行）
  - ファイル名テンプレート定数 (`EPOCH_FILE_NAME` / `STEP_STATE_NAME` 等 10 個)
  - `default_if_none` / `get_epoch_ckpt_name` / `get_step_ckpt_name` / `get_last_ckpt_name` — チェックポイント名ビルダ
  - `get_remove_epoch_no` / `get_remove_step_no` — `--save_last_n_epochs` / `--save_last_n_steps` の rotate 計算
  - `save_sd_model_on_epoch_end_or_stepwise` / `..._common` / `save_sd_model_on_train_end` / `..._common` — SD 1.x/2.x checkpoint 保存 (HF Hub upload + rotate)
  - `save_and_remove_state_on_epoch_end` / `save_and_remove_state_stepwise` / `save_state_on_train_end` — accelerator state 保存 + rotate
- `library/train_util.py` は re-export shim を維持（fork 互換）
- 当リポジトリ内 20 ファイルの呼び出しを `checkpoint_io.*` (alias) への直接参照に切替

## 変更点

- `library/checkpoint_io.py`: 新規 348 行
- `library/train_util.py`: 1,275 → 975 行 (-300 行)
- 呼び出し側 20 ファイル: `import library.checkpoint_io as checkpoint_io` を追加し `train_util.{checkpoint 名/関数}` を `checkpoint_io.*` に置換
  - top-level (14): fine_tune.py / train_db.py / train_network.py / train_textual_inversion.py / train_control_net.py / sdxl_train.py / sdxl_train_control_net.py / sdxl_train_control_net_lllite.py / sd3_train.py / flux_train.py / flux_train_control_net.py / lumina_train.py / anima_train.py / anima_train_control_net_lllite.py
  - library (6): anima_train_utils.py / flux_train_utils.py / leco_train_util.py / lumina_train_util.py / sd3_train_utils.py / sdxl_train_util.py

## Test plan

- [x] \`python -m pytest tests/\` → 150 passed, 2 skipped
- [x] 移動した 13 関数 + 10 定数が新旧パスで同一オブジェクト（shim 経由）
- [x] 20 ファイルの import smoke
- [x] kohya-ss 側スモーク（学習 + 保存・state 保存・rotate）

🤖 Generated with [Claude Code](https://claude.com/claude-code)