### PR TITLE
refactor(cleanup): SdxlNetworkTrainer.get_text_cond のデッドコードを削除

### DIFF
--- a/library/hidden_states.py
+++ b/library/hidden_states.py
@@ -4,6 +4,11 @@ Hosts the SD/SDXL text-encoder forward routines used by the training and
 sampling code (``get_hidden_states``, ``get_hidden_states_sdxl``) along with
 ``pool_workaround`` for CLIP's pooled-output bug. Extracted from
 ``library.train_util`` and re-exported there for backward compatibility.
+
+Note: ``get_hidden_states_sdxl`` is no longer called from anywhere in this
+repository (SDXL training now goes through
+``library.strategy_sdxl.SdxlTextEncodingStrategy``). It is retained only for
+fork compatibility — see the function-level comment for details.
 """
 
 import argparse
@@ -106,6 +111,12 @@ def pool_workaround(
     return pooled_output
 
 
+# NOTE: get_hidden_states_sdxl is no longer called from anywhere in this repository.
+# SDXL text-encoder hidden-state extraction has moved to
+# library.strategy_sdxl.SdxlTextEncodingStrategy._get_hidden_states_sdxl.
+# This function (and its train_util re-export shim) is kept only for backward
+# compatibility with external forks that may still import it. It can be removed
+# in a future cleanup once that compatibility is no longer a concern.
 def get_hidden_states_sdxl(
     max_token_length: int,
     input_ids1: torch.Tensor,

--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -125,60 +125,6 @@ class SdxlNetworkTrainer(train_network.NetworkTrainer):
             text_encoders[0].to(accelerator.device, dtype=weight_dtype)
             text_encoders[1].to(accelerator.device, dtype=weight_dtype)
 
-    def get_text_cond(self, args, accelerator, batch, tokenizers, text_encoders, weight_dtype):
-        if "text_encoder_outputs1_list" not in batch or batch["text_encoder_outputs1_list"] is None:
-            input_ids1 = batch["input_ids"]
-            input_ids2 = batch["input_ids2"]
-            with torch.enable_grad():
-                # Get the text embedding for conditioning
-                # TODO support weighted captions
-                # if args.weighted_captions:
-                #     encoder_hidden_states = get_weighted_text_embeddings(
-                #         tokenizer,
-                #         text_encoder,
-                #         batch["captions"],
-                #         accelerator.device,
-                #         args.max_token_length // 75 if args.max_token_length else 1,
-                #         clip_skip=args.clip_skip,
-                #     )
-                # else:
-                input_ids1 = input_ids1.to(accelerator.device)
-                input_ids2 = input_ids2.to(accelerator.device)
-                encoder_hidden_states1, encoder_hidden_states2, pool2 = train_util.get_hidden_states_sdxl(
-                    args.max_token_length,
-                    input_ids1,
-                    input_ids2,
-                    tokenizers[0],
-                    tokenizers[1],
-                    text_encoders[0],
-                    text_encoders[1],
-                    None if not args.full_fp16 else weight_dtype,
-                    accelerator=accelerator,
-                )
-        else:
-            encoder_hidden_states1 = batch["text_encoder_outputs1_list"].to(accelerator.device).to(weight_dtype)
-            encoder_hidden_states2 = batch["text_encoder_outputs2_list"].to(accelerator.device).to(weight_dtype)
-            pool2 = batch["text_encoder_pool2_list"].to(accelerator.device).to(weight_dtype)
-
-            # # verify that the text encoder outputs are correct
-            # ehs1, ehs2, p2 = train_util.get_hidden_states_sdxl(
-            #     args.max_token_length,
-            #     batch["input_ids"].to(text_encoders[0].device),
-            #     batch["input_ids2"].to(text_encoders[0].device),
-            #     tokenizers[0],
-            #     tokenizers[1],
-            #     text_encoders[0],
-            #     text_encoders[1],
-            #     None if not args.full_fp16 else weight_dtype,
-            # )
-            # b_size = encoder_hidden_states1.shape[0]
-            # assert ((encoder_hidden_states1.to("cpu") - ehs1.to(dtype=weight_dtype)).abs().max() > 1e-2).sum() <= b_size * 2
-            # assert ((encoder_hidden_states2.to("cpu") - ehs2.to(dtype=weight_dtype)).abs().max() > 1e-2).sum() <= b_size * 2
-            # assert ((pool2.to("cpu") - p2.to(dtype=weight_dtype)).abs().max() > 1e-2).sum() <= b_size * 2
-            # logger.info("text encoder outputs verified")
-
-        return encoder_hidden_states1, encoder_hidden_states2, pool2
-
     def call_unet(
         self,
         args,


### PR DESCRIPTION
## 概要

Phase 2 の前準備として、`SdxlNetworkTrainer.get_text_cond` がリポジトリ内のどこからも呼ばれていないデッドコードであることを確認したため削除します。SDXL の text encoder 出力取得は `library.strategy_sdxl.SdxlTextEncodingStrategy._get_hidden_states_sdxl` 経由に完全移行済です。

## 調査結果

- `get_text_cond` の grep 結果は `sdxl_train_network.py:128` の定義行のみ。親クラス `train_network.NetworkTrainer` 側にも呼び出しなし（テンプレートメソッドのフックではない）。
- 連鎖的にデッド化する `library.hidden_states.get_hidden_states_sdxl` の唯一の呼び出し元も同 `get_text_cond` 内のみ。
- `library.hidden_states.get_hidden_states` (SD 版) は `train_control_net.py` で現役のため対象外。

## 変更内容

- `sdxl_train_network.py`: `SdxlNetworkTrainer.get_text_cond` を削除（-54 行）
- `library/hidden_states.py`: `get_hidden_states_sdxl` の関数本体は **残す**。fork 側で `train_util.get_hidden_states_sdxl` を直接参照している可能性があるため。
  - 代わりにモジュール docstring と関数直前のコメントに「もはや当リポジトリからは呼ばれておらず、将来削除候補である」旨を明記。
- `library/train_util.py` の re-export shim はそのまま維持。

## テスト計画

- [ ] `python -m py_compile` (済: OK)
- [ ] kohya-ss によるスモークテスト（SDXL LoRA 学習が strategy 経由で問題なく走ること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)