### PR TITLE
OFTv2 / BOFT のネットワークモジュールを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ GEMINI.md
 .claude
 .gemini
 MagicMock
+.codex
 .codex-tmp
 references
 

--- a/docs/train_network.md
+++ b/docs/train_network.md
@@ -141,6 +141,7 @@ Next, we'll explain the main command-line arguments.
   * Specifies the type of network to train. For LoRA, specify `networks.lora`.
 * `--network_dim=16` **[Required]**
   * Specifies the rank (dimension) of LoRA. Higher values increase expressiveness but also increase file size and computational cost. Values between 4 and 128 are commonly used. There is no default (module dependent).
+  * For orthogonal adapters, `networks.oft` interprets this value as the number of blocks, while `networks.oft_v2` and `networks.boft` interpret it as the block size. The same value therefore has a different meaning depending on the network module.
 * `--network_alpha=1`
   * Specifies the alpha value for LoRA. This parameter is related to learning rate scaling. It is generally recommended to set it to about half the value of `network_dim`, but it can also be the same value as `network_dim`. The default is 1. Setting it to the same value as `network_dim` will result in behavior similar to older versions.
 * `--network_args`
@@ -229,6 +230,7 @@ Next, we'll explain the main command-line arguments.
     *   学習するネットワークの種別を指定します。LoRA の場合は `networks.lora` を指定します。
 *   `--network_dim=16` **[必須]**
     *   LoRA のランク (rank / 次元数) を指定します。値が大きいほど表現力は増しますが、ファイルサイズと計算コストが増加します。一般的には 4〜128 程度の値が使われます。デフォルトは指定されていません（モジュール依存）。
+    *   直交変換系アダプタでは、`networks.oft` はブロック数、`networks.oft_v2` と `networks.boft` はブロックサイズとして解釈します。同じ値でも、ネットワークモジュールによって意味が異なります。
 *   `--network_alpha=1`
     *   LoRA のアルファ値 (alpha) を指定します。学習率のスケーリングに関係するパラメータで、一般的には `network_dim` の半分程度の値を指定することが推奨されますが、`network_dim` と同じ値を指定する場合もあります。デフォルトは 1 です。`network_dim` と同じ値に設定すると、旧バージョンと同様の挙動になります。
 

--- a/networks/boft.py
+++ b/networks/boft.py
@@ -1,0 +1,656 @@
+# PEFT-style BOFT network module for SD1/SD2/SDXL training.
+
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from library.utils import setup_logging
+from networks.orthogonal_common import (
+    LORA_PREFIX_TEXT_ENCODER,
+    LORA_PREFIX_TEXT_ENCODER1,
+    LORA_PREFIX_TEXT_ENCODER2,
+    LORA_PREFIX_UNET,
+    TEXT_ENCODER_TARGET_REPLACE_MODULE,
+    UNET_TARGET_REPLACE_MODULE,
+    UNET_TARGET_REPLACE_MODULE_CONV2D_3X3,
+    adjust_block_size,
+    extract_module_state,
+    get_in_features,
+    get_out_features,
+    is_conv2d_1x1,
+    is_conv2d_module,
+    is_linear_module,
+    load_weights_sd,
+    native_prefix,
+    parse_patterns,
+    save_weights_sd,
+    str_to_bool,
+    str_to_float,
+    str_to_int,
+    text_encoder_list,
+)
+
+setup_logging()
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MultiplicativeDropoutLayer(nn.Module):
+    """PEFT-compatible multiplicative dropout for BOFT rotation blocks."""
+
+    def __init__(self, p: float = 0.0):
+        super().__init__()
+        self.p = p
+
+    def forward(self, x):
+        if not self.training or self.p <= 0:
+            return x
+
+        if x.shape[-1] != x.shape[-2]:
+            raise ValueError("The last two dimensions of input should be the same")
+
+        n_factors, block_num, block_size, _ = x.shape
+        n_random = torch.randint(0, n_factors, (1,), device=x.device).item()
+        num_to_replace = int(self.p * block_num)
+        if num_to_replace <= 0:
+            return x
+
+        mask = torch.cat(
+            [
+                torch.ones(num_to_replace, device=x.device, dtype=x.dtype),
+                torch.zeros(block_num - num_to_replace, device=x.device, dtype=x.dtype),
+            ]
+        )
+        mask = mask[torch.randperm(block_num, device=x.device)].view(1, block_num, 1, 1)
+        full_mask = torch.zeros(n_factors, block_num, 1, 1, device=x.device, dtype=x.dtype)
+        full_mask[n_random] = mask
+        eye = torch.eye(block_size, device=x.device, dtype=x.dtype).repeat(n_factors, block_num, 1, 1)
+        return (1 - full_mask) * x + full_mask * eye
+
+
+def _valid_boft_shape(in_features: int, block_size: int, block_num: int, num_factors: int) -> bool:
+    if block_size <= 0 or block_num <= 0 or block_size * block_num != in_features:
+        return False
+    internal_factors = num_factors - 1
+    if internal_factors <= 0:
+        return True
+    return (
+        block_num % (2**internal_factors) == 0
+        and block_size % 2 == 0
+        and block_num % 2 == 0
+        and in_features % (block_size * (2**internal_factors)) == 0
+    )
+
+
+def _choose_boft_shape(
+    in_features: int,
+    requested_block_size: int,
+    requested_block_num: int,
+    num_factors: int,
+    auto_adjust: bool,
+):
+    if requested_block_size and requested_block_num:
+        raise ValueError("Specify only one of boft_block_size or boft_block_num")
+
+    if requested_block_num:
+        if in_features % requested_block_num != 0:
+            raise ValueError(f"in_features ({in_features}) must be divisible by boft_block_num ({requested_block_num})")
+        block_num = requested_block_num
+        block_size = in_features // block_num
+        if not _valid_boft_shape(in_features, block_size, block_num, num_factors):
+            raise ValueError(
+                f"Invalid BOFT shape: in_features={in_features}, block_size={block_size}, "
+                f"block_num={block_num}, boft_n_butterfly_factor={num_factors}"
+            )
+        return block_size, block_num
+
+    requested_block_size = requested_block_size or 4
+    if in_features % requested_block_size == 0:
+        block_size = requested_block_size
+    elif auto_adjust:
+        block_size = adjust_block_size(in_features, requested_block_size)
+    else:
+        raise ValueError(f"in_features ({in_features}) must be divisible by boft_block_size ({requested_block_size})")
+
+    block_num = in_features // block_size
+    if _valid_boft_shape(in_features, block_size, block_num, num_factors):
+        return block_size, block_num
+
+    if not auto_adjust:
+        raise ValueError(
+            f"Invalid BOFT shape: in_features={in_features}, block_size={block_size}, "
+            f"block_num={block_num}, boft_n_butterfly_factor={num_factors}"
+        )
+
+    divisors = [d for d in range(1, in_features + 1) if in_features % d == 0]
+    divisors.sort(key=lambda d: (abs(d - requested_block_size), d))
+    for candidate_size in divisors:
+        candidate_num = in_features // candidate_size
+        if _valid_boft_shape(in_features, candidate_size, candidate_num, num_factors):
+            return candidate_size, candidate_num
+
+    raise ValueError(
+        f"Cannot find a valid BOFT block shape for in_features={in_features}, "
+        f"requested_block_size={requested_block_size}, boft_n_butterfly_factor={num_factors}"
+    )
+
+
+class BOFTModule(nn.Module):
+    def __init__(
+        self,
+        lora_name: str,
+        root_prefix: str,
+        original_name: str,
+        org_module: nn.Module,
+        multiplier: float = 1.0,
+        block_size: int = 4,
+        block_num: int = 0,
+        boft_n_butterfly_factor: int = 1,
+        dropout: Optional[float] = None,
+        auto_adjust: bool = True,
+    ):
+        super().__init__()
+        if boft_n_butterfly_factor < 1:
+            raise ValueError("boft_n_butterfly_factor must be a positive integer")
+
+        self.lora_name = lora_name
+        self.root_prefix = root_prefix
+        self.original_name = original_name
+        self.multiplier = multiplier
+        self.enabled = True
+
+        self.org_module_ref = [org_module]
+        self.org_module = [org_module]
+        self.org_forward = None
+
+        self.in_features = get_in_features(org_module)
+        self.out_features = get_out_features(org_module)
+        self.boft_n_butterfly_factor = boft_n_butterfly_factor
+        self.boft_block_size, self.boft_block_num = _choose_boft_shape(
+            self.in_features,
+            block_size,
+            block_num,
+            boft_n_butterfly_factor,
+            auto_adjust,
+        )
+
+        self.boft_R = nn.Parameter(
+            torch.zeros(boft_n_butterfly_factor, self.boft_block_num, self.boft_block_size, self.boft_block_size)
+        )
+        self.boft_s = nn.Parameter(torch.ones(self.out_features, 1))
+        self.dropout = MultiplicativeDropoutLayer(p=dropout or 0.0)
+
+        p = torch.empty(boft_n_butterfly_factor, self.in_features, self.in_features)
+        internal_factors = boft_n_butterfly_factor - 1
+        for i in range(boft_n_butterfly_factor):
+            perm = self.block_butterfly_perm(
+                self.in_features,
+                int(self.boft_block_num / (2**i)),
+                int(self.boft_block_size / 2),
+                internal_factors,
+            )
+            p[i] = self.perm2mat(perm)
+        self.register_buffer("boft_P", p, persistent=False)
+
+    def apply_to(self):
+        self.org_forward = self.org_module_ref[0].forward
+        self.org_module_ref[0].forward = self.forward
+
+    def set_network(self, network):
+        self.network = network
+
+    @staticmethod
+    def perm2mat(indices):
+        n = len(indices)
+        perm_mat = torch.zeros((n, n))
+        for i, idx in enumerate(indices):
+            perm_mat[i, idx] = 1
+        return perm_mat
+
+    @staticmethod
+    def block_butterfly_perm(n, b, r=3, n_butterfly_factor=1):
+        if n_butterfly_factor == 0:
+            return torch.arange(n)
+        if b * r * 2 > n:
+            raise ValueError("Invalid number of blocks")
+
+        block_size = int(n // b)
+        indices = torch.arange(n)
+
+        def sort_block(block_len, base):
+            step = block_len / base
+            initial_order = torch.arange(block_len)
+            sorted_order = torch.empty(block_len, dtype=torch.long)
+            evens = torch.arange(0, step, 2)
+            odds = torch.arange(1, step, 2)
+            sorted_seq = torch.cat((evens, odds), dim=0)
+            for j, pos in enumerate(sorted_seq):
+                sorted_order[int(j * base) : int(j * base + base)] = initial_order[int(pos * base) : int(pos * base + base)]
+            return sorted_order
+
+        sorted_order = sort_block(block_size, r)
+        for i in range(0, n, block_size):
+            block_end = i + block_size
+            tmp_indices = indices[i:block_end]
+            indices[i:block_end] = tmp_indices[sorted_order]
+        return indices
+
+    @staticmethod
+    def cayley_batch(data):
+        previous_dtype = data.dtype
+        data = data.to(torch.float32)
+        batch_size, rows, cols = data.shape
+        skew_mat = 0.5 * (data - data.transpose(1, 2))
+        id_mat = torch.eye(rows, device=data.device, dtype=data.dtype).unsqueeze(0).expand(batch_size, rows, cols)
+        return torch.linalg.solve(id_mat + skew_mat, id_mat - skew_mat, left=False).to(previous_dtype)
+
+    def get_rotation_and_scale(self, apply_dropout=True):
+        n_factors, block_num, block_size, _ = self.boft_R.shape
+        rotation_blocks = self.cayley_batch(self.boft_R.view(n_factors * block_num, block_size, block_size))
+        rotation_blocks = rotation_blocks.view(n_factors, block_num, block_size, block_size)
+        if apply_dropout:
+            rotation_blocks = self.dropout(rotation_blocks)
+
+        matrices = []
+        p = self.boft_P.to(device=rotation_blocks.device, dtype=rotation_blocks.dtype)
+        for i in range(n_factors):
+            block_diagonal = torch.block_diag(*torch.unbind(rotation_blocks[i]))
+            matrices.append(p[i] @ (block_diagonal @ p[i].transpose(0, 1)))
+
+        rotation = matrices[0]
+        for i in range(1, len(matrices)):
+            rotation = matrices[i] @ rotation
+        return rotation, self.boft_s
+
+    def _rotated_weight(self, weight, apply_dropout=True):
+        rotation, scale = self.get_rotation_and_scale(apply_dropout=apply_dropout)
+        weight_shape = weight.shape
+        flat_weight = weight.reshape(weight_shape[0], -1)
+        rotated = rotation.to(flat_weight.dtype) @ flat_weight.transpose(0, 1)
+        rotated = rotated.transpose(0, 1) * scale.to(flat_weight.dtype)
+        return rotated.reshape(weight_shape)
+
+    def _adapt_state_for_local_shape(self, sd):
+        if "boft_s" in sd and sd["boft_s"].shape != self.boft_s.shape:
+            if sd["boft_s"].transpose(0, 1).shape == self.boft_s.shape:
+                sd = dict(sd)
+                sd["boft_s"] = sd["boft_s"].transpose(0, 1)
+        return sd
+
+    def load_local_state(self, sd):
+        sd = self._adapt_state_for_local_shape(sd)
+        return self.load_state_dict(sd, strict=False)
+
+    def forward(self, x, *args, **kwargs):
+        if not self.enabled or self.multiplier == 0.0:
+            return self.org_forward(x, *args, **kwargs)
+
+        org_module = self.org_module_ref[0]
+        weight = org_module.weight
+        rotated_weight = self._rotated_weight(weight, apply_dropout=True)
+        if self.multiplier != 1.0:
+            rotated_weight = weight + (rotated_weight.to(weight.dtype) - weight) * self.multiplier
+
+        bias = org_module.bias.to(dtype=x.dtype) if org_module.bias is not None else None
+        if is_linear_module(org_module):
+            return F.linear(x, rotated_weight.to(dtype=x.dtype), bias)
+
+        return F.conv2d(
+            x,
+            rotated_weight.to(dtype=x.dtype),
+            bias,
+            org_module.stride,
+            org_module.padding,
+            org_module.dilation,
+            org_module.groups,
+        )
+
+    def merge_to(self, sd=None, dtype=None, device=None):
+        if sd:
+            sd = {k: v.to(device=device) if device is not None else v for k, v in sd.items()}
+            self.load_local_state(sd)
+
+        org_module = self.org_module_ref[0]
+        org_sd = org_module.state_dict()
+        org_weight = org_sd["weight"]
+        if device is not None:
+            self.to(device)
+            org_weight = org_weight.to(device)
+
+        rotated = self._rotated_weight(org_weight, apply_dropout=False)
+        if self.multiplier != 1.0:
+            rotated = org_weight + (rotated.to(org_weight.dtype) - org_weight) * self.multiplier
+
+        org_sd["weight"] = rotated.to(dtype if dtype is not None else org_sd["weight"].dtype)
+        org_module.load_state_dict(org_sd)
+
+
+class BOFTInfModule(BOFTModule):
+    pass
+
+
+class BOFTNetwork(nn.Module):
+    PARAM_NAMES = ("boft_R", "boft_s")
+
+    def __init__(
+        self,
+        text_encoder,
+        unet,
+        multiplier: float = 1.0,
+        block_size: int = 4,
+        block_num: int = 0,
+        boft_n_butterfly_factor: int = 1,
+        dropout: Optional[float] = None,
+        enable_conv: bool = False,
+        modules_state: Optional[Dict[str, torch.Tensor]] = None,
+        module_class=BOFTModule,
+        include_patterns: Optional[List[str]] = None,
+        exclude_patterns: Optional[List[str]] = None,
+        auto_adjust: bool = True,
+        verbose: bool = False,
+    ):
+        super().__init__()
+        self.multiplier = multiplier
+        self.block_size = block_size
+        self.block_num = block_num
+        self.boft_n_butterfly_factor = boft_n_butterfly_factor
+        self.dropout = dropout
+        self.enable_conv = enable_conv
+        self.module_class = module_class
+        self.include_patterns = include_patterns
+        self.exclude_patterns = exclude_patterns
+        self.auto_adjust = auto_adjust
+
+        logger.info(
+            f"create BOFT network. block_size: {block_size}, block_num: {block_num}, "
+            f"boft_n_butterfly_factor: {boft_n_butterfly_factor}, dropout: {dropout}, "
+            f"enable_conv: {enable_conv}, multiplier: {multiplier}"
+        )
+
+        text_encoders = text_encoder_list(text_encoder)
+        self.text_encoder_loras = []
+        for i, text_encoder_item in enumerate(text_encoders):
+            prefix = LORA_PREFIX_TEXT_ENCODER if len(text_encoders) == 1 else (
+                LORA_PREFIX_TEXT_ENCODER1 if i == 0 else LORA_PREFIX_TEXT_ENCODER2
+            )
+            text_loras, skipped = self._create_modules(
+                prefix,
+                text_encoder_item,
+                TEXT_ENCODER_TARGET_REPLACE_MODULE,
+                modules_state,
+            )
+            self.text_encoder_loras.extend(text_loras)
+            if verbose and skipped:
+                logger.info(f"skipped Text Encoder modules: {skipped}")
+            logger.info(f"create BOFT for Text Encoder {i + 1}: {len(text_loras)} modules.")
+
+        target_modules = list(UNET_TARGET_REPLACE_MODULE)
+        if enable_conv or modules_state is not None:
+            target_modules.extend(UNET_TARGET_REPLACE_MODULE_CONV2D_3X3)
+        self.unet_loras, skipped_unet = self._create_modules(LORA_PREFIX_UNET, unet, target_modules, modules_state)
+        if verbose and skipped_unet:
+            logger.info(f"skipped U-Net modules: {skipped_unet}")
+        logger.info(f"create BOFT for U-Net: {len(self.unet_loras)} modules.")
+
+        names = set()
+        for lora in self.text_encoder_loras + self.unet_loras:
+            assert lora.lora_name not in names, f"duplicated lora name: {lora.lora_name}"
+            names.add(lora.lora_name)
+
+    def _pattern_allowed(self, original_name: str) -> bool:
+        import re
+
+        if self.exclude_patterns and any(re.fullmatch(pattern, original_name) for pattern in self.exclude_patterns):
+            if not self.include_patterns or not any(re.fullmatch(pattern, original_name) for pattern in self.include_patterns):
+                return False
+        if self.include_patterns:
+            return any(re.fullmatch(pattern, original_name) for pattern in self.include_patterns)
+        return True
+
+    def _infer_from_state(self, state, block_size, block_num, num_factors):
+        if "boft_R" not in state:
+            return block_size, block_num, num_factors
+        boft_r = state["boft_R"]
+        return boft_r.shape[2], 0, boft_r.shape[0]
+
+    def _create_modules(self, prefix, root_module, target_replace_modules, modules_state):
+        loras = []
+        skipped = []
+        if root_module is None:
+            return loras, skipped
+
+        for name, module in root_module.named_modules():
+            if module.__class__.__name__ not in target_replace_modules:
+                continue
+            for child_name, child_module in module.named_modules():
+                if not (is_linear_module(child_module) or is_conv2d_module(child_module)):
+                    continue
+                if is_conv2d_module(child_module) and not (is_conv2d_1x1(child_module) or self.enable_conv or modules_state is not None):
+                    continue
+
+                original_name = f"{name}.{child_name}" if child_name else name
+                if not self._pattern_allowed(original_name):
+                    continue
+
+                lora_name = native_prefix(prefix, original_name)
+                state = {}
+                if modules_state is not None:
+                    state, _ = extract_module_state(modules_state, lora_name, prefix, original_name, self.PARAM_NAMES)
+                    if not state:
+                        skipped.append(lora_name)
+                        continue
+
+                module_block_size, module_block_num, module_num_factors = self._infer_from_state(
+                    state, self.block_size, self.block_num, self.boft_n_butterfly_factor
+                )
+                lora = self.module_class(
+                    lora_name,
+                    prefix,
+                    original_name,
+                    child_module,
+                    self.multiplier,
+                    module_block_size,
+                    module_block_num,
+                    module_num_factors,
+                    self.dropout,
+                    self.auto_adjust,
+                )
+                if state:
+                    lora.load_local_state(state)
+                loras.append(lora)
+
+        return loras, skipped
+
+    def set_multiplier(self, multiplier):
+        self.multiplier = multiplier
+        for lora in self.text_encoder_loras + self.unet_loras:
+            lora.multiplier = multiplier
+
+    def set_enabled(self, is_enabled):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            lora.enabled = is_enabled
+
+    def _adapt_state(self, lora, state):
+        if "boft_s" in state and state["boft_s"].shape != lora.boft_s.shape:
+            if state["boft_s"].transpose(0, 1).shape == lora.boft_s.shape:
+                state = dict(state)
+                state["boft_s"] = state["boft_s"].transpose(0, 1)
+        return state
+
+    def load_weights(self, file):
+        weights_sd = load_weights_sd(file)
+        converted = {}
+        used = []
+        for lora in self.text_encoder_loras + self.unet_loras:
+            state, state_used = extract_module_state(weights_sd, lora.lora_name, lora.root_prefix, lora.original_name, self.PARAM_NAMES)
+            state = self._adapt_state(lora, state)
+            for key, value in state.items():
+                converted[f"{lora.lora_name}.{key}"] = value
+            used.extend(state_used)
+        unused = sorted(set(weights_sd.keys()) - set(used))
+        if unused:
+            logger.warning(f"ignored {len(unused)} BOFT weight keys that do not match current targets")
+        return self.load_state_dict(converted, strict=False)
+
+    def apply_to(self, text_encoder, unet, apply_text_encoder=True, apply_unet=True):
+        if not apply_text_encoder:
+            self.text_encoder_loras = []
+        if not apply_unet:
+            self.unet_loras = []
+
+        logger.info(f"enable BOFT for text encoder: {len(self.text_encoder_loras)} modules")
+        logger.info(f"enable BOFT for U-Net: {len(self.unet_loras)} modules")
+
+        for lora in self.text_encoder_loras + self.unet_loras:
+            lora.apply_to()
+            self.add_module(lora.lora_name, lora)
+
+    def is_mergeable(self):
+        return True
+
+    def merge_to(self, text_encoder, unet, weights_sd, dtype, device):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            state, _ = extract_module_state(weights_sd, lora.lora_name, lora.root_prefix, lora.original_name, self.PARAM_NAMES)
+            state = self._adapt_state(lora, state)
+            if state:
+                lora.merge_to(state, dtype, device)
+        logger.info("BOFT weights are merged")
+
+    def _assemble_params(self, loras, lr):
+        params = []
+        for lora in loras:
+            params.extend(list(lora.parameters()))
+        if not params:
+            return []
+        group = {"params": params}
+        if lr is not None:
+            group["lr"] = lr
+        if group.get("lr", 1.0) == 0:
+            return []
+        return [group]
+
+    def prepare_optimizer_params_with_multiple_te_lrs(self, text_encoder_lr, unet_lr, default_lr):
+        if text_encoder_lr is None or (isinstance(text_encoder_lr, list) and len(text_encoder_lr) == 0):
+            text_encoder_lr = [default_lr]
+        elif isinstance(text_encoder_lr, (float, int)):
+            text_encoder_lr = [float(text_encoder_lr)]
+
+        self.requires_grad_(True)
+        params = []
+        descriptions = []
+
+        for te_idx, prefix in enumerate((LORA_PREFIX_TEXT_ENCODER, LORA_PREFIX_TEXT_ENCODER1, LORA_PREFIX_TEXT_ENCODER2)):
+            te_loras = [lora for lora in self.text_encoder_loras if lora.lora_name.startswith(prefix)]
+            if not te_loras:
+                continue
+            lr = text_encoder_lr[te_idx] if te_idx < len(text_encoder_lr) else text_encoder_lr[0]
+            groups = self._assemble_params(te_loras, lr)
+            params.extend(groups)
+            descriptions.extend([f"textencoder {te_idx + 1}"] * len(groups))
+
+        unet_groups = self._assemble_params(self.unet_loras, unet_lr if unet_lr is not None else default_lr)
+        params.extend(unet_groups)
+        descriptions.extend(["unet"] * len(unet_groups))
+        return params, descriptions
+
+    def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr):
+        return self.prepare_optimizer_params_with_multiple_te_lrs(text_encoder_lr, unet_lr, default_lr)[0]
+
+    def enable_gradient_checkpointing(self):
+        pass
+
+    def prepare_grad_etc(self, text_encoder, unet):
+        self.requires_grad_(True)
+
+    def on_epoch_start(self, text_encoder, unet):
+        self.train()
+
+    def get_trainable_params(self):
+        return self.parameters()
+
+    def save_weights(self, file, dtype, metadata):
+        save_weights_sd(file, self.state_dict(), dtype, metadata)
+
+    def backup_weights(self):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            org_module = lora.org_module_ref[0]
+            if not hasattr(org_module, "_lora_org_weight"):
+                org_module._lora_org_weight = org_module.state_dict()["weight"].detach().clone()
+                org_module._lora_restored = True
+
+    def restore_weights(self):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            org_module = lora.org_module_ref[0]
+            if not org_module._lora_restored:
+                sd = org_module.state_dict()
+                sd["weight"] = org_module._lora_org_weight
+                org_module.load_state_dict(sd)
+                org_module._lora_restored = True
+
+    def pre_calculation(self):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            org_module = lora.org_module_ref[0]
+            lora.merge_to()
+            org_module._lora_restored = False
+            lora.enabled = False
+
+
+def _create_network_args(network_dim, neuron_dropout, kwargs):
+    explicit_block_size = kwargs.get("boft_block_size", kwargs.get("block_size", None))
+    explicit_block_num = kwargs.get("boft_block_num", kwargs.get("block_num", None))
+    block_size = str_to_int(explicit_block_size, None)
+    block_num = str_to_int(explicit_block_num, 0)
+    if block_size is None:
+        block_size = network_dim if network_dim is not None else 4
+
+    boft_n_butterfly_factor = str_to_int(kwargs.get("boft_n_butterfly_factor", None), 1)
+    dropout = neuron_dropout if neuron_dropout is not None else str_to_float(kwargs.get("boft_dropout", kwargs.get("dropout", None)), None)
+    enable_conv = str_to_bool(kwargs.get("enable_conv", None), False)
+    auto_adjust = str_to_bool(kwargs.get("auto_adjust", None), True)
+    include_patterns = parse_patterns(kwargs.get("include_patterns", None))
+    exclude_patterns = parse_patterns(kwargs.get("exclude_patterns", None))
+    return {
+        "block_size": block_size,
+        "block_num": block_num,
+        "boft_n_butterfly_factor": boft_n_butterfly_factor,
+        "dropout": dropout,
+        "enable_conv": enable_conv,
+        "auto_adjust": auto_adjust,
+        "include_patterns": include_patterns,
+        "exclude_patterns": exclude_patterns,
+    }
+
+
+def create_network(
+    multiplier: float,
+    network_dim: Optional[int],
+    network_alpha: Optional[float],
+    vae,
+    text_encoder,
+    unet,
+    neuron_dropout: Optional[float] = None,
+    **kwargs,
+):
+    del network_alpha, vae
+    args = _create_network_args(network_dim, neuron_dropout, kwargs)
+    return BOFTNetwork(text_encoder, unet, multiplier=multiplier, verbose=True, **args)
+
+
+def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weights_sd=None, for_inference=False, **kwargs):
+    del vae
+    weights_sd = load_weights_sd(file, weights_sd)
+    args = _create_network_args(kwargs.get("network_dim", None), None, kwargs)
+    module_class = BOFTInfModule if for_inference else BOFTModule
+    network = BOFTNetwork(
+        text_encoder,
+        unet,
+        multiplier=multiplier,
+        modules_state=weights_sd,
+        module_class=module_class,
+        verbose=True,
+        **args,
+    )
+    return network, weights_sd

--- a/networks/boft.py
+++ b/networks/boft.py
@@ -542,8 +542,12 @@ class BOFTNetwork(nn.Module):
         params = []
         descriptions = []
 
-        for te_idx, prefix in enumerate((LORA_PREFIX_TEXT_ENCODER, LORA_PREFIX_TEXT_ENCODER1, LORA_PREFIX_TEXT_ENCODER2)):
-            te_loras = [lora for lora in self.text_encoder_loras if lora.lora_name.startswith(prefix)]
+        for prefix, te_idx in (
+            (LORA_PREFIX_TEXT_ENCODER, 0),
+            (LORA_PREFIX_TEXT_ENCODER1, 0),
+            (LORA_PREFIX_TEXT_ENCODER2, 1),
+        ):
+            te_loras = [lora for lora in self.text_encoder_loras if lora.lora_name.startswith(prefix + "_")]
             if not te_loras:
                 continue
             lr = text_encoder_lr[te_idx] if te_idx < len(text_encoder_lr) else text_encoder_lr[0]

--- a/networks/oft_v2.py
+++ b/networks/oft_v2.py
@@ -1,0 +1,626 @@
+# OneTrainer/PEFT-style OFTv2 network module for SD1/SD2/SDXL training.
+
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from library.utils import setup_logging
+from networks.orthogonal_common import (
+    LORA_PREFIX_TEXT_ENCODER,
+    LORA_PREFIX_TEXT_ENCODER1,
+    LORA_PREFIX_TEXT_ENCODER2,
+    LORA_PREFIX_UNET,
+    TEXT_ENCODER_TARGET_REPLACE_MODULE,
+    UNET_TARGET_REPLACE_MODULE,
+    UNET_TARGET_REPLACE_MODULE_CONV2D_3X3,
+    adjust_block_size,
+    extract_module_state,
+    get_in_features,
+    is_conv2d_1x1,
+    is_conv2d_module,
+    is_linear_module,
+    load_weights_sd,
+    native_prefix,
+    parse_patterns,
+    save_weights_sd,
+    str_to_bool,
+    str_to_float,
+    str_to_int,
+    text_encoder_list,
+    triangular_block_size,
+)
+
+setup_logging()
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MultiplicativeDropoutLayer(nn.Module):
+    """Randomly replace learned rotation blocks with identity matrices."""
+
+    def __init__(self, p: float = 0.0):
+        super().__init__()
+        self.p = p
+
+    def forward(self, x):
+        if not self.training or self.p <= 0:
+            return x
+
+        if x.shape[-1] != x.shape[-2]:
+            raise ValueError("The last two dimensions of input should be the same")
+
+        blocks, block_size, _ = x.shape
+        if blocks == 1:
+            return x
+
+        keep_prob = 1.0 - self.p
+        mask = torch.empty(blocks, 1, 1, device=x.device, dtype=x.dtype).bernoulli_(p=keep_prob)
+        eye = torch.eye(block_size, device=x.device, dtype=x.dtype).repeat(blocks, 1, 1)
+        return mask * x + (1 - mask) * eye
+
+
+class OFTRotationModule(nn.Module):
+    def __init__(
+        self,
+        r: int,
+        n_elements: int,
+        block_size: int,
+        in_features: int,
+        coft: bool = False,
+        coft_eps: float = 6e-5,
+        block_share: bool = False,
+        use_cayley_neumann: bool = True,
+        num_cayley_neumann_terms: int = 5,
+        dropout_probability: float = 0.0,
+    ):
+        super().__init__()
+        self.r = r
+        self.n_elements = n_elements
+        self.block_size = block_size
+        self.in_features = in_features
+        self.coft = coft
+        self.coft_eps = coft_eps
+        self.block_share = block_share
+        self.use_cayley_neumann = use_cayley_neumann
+        self.num_cayley_neumann_terms = num_cayley_neumann_terms
+
+        self.weight = nn.Parameter(torch.zeros(r, n_elements))
+
+        rows, cols = torch.triu_indices(block_size, block_size, 1)
+        self.register_buffer("rows", rows, persistent=False)
+        self.register_buffer("cols", cols, persistent=False)
+        self.dropout = MultiplicativeDropoutLayer(p=dropout_probability)
+
+    def _pytorch_skew_symmetric(self, vec, block_size):
+        batch_size = vec.shape[0]
+        matrix = torch.zeros(batch_size, block_size, block_size, device=vec.device, dtype=vec.dtype)
+
+        batch_idx = torch.arange(batch_size, device=vec.device)[:, None]
+        matrix = matrix.index_put((batch_idx, self.rows, self.cols), vec)
+        return matrix - matrix.transpose(-2, -1)
+
+    def _pytorch_skew_symmetric_inv(self, matrix, block_size):
+        return matrix[:, self.rows, self.cols]
+
+    def _cayley_batch(self, q, block_size, use_cayley_neumann=True, num_neumann_terms=5):
+        batch_size, _ = q.shape
+        previous_dtype = q.dtype
+        q = q.to(torch.float32)
+        q_skew = self._pytorch_skew_symmetric(q, block_size)
+
+        if use_cayley_neumann:
+            r = torch.eye(block_size, device=q.device, dtype=q.dtype).repeat(batch_size, 1, 1)
+            if num_neumann_terms > 1:
+                r.add_(q_skew, alpha=2.0)
+                if num_neumann_terms > 2:
+                    q_squared = torch.bmm(q_skew, q_skew)
+                    r.add_(q_squared, alpha=2.0)
+
+                    q_power = q_squared
+                    for _ in range(3, num_neumann_terms - 1):
+                        q_power = torch.bmm(q_power, q_skew)
+                        r.add_(q_power, alpha=2.0)
+                    q_power = torch.bmm(q_power, q_skew)
+                    r.add_(q_power)
+        else:
+            id_mat = torch.eye(q_skew.shape[-1], device=q_skew.device, dtype=q_skew.dtype).unsqueeze(0)
+            id_mat = id_mat.expand(batch_size, q_skew.shape[-1], q_skew.shape[-1])
+            r = torch.linalg.solve(id_mat + q_skew, id_mat - q_skew, left=False)
+
+        return r.to(previous_dtype)
+
+    def _project_batch(self, q, coft_eps=1e-4):
+        oft_r = self._pytorch_skew_symmetric(q, self.block_size)
+        coft_eps = coft_eps * 1 / torch.sqrt(torch.tensor(oft_r.shape[0], device=oft_r.device, dtype=oft_r.dtype))
+        origin = torch.zeros((oft_r.size(1), oft_r.size(1)), device=oft_r.device, dtype=oft_r.dtype).unsqueeze(0)
+        origin = origin.expand_as(oft_r)
+        diff = oft_r - origin
+        norm_diff = torch.norm(diff, dim=(1, 2), keepdim=True)
+        mask = (norm_diff <= coft_eps).bool()
+        out = torch.where(mask, oft_r, origin + coft_eps * (diff / norm_diff))
+        return self._pytorch_skew_symmetric_inv(out, self.block_size)
+
+    def get_rotation_blocks(self, apply_dropout=True):
+        weight = self.weight
+        if self.coft:
+            with torch.no_grad():
+                weight = self._project_batch(weight, coft_eps=self.coft_eps)
+                self.weight.copy_(weight)
+
+        rotation = self._cayley_batch(
+            weight,
+            self.block_size,
+            self.use_cayley_neumann,
+            self.num_cayley_neumann_terms,
+        )
+        if apply_dropout:
+            rotation = self.dropout(rotation)
+
+        if self.block_share:
+            rank = self.in_features // self.block_size
+            rotation = rotation.repeat(rank, 1, 1)
+
+        return rotation
+
+    def get_weight(self, apply_dropout=True):
+        rotation = self.get_rotation_blocks(apply_dropout=apply_dropout)
+        return torch.block_diag(*torch.unbind(rotation))
+
+    def forward(self, x):
+        required_dtype = x.dtype
+        if required_dtype != self.weight.dtype:
+            x = x.to(self.weight.dtype)
+
+        orig_shape = x.shape
+        rank = self.in_features // self.block_size
+        batch_dims = x.shape[:-1]
+        x_reshaped = x.reshape(*batch_dims, rank, self.block_size)
+        rotation = self.get_rotation_blocks(apply_dropout=True)
+        x_rotated = torch.einsum("...rk,rkc->...rc", x_reshaped, rotation)
+        return x_rotated.reshape(*orig_shape).to(required_dtype)
+
+
+class OFTv2Module(nn.Module):
+    def __init__(
+        self,
+        lora_name: str,
+        root_prefix: str,
+        original_name: str,
+        org_module: nn.Module,
+        multiplier: float = 1.0,
+        block_size: int = 32,
+        coft: bool = False,
+        coft_eps: float = 6e-5,
+        block_share: bool = False,
+        dropout: Optional[float] = None,
+        auto_adjust: bool = True,
+    ):
+        super().__init__()
+        self.lora_name = lora_name
+        self.root_prefix = root_prefix
+        self.original_name = original_name
+        self.multiplier = multiplier
+        self.coft = coft
+        self.coft_eps = coft_eps
+        self.block_share = block_share
+        self.enabled = True
+
+        self.org_module_ref = [org_module]
+        self.org_module = [org_module]
+        self.org_forward = None
+
+        self.in_features = get_in_features(org_module)
+        if auto_adjust:
+            block_size = adjust_block_size(self.in_features, block_size)
+        elif self.in_features % block_size != 0:
+            raise ValueError(f"in_features ({self.in_features}) must be divisible by block_size ({block_size})")
+
+        self.block_size = block_size
+        self.rank = self.in_features // self.block_size
+        n_elements = self.block_size * (self.block_size - 1) // 2
+        r = 1 if block_share else self.rank
+        self.oft_R = OFTRotationModule(
+            r=r,
+            n_elements=n_elements,
+            block_size=self.block_size,
+            in_features=self.in_features,
+            coft=coft,
+            coft_eps=coft_eps,
+            block_share=block_share,
+            dropout_probability=dropout or 0.0,
+        )
+
+    def apply_to(self):
+        self.org_forward = self.org_module_ref[0].forward
+        self.org_module_ref[0].forward = self.forward
+
+    def set_network(self, network):
+        self.network = network
+
+    def forward(self, x, *args, **kwargs):
+        if not self.enabled or self.multiplier == 0.0:
+            return self.org_forward(x, *args, **kwargs)
+
+        org_module = self.org_module_ref[0]
+        if is_linear_module(org_module):
+            rotated_x = self.oft_R(x)
+            if self.multiplier != 1.0:
+                rotated_x = x + (rotated_x - x) * self.multiplier
+            return self.org_forward(rotated_x, *args, **kwargs)
+
+        rotation = self.oft_R.get_rotation_blocks(apply_dropout=True)
+        weight = org_module.weight
+        rotated_weight = self._rotate_conv_weight(weight, rotation)
+        if self.multiplier != 1.0:
+            rotated_weight = weight + (rotated_weight - weight) * self.multiplier
+        return F.conv2d(
+            x,
+            rotated_weight.to(dtype=x.dtype),
+            org_module.bias.to(dtype=x.dtype) if org_module.bias is not None else None,
+            org_module.stride,
+            org_module.padding,
+            org_module.dilation,
+            org_module.groups,
+        )
+
+    def _rotate_conv_weight(self, weight, rotation_blocks):
+        weight_dtype = weight.dtype
+        weight_float = weight.to(rotation_blocks.dtype)
+        weight_reshaped = weight_float.reshape(weight.shape[0], self.rank, self.block_size)
+        rotated = torch.einsum("ork,rkc->orc", weight_reshaped, rotation_blocks)
+        return rotated.reshape(weight.shape).to(weight_dtype)
+
+    def load_local_state(self, sd):
+        return self.load_state_dict(sd, strict=False)
+
+    def merge_to(self, sd=None, dtype=None, device=None):
+        if sd:
+            sd = {k: v.to(device=device) if device is not None else v for k, v in sd.items()}
+            self.load_local_state(sd)
+
+        org_module = self.org_module_ref[0]
+        org_sd = org_module.state_dict()
+        org_weight = org_sd["weight"]
+
+        if device is not None:
+            self.to(device)
+            org_weight = org_weight.to(device)
+
+        if is_linear_module(org_module):
+            rotation = self.oft_R.get_weight(apply_dropout=False).to(device=org_weight.device)
+            rotated = org_weight.to(rotation.dtype).reshape(org_weight.shape[0], -1) @ rotation.transpose(0, 1)
+            rotated = rotated.reshape(org_weight.shape)
+        else:
+            rotation_blocks = self.oft_R.get_rotation_blocks(apply_dropout=False).to(device=org_weight.device)
+            rotated = self._rotate_conv_weight(org_weight, rotation_blocks)
+
+        if self.multiplier != 1.0:
+            rotated = org_weight + (rotated.to(org_weight.dtype) - org_weight) * self.multiplier
+
+        org_sd["weight"] = rotated.to(dtype if dtype is not None else org_sd["weight"].dtype)
+        org_module.load_state_dict(org_sd)
+
+
+class OFTv2InfModule(OFTv2Module):
+    pass
+
+
+class OFTv2Network(nn.Module):
+    PARAM_NAMES = ("oft_R.weight",)
+
+    def __init__(
+        self,
+        text_encoder,
+        unet,
+        multiplier: float = 1.0,
+        block_size: int = 32,
+        coft: bool = False,
+        coft_eps: float = 6e-5,
+        block_share: bool = False,
+        dropout: Optional[float] = None,
+        enable_conv: bool = False,
+        modules_state: Optional[Dict[str, torch.Tensor]] = None,
+        module_class=OFTv2Module,
+        include_patterns: Optional[List[str]] = None,
+        exclude_patterns: Optional[List[str]] = None,
+        auto_adjust: bool = True,
+        verbose: bool = False,
+    ):
+        super().__init__()
+        self.multiplier = multiplier
+        self.block_size = block_size
+        self.coft = coft
+        self.coft_eps = coft_eps
+        self.block_share = block_share
+        self.dropout = dropout
+        self.enable_conv = enable_conv
+        self.module_class = module_class
+        self.include_patterns = include_patterns
+        self.exclude_patterns = exclude_patterns
+        self.auto_adjust = auto_adjust
+
+        logger.info(
+            f"create OFTv2 network. block_size: {block_size}, coft: {coft}, block_share: {block_share}, "
+            f"dropout: {dropout}, enable_conv: {enable_conv}, multiplier: {multiplier}"
+        )
+
+        self.text_encoder_loras = []
+        for i, text_encoder_item in enumerate(text_encoder_list(text_encoder)):
+            prefix = LORA_PREFIX_TEXT_ENCODER if len(text_encoder_list(text_encoder)) == 1 else (
+                LORA_PREFIX_TEXT_ENCODER1 if i == 0 else LORA_PREFIX_TEXT_ENCODER2
+            )
+            text_loras, skipped = self._create_modules(
+                prefix,
+                text_encoder_item,
+                TEXT_ENCODER_TARGET_REPLACE_MODULE,
+                modules_state,
+            )
+            self.text_encoder_loras.extend(text_loras)
+            if verbose and skipped:
+                logger.info(f"skipped Text Encoder modules: {skipped}")
+            logger.info(f"create OFTv2 for Text Encoder {i + 1}: {len(text_loras)} modules.")
+
+        target_modules = list(UNET_TARGET_REPLACE_MODULE)
+        if enable_conv or modules_state is not None:
+            target_modules.extend(UNET_TARGET_REPLACE_MODULE_CONV2D_3X3)
+        self.unet_loras, skipped_unet = self._create_modules(LORA_PREFIX_UNET, unet, target_modules, modules_state)
+        if verbose and skipped_unet:
+            logger.info(f"skipped U-Net modules: {skipped_unet}")
+        logger.info(f"create OFTv2 for U-Net: {len(self.unet_loras)} modules.")
+
+        names = set()
+        for lora in self.text_encoder_loras + self.unet_loras:
+            assert lora.lora_name not in names, f"duplicated lora name: {lora.lora_name}"
+            names.add(lora.lora_name)
+
+    def _pattern_allowed(self, original_name: str) -> bool:
+        import re
+
+        if self.exclude_patterns and any(re.fullmatch(pattern, original_name) for pattern in self.exclude_patterns):
+            if not self.include_patterns or not any(re.fullmatch(pattern, original_name) for pattern in self.include_patterns):
+                return False
+        if self.include_patterns:
+            return any(re.fullmatch(pattern, original_name) for pattern in self.include_patterns)
+        return True
+
+    def _infer_from_state(self, state, org_module, block_size, block_share):
+        if "oft_R.weight" not in state:
+            return block_size, block_share
+        weight = state["oft_R.weight"]
+        inferred_block_size = triangular_block_size(weight.shape[1])
+        rank = get_in_features(org_module) // inferred_block_size
+        inferred_block_share = weight.shape[0] == 1 and rank > 1
+        return inferred_block_size, inferred_block_share
+
+    def _create_modules(self, prefix, root_module, target_replace_modules, modules_state):
+        loras = []
+        skipped = []
+        if root_module is None:
+            return loras, skipped
+
+        for name, module in root_module.named_modules():
+            if module.__class__.__name__ not in target_replace_modules:
+                continue
+            for child_name, child_module in module.named_modules():
+                if not (is_linear_module(child_module) or is_conv2d_module(child_module)):
+                    continue
+                if is_conv2d_module(child_module) and not (is_conv2d_1x1(child_module) or self.enable_conv or modules_state is not None):
+                    continue
+
+                original_name = f"{name}.{child_name}" if child_name else name
+                if not self._pattern_allowed(original_name):
+                    continue
+
+                lora_name = native_prefix(prefix, original_name)
+                state = {}
+                if modules_state is not None:
+                    state, _ = extract_module_state(modules_state, lora_name, prefix, original_name, self.PARAM_NAMES)
+                    if not state:
+                        skipped.append(lora_name)
+                        continue
+
+                module_block_size, module_block_share = self._infer_from_state(
+                    state, child_module, self.block_size, self.block_share
+                )
+                lora = self.module_class(
+                    lora_name,
+                    prefix,
+                    original_name,
+                    child_module,
+                    self.multiplier,
+                    module_block_size,
+                    self.coft,
+                    self.coft_eps,
+                    module_block_share,
+                    self.dropout,
+                    self.auto_adjust,
+                )
+                if state:
+                    lora.load_local_state(state)
+                loras.append(lora)
+
+        return loras, skipped
+
+    def set_multiplier(self, multiplier):
+        self.multiplier = multiplier
+        for lora in self.text_encoder_loras + self.unet_loras:
+            lora.multiplier = multiplier
+
+    def set_enabled(self, is_enabled):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            lora.enabled = is_enabled
+
+    def load_weights(self, file):
+        weights_sd = load_weights_sd(file)
+        converted = {}
+        used = []
+        for lora in self.text_encoder_loras + self.unet_loras:
+            state, state_used = extract_module_state(weights_sd, lora.lora_name, lora.root_prefix, lora.original_name, self.PARAM_NAMES)
+            for key, value in state.items():
+                converted[f"{lora.lora_name}.{key}"] = value
+            used.extend(state_used)
+        unused = sorted(set(weights_sd.keys()) - set(used))
+        if unused:
+            logger.warning(f"ignored {len(unused)} OFTv2 weight keys that do not match current targets")
+        return self.load_state_dict(converted, strict=False)
+
+    def apply_to(self, text_encoder, unet, apply_text_encoder=True, apply_unet=True):
+        if not apply_text_encoder:
+            self.text_encoder_loras = []
+        if not apply_unet:
+            self.unet_loras = []
+
+        logger.info(f"enable OFTv2 for text encoder: {len(self.text_encoder_loras)} modules")
+        logger.info(f"enable OFTv2 for U-Net: {len(self.unet_loras)} modules")
+
+        for lora in self.text_encoder_loras + self.unet_loras:
+            lora.apply_to()
+            self.add_module(lora.lora_name, lora)
+
+    def is_mergeable(self):
+        return True
+
+    def merge_to(self, text_encoder, unet, weights_sd, dtype, device):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            state, _ = extract_module_state(weights_sd, lora.lora_name, lora.root_prefix, lora.original_name, self.PARAM_NAMES)
+            if state:
+                lora.merge_to(state, dtype, device)
+        logger.info("OFTv2 weights are merged")
+
+    def _assemble_params(self, loras, lr):
+        params = []
+        for lora in loras:
+            params.extend(list(lora.parameters()))
+        if not params:
+            return []
+        group = {"params": params}
+        if lr is not None:
+            group["lr"] = lr
+        if group.get("lr", 1.0) == 0:
+            return []
+        return [group]
+
+    def prepare_optimizer_params_with_multiple_te_lrs(self, text_encoder_lr, unet_lr, default_lr):
+        if text_encoder_lr is None or (isinstance(text_encoder_lr, list) and len(text_encoder_lr) == 0):
+            text_encoder_lr = [default_lr]
+        elif isinstance(text_encoder_lr, (float, int)):
+            text_encoder_lr = [float(text_encoder_lr)]
+
+        self.requires_grad_(True)
+        params = []
+        descriptions = []
+
+        for te_idx, prefix in enumerate((LORA_PREFIX_TEXT_ENCODER, LORA_PREFIX_TEXT_ENCODER1, LORA_PREFIX_TEXT_ENCODER2)):
+            te_loras = [lora for lora in self.text_encoder_loras if lora.lora_name.startswith(prefix)]
+            if not te_loras:
+                continue
+            lr = text_encoder_lr[te_idx] if te_idx < len(text_encoder_lr) else text_encoder_lr[0]
+            groups = self._assemble_params(te_loras, lr)
+            params.extend(groups)
+            descriptions.extend([f"textencoder {te_idx + 1}"] * len(groups))
+
+        unet_groups = self._assemble_params(self.unet_loras, unet_lr if unet_lr is not None else default_lr)
+        params.extend(unet_groups)
+        descriptions.extend(["unet"] * len(unet_groups))
+        return params, descriptions
+
+    def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr):
+        return self.prepare_optimizer_params_with_multiple_te_lrs(text_encoder_lr, unet_lr, default_lr)[0]
+
+    def enable_gradient_checkpointing(self):
+        pass
+
+    def prepare_grad_etc(self, text_encoder, unet):
+        self.requires_grad_(True)
+
+    def on_epoch_start(self, text_encoder, unet):
+        self.train()
+
+    def get_trainable_params(self):
+        return self.parameters()
+
+    def save_weights(self, file, dtype, metadata):
+        save_weights_sd(file, self.state_dict(), dtype, metadata)
+
+    def backup_weights(self):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            org_module = lora.org_module_ref[0]
+            if not hasattr(org_module, "_lora_org_weight"):
+                org_module._lora_org_weight = org_module.state_dict()["weight"].detach().clone()
+                org_module._lora_restored = True
+
+    def restore_weights(self):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            org_module = lora.org_module_ref[0]
+            if not org_module._lora_restored:
+                sd = org_module.state_dict()
+                sd["weight"] = org_module._lora_org_weight
+                org_module.load_state_dict(sd)
+                org_module._lora_restored = True
+
+    def pre_calculation(self):
+        for lora in self.text_encoder_loras + self.unet_loras:
+            org_module = lora.org_module_ref[0]
+            lora.merge_to()
+            org_module._lora_restored = False
+            lora.enabled = False
+
+
+def _create_network_args(network_dim, neuron_dropout, kwargs):
+    block_size = str_to_int(kwargs.get("oft_block_size", kwargs.get("block_size", network_dim)), 32)
+    coft = str_to_bool(kwargs.get("oft_coft", kwargs.get("coft", None)), False)
+    coft_eps = str_to_float(kwargs.get("coft_eps", None), 6e-5)
+    block_share = str_to_bool(kwargs.get("oft_block_share", kwargs.get("block_share", None)), False)
+    dropout = neuron_dropout if neuron_dropout is not None else str_to_float(
+        kwargs.get("dropout_probability", kwargs.get("dropout", None)), None
+    )
+    enable_conv = str_to_bool(kwargs.get("enable_conv", None), False)
+    auto_adjust = str_to_bool(kwargs.get("auto_adjust", None), True)
+    include_patterns = parse_patterns(kwargs.get("include_patterns", None))
+    exclude_patterns = parse_patterns(kwargs.get("exclude_patterns", None))
+    return {
+        "block_size": block_size,
+        "coft": coft,
+        "coft_eps": coft_eps,
+        "block_share": block_share,
+        "dropout": dropout,
+        "enable_conv": enable_conv,
+        "auto_adjust": auto_adjust,
+        "include_patterns": include_patterns,
+        "exclude_patterns": exclude_patterns,
+    }
+
+
+def create_network(
+    multiplier: float,
+    network_dim: Optional[int],
+    network_alpha: Optional[float],
+    vae,
+    text_encoder,
+    unet,
+    neuron_dropout: Optional[float] = None,
+    **kwargs,
+):
+    del network_alpha
+    args = _create_network_args(network_dim, neuron_dropout, kwargs)
+    return OFTv2Network(text_encoder, unet, multiplier=multiplier, verbose=True, **args)
+
+
+def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weights_sd=None, for_inference=False, **kwargs):
+    del vae
+    weights_sd = load_weights_sd(file, weights_sd)
+    args = _create_network_args(kwargs.get("network_dim", None), None, kwargs)
+    module_class = OFTv2InfModule if for_inference else OFTv2Module
+    network = OFTv2Network(
+        text_encoder,
+        unet,
+        multiplier=multiplier,
+        modules_state=weights_sd,
+        module_class=module_class,
+        verbose=True,
+        **args,
+    )
+    return network, weights_sd

--- a/networks/oft_v2.py
+++ b/networks/oft_v2.py
@@ -144,14 +144,12 @@ class OFTRotationModule(nn.Module):
         return self._pytorch_skew_symmetric_inv(out, self.block_size)
 
     def get_rotation_blocks(self, apply_dropout=True):
-        weight = self.weight
         if self.coft:
             with torch.no_grad():
-                weight = self._project_batch(weight, coft_eps=self.coft_eps)
-                self.weight.copy_(weight)
+                self.weight.copy_(self._project_batch(self.weight, coft_eps=self.coft_eps))
 
         rotation = self._cayley_batch(
-            weight,
+            self.weight,
             self.block_size,
             self.use_cayley_neumann,
             self.num_cayley_neumann_terms,
@@ -513,8 +511,12 @@ class OFTv2Network(nn.Module):
         params = []
         descriptions = []
 
-        for te_idx, prefix in enumerate((LORA_PREFIX_TEXT_ENCODER, LORA_PREFIX_TEXT_ENCODER1, LORA_PREFIX_TEXT_ENCODER2)):
-            te_loras = [lora for lora in self.text_encoder_loras if lora.lora_name.startswith(prefix)]
+        for prefix, te_idx in (
+            (LORA_PREFIX_TEXT_ENCODER, 0),
+            (LORA_PREFIX_TEXT_ENCODER1, 0),
+            (LORA_PREFIX_TEXT_ENCODER2, 1),
+        ):
+            te_loras = [lora for lora in self.text_encoder_loras if lora.lora_name.startswith(prefix + "_")]
             if not te_loras:
                 continue
             lr = text_encoder_lr[te_idx] if te_idx < len(text_encoder_lr) else text_encoder_lr[0]

--- a/networks/orthogonal_common.py
+++ b/networks/orthogonal_common.py
@@ -1,0 +1,243 @@
+# Shared helpers for orthogonal adapter network modules.
+
+import ast
+import math
+import os
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import torch
+
+from library.utils import setup_logging
+
+setup_logging()
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+TEXT_ENCODER_TARGET_REPLACE_MODULE = ["CLIPAttention", "CLIPSdpaAttention", "CLIPMLP"]
+UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel"]
+UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
+
+LORA_PREFIX_UNET = "lora_unet"
+LORA_PREFIX_TEXT_ENCODER = "lora_te"
+LORA_PREFIX_TEXT_ENCODER1 = "lora_te1"
+LORA_PREFIX_TEXT_ENCODER2 = "lora_te2"
+
+
+def str_to_bool(value, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in ("1", "true", "yes", "y", "on")
+
+
+def str_to_int(value, default: Optional[int] = None) -> Optional[int]:
+    if value is None:
+        return default
+    return int(value)
+
+
+def str_to_float(value, default: Optional[float] = None) -> Optional[float]:
+    if value is None:
+        return default
+    return float(value)
+
+
+def parse_patterns(value) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    try:
+        parsed = ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        return [str(value)]
+    return parsed if isinstance(parsed, list) else [parsed]
+
+
+def text_encoder_list(text_encoder) -> List[torch.nn.Module]:
+    if text_encoder is None:
+        return []
+    if isinstance(text_encoder, list):
+        return [te for te in text_encoder if te is not None]
+    return [text_encoder]
+
+
+def load_weights_sd(file, weights_sd=None) -> Dict[str, torch.Tensor]:
+    if weights_sd is not None:
+        return weights_sd
+
+    if os.path.isdir(file):
+        safetensors_file = os.path.join(file, "adapter_model.safetensors")
+        bin_file = os.path.join(file, "adapter_model.bin")
+        if os.path.exists(safetensors_file):
+            file = safetensors_file
+        elif os.path.exists(bin_file):
+            file = bin_file
+        else:
+            raise FileNotFoundError(f"No adapter_model.safetensors or adapter_model.bin found in {file}")
+
+    if os.path.splitext(file)[1] == ".safetensors":
+        from safetensors.torch import load_file
+
+        return load_file(file)
+
+    return torch.load(file, map_location="cpu")
+
+
+def save_weights_sd(file, state_dict, dtype, metadata):
+    if metadata is not None and len(metadata) == 0:
+        metadata = None
+
+    if dtype is not None:
+        state_dict = {k: v.detach().clone().to("cpu").to(dtype) for k, v in state_dict.items()}
+    else:
+        state_dict = {k: v.detach().clone().to("cpu") for k, v in state_dict.items()}
+
+    if os.path.splitext(file)[1] == ".safetensors":
+        from safetensors.torch import save_file
+        from library import train_util
+
+        if metadata is None:
+            metadata = {}
+        model_hash, legacy_hash = train_util.precalculate_safetensors_hashes(state_dict, metadata)
+        metadata["sshs_model_hash"] = model_hash
+        metadata["sshs_legacy_hash"] = legacy_hash
+        save_file(state_dict, file, metadata)
+    else:
+        torch.save(state_dict, file)
+
+
+def is_linear_module(module: torch.nn.Module) -> bool:
+    return module.__class__.__name__ == "Linear"
+
+
+def is_conv2d_module(module: torch.nn.Module) -> bool:
+    return module.__class__.__name__ == "Conv2d"
+
+
+def is_conv2d_1x1(module: torch.nn.Module) -> bool:
+    return is_conv2d_module(module) and module.kernel_size == (1, 1)
+
+
+def get_in_features(module: torch.nn.Module) -> int:
+    if is_linear_module(module):
+        return module.in_features
+    if is_conv2d_module(module):
+        if module.groups != 1:
+            raise ValueError("Orthogonal adapters do not support grouped Conv2d layers")
+        if module.dilation[0] > 1 or module.dilation[1] > 1:
+            raise ValueError("Orthogonal adapters do not support Conv2d layers with dilation > 1")
+        return module.in_channels * module.kernel_size[0] * module.kernel_size[1]
+    raise TypeError(f"Unsupported module type: {module.__class__.__name__}")
+
+
+def get_out_features(module: torch.nn.Module) -> int:
+    if is_linear_module(module):
+        return module.out_features
+    if is_conv2d_module(module):
+        return module.out_channels
+    raise TypeError(f"Unsupported module type: {module.__class__.__name__}")
+
+
+def adjust_block_size(in_features: int, block_size: int) -> int:
+    if block_size <= 0:
+        raise ValueError("block size must be positive")
+    if in_features % block_size == 0 and block_size <= in_features:
+        return block_size
+    if block_size >= in_features:
+        return in_features
+
+    higher = block_size
+    while higher <= in_features and in_features % higher != 0:
+        higher += 1
+
+    lower = block_size
+    while lower > 1 and in_features % lower != 0:
+        lower -= 1
+
+    if higher > in_features:
+        return lower
+    return lower if (block_size - lower) <= (higher - block_size) else higher
+
+
+def triangular_block_size(n_elements: int) -> int:
+    # n = b * (b - 1) / 2
+    block_size = int((1 + math.sqrt(1 + 8 * n_elements)) / 2)
+    if block_size * (block_size - 1) // 2 != n_elements:
+        raise ValueError(f"Cannot infer OFT block size from {n_elements} triangular elements")
+    return block_size
+
+
+def native_prefix(root_prefix: str, original_name: str) -> str:
+    return f"{root_prefix}.{original_name}".replace(".", "_")
+
+
+def omi_prefix(root_prefix: str, original_name: str) -> Optional[str]:
+    if root_prefix == LORA_PREFIX_UNET:
+        return f"unet.{original_name}"
+    if root_prefix == LORA_PREFIX_TEXT_ENCODER:
+        return f"clip_l.{original_name}"
+    if root_prefix == LORA_PREFIX_TEXT_ENCODER1:
+        return f"clip_l.{original_name}"
+    if root_prefix == LORA_PREFIX_TEXT_ENCODER2:
+        return f"clip_g.{original_name}"
+    return None
+
+
+def candidate_module_prefixes(lora_name: str, root_prefix: str, original_name: str) -> List[str]:
+    candidates = [
+        lora_name,
+        f"{root_prefix}.{original_name}",
+    ]
+    omi = omi_prefix(root_prefix, original_name)
+    if omi is not None:
+        candidates.append(omi)
+    return candidates
+
+
+def extract_module_state(
+    weights_sd: Dict[str, torch.Tensor],
+    lora_name: str,
+    root_prefix: str,
+    original_name: str,
+    param_names: Iterable[str],
+) -> Tuple[Dict[str, torch.Tensor], List[str]]:
+    state = {}
+    used = []
+    keys = set(weights_sd.keys())
+    prefixes = candidate_module_prefixes(lora_name, root_prefix, original_name)
+
+    for param_name in param_names:
+        found_key = None
+        for prefix in prefixes:
+            key = f"{prefix}.{param_name}"
+            if key in keys:
+                found_key = key
+                break
+
+        if found_key is None:
+            suffix = f".{original_name}.{param_name}"
+            for key in keys:
+                if key.endswith(suffix):
+                    found_key = key
+                    break
+
+        if found_key is not None:
+            state[param_name] = weights_sd[found_key]
+            used.append(found_key)
+
+    return state, used
+
+
+def has_any_module_state(
+    weights_sd: Dict[str, torch.Tensor],
+    lora_name: str,
+    root_prefix: str,
+    original_name: str,
+    param_names: Iterable[str],
+) -> bool:
+    state, _ = extract_module_state(weights_sd, lora_name, root_prefix, original_name, param_names)
+    return len(state) > 0

--- a/networks/orthogonal_common.py
+++ b/networks/orthogonal_common.py
@@ -98,11 +98,17 @@ def save_weights_sd(file, state_dict, dtype, metadata):
 
     if os.path.splitext(file)[1] == ".safetensors":
         from safetensors.torch import save_file
-        from library import train_util
+        try:
+            from library.model_io import precalculate_safetensors_hashes
+        except ModuleNotFoundError as e:
+            if e.name != "library.model_io":
+                raise
+            # リファクタリング前の sd-scripts との互換性を保つ。
+            from library.train_util import precalculate_safetensors_hashes
 
         if metadata is None:
             metadata = {}
-        model_hash, legacy_hash = train_util.precalculate_safetensors_hashes(state_dict, metadata)
+        model_hash, legacy_hash = precalculate_safetensors_hashes(state_dict, metadata)
         metadata["sshs_model_hash"] = model_hash
         metadata["sshs_legacy_hash"] = legacy_hash
         save_file(state_dict, file, metadata)
@@ -220,10 +226,11 @@ def extract_module_state(
 
         if found_key is None:
             suffix = f".{original_name}.{param_name}"
-            for key in keys:
-                if key.endswith(suffix):
-                    found_key = key
-                    break
+            matches = sorted(key for key in keys if key.startswith("base_model.model.") and key.endswith(suffix))
+            if len(matches) > 1:
+                raise ValueError(f"Ambiguous PEFT weight keys for {lora_name}.{param_name}: {matches}")
+            if matches:
+                found_key = matches[0]
 
         if found_key is not None:
             state[param_name] = weights_sd[found_key]

--- a/tests/test_orthogonal_networks.py
+++ b/tests/test_orthogonal_networks.py
@@ -1,0 +1,129 @@
+import sys
+import types
+
+import torch
+from torch import nn
+
+try:
+    import library.utils
+except ModuleNotFoundError as e:
+    if e.name != "diffusers":
+        raise
+    utils_mod = types.ModuleType("library.utils")
+    utils_mod.setup_logging = lambda *args, **kwargs: None
+    sys.modules["library.utils"] = utils_mod
+
+from networks import boft, oft_v2
+
+
+class Transformer2DModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.to_q = nn.Linear(8, 4, bias=False)
+
+    def forward(self, x):
+        return self.to_q(x)
+
+
+class ToyUNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = Transformer2DModel()
+
+    def forward(self, x):
+        return self.block(x)
+
+
+def _clone_linear(linear):
+    cloned = nn.Linear(linear.in_features, linear.out_features, bias=linear.bias is not None)
+    cloned.load_state_dict(linear.state_dict())
+    return cloned
+
+
+def test_oftv2_linear_forward_matches_merge():
+    torch.manual_seed(1)
+    base = nn.Linear(8, 4, bias=False)
+    base_for_merge = _clone_linear(base)
+    x = torch.randn(3, 8)
+
+    module = oft_v2.OFTv2Module("lora_unet_block_to_q", "lora_unet", "block.to_q", base, block_size=4)
+    module.oft_R.weight.data.normal_(0, 0.05)
+    module.apply_to()
+
+    merge_module = oft_v2.OFTv2Module("lora_unet_block_to_q", "lora_unet", "block.to_q", base_for_merge, block_size=4)
+    merge_module.load_state_dict(module.state_dict(), strict=False)
+    merge_module.merge_to()
+
+    with torch.no_grad():
+        hooked = base(x)
+        merged = base_for_merge(x)
+
+    assert torch.allclose(hooked, merged, atol=1e-5, rtol=1e-5)
+
+
+def test_boft_linear_forward_matches_merge():
+    torch.manual_seed(2)
+    base = nn.Linear(8, 4, bias=False)
+    base_for_merge = _clone_linear(base)
+    x = torch.randn(3, 8)
+
+    module = boft.BOFTModule("lora_unet_block_to_q", "lora_unet", "block.to_q", base, block_size=4)
+    module.boft_R.data.normal_(0, 0.04)
+    module.boft_s.data.normal_(1.0, 0.02)
+    module.apply_to()
+
+    merge_module = boft.BOFTModule("lora_unet_block_to_q", "lora_unet", "block.to_q", base_for_merge, block_size=4)
+    merge_module.load_state_dict(module.state_dict(), strict=False)
+    merge_module.merge_to()
+
+    with torch.no_grad():
+        hooked = base(x)
+        merged = base_for_merge(x)
+
+    assert torch.allclose(hooked, merged, atol=1e-5, rtol=1e-5)
+
+
+def test_oftv2_create_network_from_peft_style_weights():
+    toy = ToyUNet()
+    weights_sd = {
+        "base_model.model.block.to_q.oft_R.weight": torch.zeros(2, 6),
+    }
+
+    network, returned_sd = oft_v2.create_network_from_weights(1.0, None, None, [], toy, weights_sd=weights_sd)
+
+    assert returned_sd is weights_sd
+    assert len(network.unet_loras) == 1
+    assert network.unet_loras[0].lora_name == "lora_unet_block_to_q"
+    assert network.unet_loras[0].oft_R.weight.shape == (2, 6)
+
+
+def test_boft_create_network_from_peft_style_weights():
+    toy = ToyUNet()
+    weights_sd = {
+        "base_model.model.block.to_q.boft_R": torch.zeros(1, 2, 4, 4),
+        "base_model.model.block.to_q.boft_s": torch.ones(4, 1),
+    }
+
+    network, returned_sd = boft.create_network_from_weights(1.0, None, None, [], toy, weights_sd=weights_sd)
+
+    assert returned_sd is weights_sd
+    assert len(network.unet_loras) == 1
+    assert network.unet_loras[0].lora_name == "lora_unet_block_to_q"
+    assert network.unet_loras[0].boft_R.shape == (1, 2, 4, 4)
+    assert network.unet_loras[0].boft_s.shape == (4, 1)
+
+
+def test_boft_training_load_accepts_peft_style_weights(tmp_path):
+    toy = ToyUNet()
+    weights_sd = {
+        "base_model.model.block.to_q.boft_R": torch.randn(1, 2, 4, 4) * 0.01,
+        "base_model.model.block.to_q.boft_s": torch.ones(4, 1),
+    }
+    weights_file = tmp_path / "boft.pt"
+    torch.save(weights_sd, weights_file)
+
+    network = boft.create_network(1.0, 4, None, None, [], toy)
+    network.apply_to([], toy, apply_text_encoder=False, apply_unet=True)
+    network.load_weights(str(weights_file))
+
+    assert torch.allclose(network.unet_loras[0].boft_R, weights_sd["base_model.model.block.to_q.boft_R"])

--- a/tests/test_orthogonal_networks.py
+++ b/tests/test_orthogonal_networks.py
@@ -1,6 +1,8 @@
+import copy
 import sys
 import types
 
+import pytest
 import torch
 from torch import nn
 
@@ -34,17 +36,36 @@ class ToyUNet(nn.Module):
         return self.block(x)
 
 
-def _clone_linear(linear):
-    cloned = nn.Linear(linear.in_features, linear.out_features, bias=linear.bias is not None)
-    cloned.load_state_dict(linear.state_dict())
-    return cloned
+class CLIPAttention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.to_q = nn.Linear(8, 4, bias=False)
+
+    def forward(self, x):
+        return self.to_q(x)
 
 
-def test_oftv2_linear_forward_matches_merge():
+class ToyTextEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = CLIPAttention()
+
+    def forward(self, x):
+        return self.block(x)
+
+
+def _base_and_input(layer):
+    if layer == "linear":
+        return nn.Linear(8, 4, bias=False), torch.randn(3, 8)
+    kernel_size = 1 if layer == "conv1x1" else 3
+    return nn.Conv2d(8, 4, kernel_size, padding=kernel_size // 2, bias=True), torch.randn(2, 8, 5, 5)
+
+
+@pytest.mark.parametrize("layer", ["linear", "conv1x1", "conv3x3"])
+def test_oftv2_linear_forward_matches_merge(layer):
     torch.manual_seed(1)
-    base = nn.Linear(8, 4, bias=False)
-    base_for_merge = _clone_linear(base)
-    x = torch.randn(3, 8)
+    base, x = _base_and_input(layer)
+    base_for_merge = copy.deepcopy(base)
 
     module = oft_v2.OFTv2Module("lora_unet_block_to_q", "lora_unet", "block.to_q", base, block_size=4)
     module.oft_R.weight.data.normal_(0, 0.05)
@@ -61,11 +82,11 @@ def test_oftv2_linear_forward_matches_merge():
     assert torch.allclose(hooked, merged, atol=1e-5, rtol=1e-5)
 
 
-def test_boft_linear_forward_matches_merge():
+@pytest.mark.parametrize("layer", ["linear", "conv1x1", "conv3x3"])
+def test_boft_linear_forward_matches_merge(layer):
     torch.manual_seed(2)
-    base = nn.Linear(8, 4, bias=False)
-    base_for_merge = _clone_linear(base)
-    x = torch.randn(3, 8)
+    base, x = _base_and_input(layer)
+    base_for_merge = copy.deepcopy(base)
 
     module = boft.BOFTModule("lora_unet_block_to_q", "lora_unet", "block.to_q", base, block_size=4)
     module.boft_R.data.normal_(0, 0.04)
@@ -127,3 +148,157 @@ def test_boft_training_load_accepts_peft_style_weights(tmp_path):
     network.load_weights(str(weights_file))
 
     assert torch.allclose(network.unet_loras[0].boft_R, weights_sd["base_model.model.block.to_q.boft_R"])
+
+
+@pytest.mark.parametrize("block_share", [False, True])
+@pytest.mark.parametrize("use_cayley_neumann", [False, True], ids=["exact", "neumann"])
+@pytest.mark.parametrize("initial_scale", [0.0, 0.2], ids=["zero", "projected"])
+def test_coft_backward_updates_rotation(initial_scale, use_cayley_neumann, block_share):
+    torch.manual_seed(13)
+    base = nn.Linear(8, 4, bias=False).requires_grad_(False)
+    base_before = base.weight.detach().clone()
+    module = oft_v2.OFTv2Module(
+        "lora_unet_block_to_q", "lora_unet", "block.to_q", base,
+        block_size=4, coft=True, coft_eps=0.05, block_share=block_share,
+    )
+    module.oft_R.use_cayley_neumann = use_cayley_neumann
+    with torch.no_grad():
+        module.oft_R.weight.normal_(0, initial_scale)
+    initial = module.oft_R.weight.detach().clone()
+    module.apply_to()
+    optimizer = torch.optim.SGD(module.parameters(), lr=0.01)
+    # 修正前にも backward 自体は実行し、アダプターへの勾配欠落を検出する。
+    x = torch.randn(3, 8, requires_grad=True)
+    target = torch.randn(3, 4)
+    loss = (base(x) - target).square().mean()
+    projected = module.oft_R.weight.detach().clone()
+    assert torch.isfinite(projected).all()
+    if initial_scale:
+        assert not torch.equal(initial, projected)
+    else:
+        assert torch.equal(initial, projected)
+    loss.backward()
+
+    grad = module.oft_R.weight.grad
+    assert grad is not None
+    assert torch.isfinite(grad).all()
+    assert torch.count_nonzero(grad) > 0
+    optimizer.step()
+    assert not torch.equal(module.oft_R.weight.detach(), projected)
+    assert base.weight.grad is None
+    assert torch.equal(base.weight.detach(), base_before)
+
+
+@pytest.mark.parametrize("backend", [oft_v2, boft], ids=["oftv2", "boft"])
+@pytest.mark.parametrize("encoder_count", [1, 2], ids=["sd1", "sdxl"])
+@pytest.mark.parametrize(
+    "te_lrs, expected_lrs",
+    [
+        ([0.001, 0.002], [0.001, 0.002]),
+        ([0.001], [0.001, 0.001]),
+        (0.001, [0.001, 0.001]),
+        (None, [0.003, 0.003]),
+        ([], [0.003, 0.003]),
+        ([0.0, 0.002], [0.0, 0.002]),
+        ([0.001, 0.0], [0.001, 0.0]),
+    ],
+    ids=["distinct", "single-list", "scalar", "default", "empty", "te1-zero", "te2-zero"],
+)
+def test_text_encoder_optimizer_groups(backend, encoder_count, te_lrs, expected_lrs):
+    encoders = [ToyTextEncoder() for _ in range(encoder_count)]
+    unet = ToyUNet()
+    for model in [*encoders, unet]:
+        model.requires_grad_(False)
+    network = backend.create_network(1.0, 4, None, None, encoders, unet)
+    network.apply_to(encoders, unet)
+    assert len(network.text_encoder_loras) == encoder_count
+    assert len(network.unet_loras) == 1
+    groups, descriptions = network.prepare_optimizer_params_with_multiple_te_lrs(te_lrs, 0.004, 0.003)
+    # 実際の登録済みパラメーターで、グループ間の重複も検出する。
+    optimizer = torch.optim.AdamW(groups, lr=0.003)
+    parameter_ids = [id(p) for group in optimizer.param_groups for p in group["params"]]
+    assert len(parameter_ids) == len(set(parameter_ids))
+    assert len(descriptions) == len(groups)
+    registered_ids = {id(p) for p in network.parameters()}
+    assert set(parameter_ids) <= registered_ids
+    actual_lrs = {id(p): group["lr"] for group in optimizer.param_groups for p in group["params"]}
+    expected = {}
+    for index, lora in enumerate(network.text_encoder_loras):
+        expected_prefix = "lora_te" if encoder_count == 1 else f"lora_te{index + 1}"
+        assert lora.root_prefix == expected_prefix
+        if expected_lrs[index] != 0:
+            expected.update({id(p): expected_lrs[index] for p in lora.parameters()})
+    for lora in network.unet_loras:
+        expected.update({id(p): 0.004 for p in lora.parameters()})
+    assert actual_lrs == expected
+
+
+def _local_adapter_state(backend):
+    if backend is oft_v2:
+        return {"oft_R.weight": torch.full((2, 6), 0.025)}
+    return {
+        "boft_R": torch.arange(32, dtype=torch.float32).reshape(1, 2, 4, 4) * 0.001,
+        "boft_s": torch.full((4, 1), 1.125),
+    }
+
+
+@pytest.mark.parametrize("backend", [oft_v2, boft], ids=["oftv2", "boft"])
+@pytest.mark.parametrize(
+    "source_prefix, target_index",
+    [("clip_l.block.to_q", 0), ("clip_g.block.to_q", 1),
+     ("lora_te1_block_to_q", 0), ("lora_te2_block_to_q", 1)],
+    ids=["clip-l", "clip-g", "native-te1", "native-te2"],
+)
+def test_encoder_weight_namespace_isolation(backend, source_prefix, target_index, tmp_path):
+    local_state = _local_adapter_state(backend)
+    weights_sd = {f"{source_prefix}.{name}": value for name, value in local_state.items()}
+    encoders = [ToyTextEncoder(), ToyTextEncoder()]
+    network, returned_sd = backend.create_network_from_weights(
+        1.0, None, None, encoders, ToyUNet(), weights_sd=weights_sd,
+    )
+    assert returned_sd is weights_sd
+    assert [lora.root_prefix for lora in network.text_encoder_loras] == [f"lora_te{target_index + 1}"]
+    assert network.unet_loras == []
+    for name, value in local_state.items():
+        assert torch.equal(network.text_encoder_loras[0].state_dict()[name], value)
+
+    # 全ターゲットを作成済みの学習用ロードでも、他のエンコーダーを保持する。
+    encoders = [ToyTextEncoder(), ToyTextEncoder()]
+    unet = ToyUNet()
+    training_network = backend.create_network(1.0, 4, None, None, encoders, unet)
+    training_network.apply_to(encoders, unet)
+    untouched = [training_network.text_encoder_loras[1 - target_index], *training_network.unet_loras]
+    before = [{name: value.clone() for name, value in lora.state_dict().items()} for lora in untouched]
+    weights_file = tmp_path / "adapter.pt"
+    torch.save(weights_sd, weights_file)
+    training_network.load_weights(str(weights_file))
+    for name, value in local_state.items():
+        assert torch.equal(training_network.text_encoder_loras[target_index].state_dict()[name], value)
+    for lora, previous in zip(untouched, before):
+        for name, value in previous.items():
+            assert torch.equal(lora.state_dict()[name], value)
+
+
+@pytest.mark.parametrize("backend", [oft_v2, boft], ids=["oftv2", "boft"])
+def test_nested_peft_module_prefix_is_supported(backend):
+    local_state = _local_adapter_state(backend)
+    weights_sd = {f"base_model.model.encoder.block.to_q.{name}": value for name, value in local_state.items()}
+    network, _ = backend.create_network_from_weights(1.0, None, None, [], ToyUNet(), weights_sd=weights_sd)
+    assert len(network.unet_loras) == 1
+    for name, value in local_state.items():
+        assert torch.equal(network.unet_loras[0].state_dict()[name], value)
+
+
+@pytest.mark.parametrize("backend", [oft_v2, boft], ids=["oftv2", "boft"])
+@pytest.mark.parametrize("reverse_order", [False, True], ids=["forward-order", "reverse-order"])
+def test_ambiguous_peft_suffix_is_rejected(backend, reverse_order):
+    local_state = _local_adapter_state(backend)
+    entries = [
+        (f"base_model.model.{encoder}.block.to_q.{name}", value + index)
+        for index, encoder in enumerate(["encoder_a", "encoder_b"])
+        for name, value in local_state.items()
+    ]
+    if reverse_order:
+        entries.reverse()
+    with pytest.raises(ValueError, match="(?i)ambig"):
+        backend.create_network_from_weights(1.0, None, None, [], ToyUNet(), weights_sd=dict(entries))


### PR DESCRIPTION
## 概要

SD1/SD2/SDXL の network training 向けに、直交変換系アダプタの新しい network module を追加しました。

- `networks.oft_v2`
  - OneTrainer / PEFT 形式に近い OFTv2 対応
  - `oft_R.weight` の保存・読み込みに対応
  - 学習、既存重み読み込み、merge flow に対応

- `networks.boft`
  - PEFT 形式に近い BOFT 対応
  - `boft_R` / `boft_s` の保存・読み込みに対応
  - 学習、既存重み読み込み、merge flow に対応

既存の legacy `networks.oft` は変更していません。

## 対象範囲

今回の対象としたのは、`train_network.py` / `sdxl_train_network.py` 経由の SD1/SD2/SDXL 向け network training です。

今回のPRで、以下のアーキテクチャ群はひとまず対象外にしました。

- Flux
- SD3
- Hunyuan
- Lumina
- Anima 固有の network module

## 互換性

新規モジュールでは、以下の形式を読み込めるようにしました。

- sd-scripts native 形式
  - 例: `lora_unet_...oft_R.weight`
- OneTrainer 由来の OFTv2 形式
  - `oft_R.weight`
- PEFT 由来の OFT / BOFT adapter 形式
  - sd-scripts側の対象module名とsuffixが一致する場合に読み込み

BOFT は PEFT の保存形式に合わせ、保存対象を以下にしています。

- `boft_R`
- `boft_s`

`boft_P` は実行時に再構築するため保存しません。

## 使い方の例

OFTv2:

```bash
accelerate launch --num_cpu_threads_per_process 1 sdxl_train_network.py \
  --pretrained_model_name_or_path="/path/to/sdxl_model.safetensors" \
  --dataset_config="/path/to/config.toml" \
  --output_dir="./output" \
  --output_name="sdxl_oftv2_test" \
  --save_model_as=safetensors \
  --network_module=networks.oft_v2 \
  --network_dim=32 \
  --network_args "coft=false" "block_share=false" \
  --network_train_unet_only \
  --learning_rate=1e-4 \
  --unet_lr=1e-4 \
  --max_train_steps=20 \
  --train_batch_size=1 \
  --mixed_precision=fp16 \
  --no_half_vae \
  --sdpa \
  --gradient_checkpointing \
  --cache_latents
```

## 検証
　- 追加ファイルの py_compile を確認
　- 軽量テストで forward hook と merge 後の出力一致を確認
　- PEFT風の oft_R.weight / boft_R / boft_s キーから network を作成できることを確認
　- Ubuntu 環境で sdxl_train_network.py による SDXL OFTv2 の短時間学習が完走することを確認

## その他

Codex 使用時の作業ファイルを管理対象外にするため、.gitignore に .codex を追加しました。