### PR TITLE
refactor(cleanup): train_util.py の小ヘルパーと前処理クラスを再配置

### DIFF
--- a/finetune/image_loading_dataset.py
+++ b/finetune/image_loading_dataset.py
@@ -1,0 +1,32 @@
+import logging
+
+import torch
+from PIL import Image
+from torchvision import transforms
+
+from library.utils import setup_logging
+
+setup_logging()
+
+logger = logging.getLogger(__name__)
+
+
+class ImageLoadingDataset(torch.utils.data.Dataset):
+    def __init__(self, image_paths):
+        self.images = image_paths
+
+    def __len__(self):
+        return len(self.images)
+
+    def __getitem__(self, idx):
+        img_path = self.images[idx]
+
+        try:
+            image = Image.open(img_path).convert("RGB")
+            # convert to tensor temporarily so dataloader will accept it
+            tensor_pil = transforms.functional.pil_to_tensor(image)
+        except Exception as e:
+            logger.error(f"Could not load image path / 画像を読み込めません: {img_path}, error: {e}")
+            return None
+
+        return (tensor_pil, img_path)

--- a/finetune/make_captions_by_git.py
+++ b/finetune/make_captions_by_git.py
@@ -14,6 +14,7 @@ from transformers import AutoProcessor, AutoModelForCausalLM
 from transformers.generation.utils import GenerationMixin
 
 import library.train_util as train_util
+from finetune.image_loading_dataset import ImageLoadingDataset
 from library.utils import setup_logging
 setup_logging()
 import logging
@@ -108,7 +109,7 @@ def main(args):
 
     # 読み込みの高速化のためにDataLoaderを使うオプション
     if args.max_data_loader_n_workers is not None:
-        dataset = train_util.ImageLoadingDataset(image_paths)
+        dataset = ImageLoadingDataset(image_paths)
         data = torch.utils.data.DataLoader(
             dataset,
             batch_size=args.batch_size,

--- a/finetune/prepare_buckets_latents.py
+++ b/finetune/prepare_buckets_latents.py
@@ -20,6 +20,7 @@ import library.caching as caching
 import library.dataset as dataset
 import library.model_util as model_util
 import library.train_util as train_util
+from finetune.image_loading_dataset import ImageLoadingDataset
 from library.utils import setup_logging
 
 setup_logging()
@@ -119,7 +120,7 @@ def main(args):
 
     # 読み込みの高速化のためにDataLoaderを使うオプション
     if args.max_data_loader_n_workers is not None:
-        dataset = train_util.ImageLoadingDataset(image_paths)
+        dataset = ImageLoadingDataset(image_paths)
         data = torch.utils.data.DataLoader(
             dataset,
             batch_size=1,

--- a/library/dataset.py
+++ b/library/dataset.py
@@ -1957,3 +1957,24 @@ def load_image(image_path, alpha=False):
     except (IOError, OSError) as e:
         logger.error(f"Error loading file: {image_path}")
         raise e
+
+
+# collate_fn 用 epoch, step は multiprocessing.Value
+class collator_class:
+    def __init__(self, epoch, step, dataset):
+        self.current_epoch = epoch
+        self.current_step = step
+        self.dataset = dataset  # not used if worker_info is not None, in case of multiprocessing
+
+    def __call__(self, examples):
+        worker_info = torch.utils.data.get_worker_info()
+        # worker_info is None in the main process
+        if worker_info is not None:
+            dataset = worker_info.dataset
+        else:
+            dataset = self.dataset
+
+        # set epoch and step
+        dataset.set_current_epoch(self.current_epoch.value)
+        dataset.set_current_step(self.current_step.value)
+        return examples[0]

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -2,10 +2,6 @@
 
 import logging
 
-import torch
-from torchvision import transforms
-from PIL import Image
-
 from library.device_utils import init_ipex, clean_memory_on_device  # noqa: F401  (clean_memory_on_device re-exported for backward compatibility)
 from library.utils import setup_logging
 
@@ -72,6 +68,7 @@ from library.dataset import (  # noqa: F401, E402
     glob_images,
     glob_images_pathlib,
     load_image,
+    collator_class,
 )
 
 
@@ -99,21 +96,6 @@ from library.caching import (  # noqa: F401, E402
     save_text_encoder_outputs_to_disk,
     load_text_encoder_outputs_from_disk,
 )
-
-
-# constants
-
-EPSILON = 1e-6
-
-# helper functions
-
-
-def exists(val):
-    return val is not None
-
-
-def default(val, d):
-    return val if exists(val) else d
 
 
 # Model I/O, hashing and metadata helpers have moved to library.model_io;
@@ -237,58 +219,4 @@ from library.sampling import (  # noqa: F401, E402
 # Logging / tracker helpers have moved to library.logging_util;
 # re-exported here for backward compatibility.
 # New code should import from library.logging_util directly.
-from library.logging_util import init_trackers  # noqa: F401, E402
-
-
-# region 前処理用
-
-
-class ImageLoadingDataset(torch.utils.data.Dataset):
-    def __init__(self, image_paths):
-        self.images = image_paths
-
-    def __len__(self):
-        return len(self.images)
-
-    def __getitem__(self, idx):
-        img_path = self.images[idx]
-
-        try:
-            image = Image.open(img_path).convert("RGB")
-            # convert to tensor temporarily so dataloader will accept it
-            tensor_pil = transforms.functional.pil_to_tensor(image)
-        except Exception as e:
-            logger.error(f"Could not load image path / 画像を読み込めません: {img_path}, error: {e}")
-            return None
-
-        return (tensor_pil, img_path)
-
-
-# endregion
-
-
-# collate_fn用 epoch,stepはmultiprocessing.Value
-class collator_class:
-    def __init__(self, epoch, step, dataset):
-        self.current_epoch = epoch
-        self.current_step = step
-        self.dataset = dataset  # not used if worker_info is not None, in case of multiprocessing
-
-    def __call__(self, examples):
-        worker_info = torch.utils.data.get_worker_info()
-        # worker_info is None in the main process
-        if worker_info is not None:
-            dataset = worker_info.dataset
-        else:
-            dataset = self.dataset
-
-        # set epoch and step
-        dataset.set_current_epoch(self.current_epoch.value)
-        dataset.set_current_step(self.current_step.value)
-        return examples[0]
-
-
-# LossRecorder has moved to library.logging_util;
-# re-exported here for backward compatibility.
-# New code should import from library.logging_util directly.
-from library.logging_util import LossRecorder  # noqa: F401, E402
+from library.logging_util import init_trackers, LossRecorder  # noqa: F401, E402


### PR DESCRIPTION
## 概要

Phase 1 完了後の掃除 PR その 2（PR #2346 に続く）。train_util.py に残った小ヘルパーと前処理用クラスを適切な場所へ再配置し、train_util.py をさらに shim 寄りに整理する。動作仕様は変えない。

## 変更内容

### 1. `EPSILON` / `exists` / `default` を完全削除

リポジトリ全体を grep した結果、`train_util.X` 経由・`from library.train_util import X` 経由ともに参照ゼロのデッドコードであることを確認。shim も残さず完全削除。

### 2. `ImageLoadingDataset` を `finetune/image_loading_dataset.py` に新設・移動

参照元は `finetune/prepare_buckets_latents.py:122` と `finetune/make_captions_by_git.py:111` の 2 箇所のみで、いずれも前処理 / captioning スクリプト。`finetune/` ディレクトリ内に閉じているため、`finetune/image_loading_dataset.py` を単一クラスファイルとして新設し、参照元を新パス参照に書き換え。`train_util` 側の shim は置かない。

### 3. `collator_class` を `library/dataset.py` に移動 + shim

学習スクリプト 15 ファイルから `train_util.collator_class` 経由で参照されているため、`library/dataset.py` に移動した上で `train_util.py` から re-export shim を維持。学習スクリプトの呼び出し側は書き換え不要（shim 経由で透過的に動作）。

参照元学習スクリプト（書き換え不要・shim 経由で動作）:
`fine_tune.py` / `train_db.py` / `train_network.py` / `train_textual_inversion.py` / `train_control_net.py` / `sdxl_train.py` / `sdxl_train_control_net.py` / `sdxl_train_control_net_lllite.py` / `sd3_train.py` / `flux_train.py` / `flux_train_control_net.py` / `lumina_train.py` / `anima_train.py` / `anima_train_control_net_lllite.py`

### 4. `train_util.py` の不要 import 整理

`ImageLoadingDataset` / `collator_class` 本体の削除に伴い不要になった `torch` / `torchvision.transforms` / `PIL.Image` import を削除。`init_trackers` と `LossRecorder` の import を 1 行に統合。

## 結果

- `library/train_util.py`: 295 → 222 行（-73 行）
- `finetune/image_loading_dataset.py`: 新設（+33 行）
- `library/dataset.py`: `collator_class` 追加（+21 行）
- `pytest`: 150 passed, 2 skipped（変更前と同じ）
- `ruff check library/train_util.py`: clean
- スモークテスト: 動作確認済み
- shim 動作確認: `train_util.collator_class` → `library.dataset.collator_class` を返す
- 削除確認: `train_util.{EPSILON, exists, default, ImageLoadingDataset}` はいずれも `AttributeError`

## 関連

- ベース: `refactor-for-ai-agents`
- 直前 PR (掃除 PR-A): #2346
- Phase 1 完了 PR 群: #2332 〜 #2345
- 次は Phase 2（NetworkTrainer 整理）に着手予定