### PR TITLE
Fix: Anima学習時の--base_weightsのバグを修正する

### DIFF
--- a/networks/lora_anima.py
+++ b/networks/lora_anima.py
@@ -148,7 +148,6 @@ class LoRAInfModule(LoRAModule):
         weight = org_sd["weight"]
         org_dtype = weight.dtype
         org_device = weight.device
-        weight = weight.to(torch.float)  # calc in float
 
         if dtype is None:
             dtype = org_dtype
@@ -158,6 +157,9 @@ class LoRAInfModule(LoRAModule):
         # get up/down weight
         down_weight = sd["lora_down.weight"].to(torch.float).to(device)
         up_weight = sd["lora_up.weight"].to(torch.float).to(device)
+
+        # weight
+        weight = weight.to(torch.float).to(device)  # calc in float
 
         # merge weight
         if len(weight.size()) == 2:

--- a/networks/lora_fa.py
+++ b/networks/lora_fa.py
@@ -183,7 +183,7 @@ class LoRAInfModule(LoRAModule):
 
         # extract weight from org_module
         org_sd = self.org_module.state_dict()
-        weight = org_sd["weight"].to(torch.float)
+        weight = org_sd["weight"].to(torch.float).to(device)
 
         # merge weight
         if len(weight.size()) == 2:

--- a/networks/lora_flux.py
+++ b/networks/lora_flux.py
@@ -340,12 +340,13 @@ class LoRAInfModule(LoRAModule):
         weight = org_sd["weight"]
         org_dtype = weight.dtype
         org_device = weight.device
-        weight = weight.to(torch.float)  # calc in float
 
         if dtype is None:
             dtype = org_dtype
         if device is None:
             device = org_device
+
+        weight = weight.to(torch.float).to(device)  # calc in float
 
         if self.split_dims is None:
             # get up/down weight

--- a/networks/lora_lumina.py
+++ b/networks/lora_lumina.py
@@ -193,12 +193,13 @@ class LoRAInfModule(LoRAModule):
         weight = org_sd["weight"]
         org_dtype = weight.dtype
         org_device = weight.device
-        weight = weight.to(torch.float)  # calc in float
 
         if dtype is None:
             dtype = org_dtype
         if device is None:
             device = org_device
+
+        weight = weight.to(torch.float).to(device)  # calc in float
 
         if self.split_dims is None:
             # get up/down weight


### PR DESCRIPTION
Anima学習時に手元で発生した`--base_weights`指定時の以下の例外を修正するものです。(`--lowram`未指定)

```
2026-05-15 09:06:57 INFO     Loaded DiT model from                                                                                                         anima_utils.py:146
                             /home/u-haru/workspace/models/animaOfficial_preview3Base.safetensors, unexpected missing                    
                             keys: 0, unexpected keys: 0                                                                                                                     
import network module: networks.lora_anima
merging module: /home/u-haru/workspace/models/test.safetensors with multiplier 1.0
                    INFO     create LoRA network from weights                                                                                               lora_anima.py:424
                    INFO     create LoRA for Text Encoder 1:                                                                                                lora_anima.py:531
                    INFO     create LoRA for Text Encoder 1: 196 modules.                                                                                   lora_anima.py:533
                    INFO     create LoRA for Anima DiT: 280 modules.                                                                                        lora_anima.py:545
                    INFO     enable LoRA for text encoder                                                                                                   lora_anima.py:609
                    INFO     enable LoRA for DiT                                                                                                            lora_anima.py:614
Traceback (most recent call last):
  File "/home/u-haru/workspace/sd-scripts/anima_train_network.py", line 451, in <module>
    trainer.train(args)
  File "/home/u-haru/workspace/sd-scripts/train_network.py", line 657, in train
    module.merge_to(text_encoder, unet, weights_sd, weight_dtype, accelerator.device if args.lowram else "cpu")
  File "/home/u-haru/workspace/sd-scripts/networks/lora_anima.py", line 623, in merge_to
    lora.merge_to(sd_for_lora, dtype, device)
  File "/home/u-haru/workspace/sd-scripts/networks/lora_anima.py", line 165, in merge_to
    weight = weight + self.multiplier * (up_weight @ down_weight) * self.scale
             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

`merge_to(self, sd, dtype, device)`関数において`weight.to(device)`がなかったため発生していたようです。
検索したところlora_anima.py以外にも同様のコードがあったため、合わせて修正しています。
- networks/lora_anima.py
- networks/lora_fa.py
- networks/lora_flux.py
- networks/lora_lumina.py