### PR TITLE
Fix overlap GPU encoding with async disk writes for VAE and text encoder caching

### DIFF
--- a/library/strategy_anima.py
+++ b/library/strategy_anima.py
@@ -235,7 +235,7 @@ class AnimaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
             caption_dropout_rate = torch.tensor(info.caption_dropout_rate, dtype=torch.float32)
 
             if self.cache_to_disk:
-                np.savez(
+                self.save_outputs_npz(
                     info.text_encoder_outputs_npz,
                     prompt_embeds=prompt_embeds_i,
                     attn_mask=attn_mask_i,

--- a/library/strategy_base.py
+++ b/library/strategy_base.py
@@ -20,6 +20,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _write_npz(npz_path: str, kwargs: dict):
+    np.savez(npz_path, **kwargs)
+
+
 class TokenizeStrategy:
     _strategy = None  # strategy instance: actual strategy class
 
@@ -371,6 +375,31 @@ class TextEncoderOutputsCachingStrategy:
     def is_disk_cached_outputs_expected(self, npz_path: str) -> bool:
         raise NotImplementedError
 
+    def set_async_write_executor(self, executor):
+        self._write_executor = executor
+        self._write_futures = []
+
+    def wait_for_async_writes(self):
+        for f in getattr(self, "_write_futures", []):
+            f.result()
+        self._write_futures = []
+
+    def submit_async_write(self, fn, *args):
+        executor = getattr(self, "_write_executor", None)
+        if executor is not None:
+            if not hasattr(self, "_write_futures"):
+                self._write_futures = []
+            future = executor.submit(fn, *args)
+            self._write_futures.append(future)
+            self._write_futures = [f for f in self._write_futures if not f.done()]
+        else:
+            fn(*args)
+
+    def save_outputs_npz(self, npz_path: str, **kwargs):
+        """Save text encoder outputs to npz, async if executor is set. Copies numpy arrays to prevent races."""
+        safe_kwargs = {k: (v.copy() if isinstance(v, np.ndarray) else v) for k, v in kwargs.items()}
+        self.submit_async_write(_write_npz, npz_path, safe_kwargs)
+
     def cache_batch_outputs(
         self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, batch: List
     ):
@@ -609,6 +638,15 @@ class LatentsCachingStrategy:
         alpha_mask = npz["alpha_mask" + key_reso_suffix] if "alpha_mask" + key_reso_suffix in npz else None
         return latents, original_size, crop_ltrb, flipped_latents, alpha_mask
 
+    def set_async_write_executor(self, executor):
+        self._write_executor = executor
+        self._write_futures = []
+
+    def wait_for_async_writes(self):
+        for f in getattr(self, "_write_futures", []):
+            f.result()
+        self._write_futures = []
+
     def save_latents_to_disk(
         self,
         npz_path,
@@ -619,19 +657,34 @@ class LatentsCachingStrategy:
         alpha_mask=None,
         key_reso_suffix="",
     ):
-        """
-        Args:
-            npz_path (str): Path to the npz file.
-            latents_tensor (torch.Tensor): Latent tensor
-            original_size (List[int]): Original size of the image
-            crop_ltrb (List[int]): Crop left top right bottom
-            flipped_latents_tensor (Optional[torch.Tensor]): Flipped latent tensor
-            alpha_mask (Optional[torch.Tensor]): Alpha mask
-            key_reso_suffix (str): Key resolution suffix
+        executor = getattr(self, "_write_executor", None)
+        if executor is not None:
+            latents_copy = latents_tensor.float().cpu().clone()
+            flipped_copy = flipped_latents_tensor.float().cpu().clone() if flipped_latents_tensor is not None else None
+            alpha_copy = alpha_mask.float().cpu().clone() if alpha_mask is not None else None
+            future = executor.submit(
+                self._save_latents_to_disk_impl,
+                npz_path, latents_copy, original_size, crop_ltrb, flipped_copy, alpha_copy, key_reso_suffix,
+            )
+            if not hasattr(self, "_write_futures"):
+                self._write_futures = []
+            self._write_futures.append(future)
+            self._write_futures = [f for f in self._write_futures if not f.done()]
+        else:
+            self._save_latents_to_disk_impl(
+                npz_path, latents_tensor, original_size, crop_ltrb, flipped_latents_tensor, alpha_mask, key_reso_suffix
+            )
 
-        Returns:
-            None
-        """
+    def _save_latents_to_disk_impl(
+        self,
+        npz_path,
+        latents_tensor,
+        original_size,
+        crop_ltrb,
+        flipped_latents_tensor=None,
+        alpha_mask=None,
+        key_reso_suffix="",
+    ):
         kwargs = {}
 
         if os.path.exists(npz_path):

--- a/library/strategy_flux.py
+++ b/library/strategy_flux.py
@@ -181,7 +181,7 @@ class FluxTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
             apply_t5_attn_mask_i = self.apply_t5_attn_mask
 
             if self.cache_to_disk:
-                np.savez(
+                self.save_outputs_npz(
                     info.text_encoder_outputs_npz,
                     l_pooled=l_pooled_i,
                     t5_out=t5_out_i,

--- a/library/strategy_hunyuan_image.py
+++ b/library/strategy_hunyuan_image.py
@@ -159,7 +159,7 @@ class HunyuanImageTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStr
             ocr_mask_i = ocr_mask[i]
 
             if self.cache_to_disk:
-                np.savez(
+                self.save_outputs_npz(
                     info.text_encoder_outputs_npz,
                     vlm_embed=vlm_embed_i,
                     vlm_mask=vlm_mask_i,

--- a/library/strategy_lumina.py
+++ b/library/strategy_lumina.py
@@ -267,7 +267,7 @@ class LuminaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy)
 
             if self.cache_to_disk:
                 assert info.text_encoder_outputs_npz is not None, f"Text encoder cache outputs to disk not found for image {info.image_key}"
-                np.savez(
+                self.save_outputs_npz(
                     info.text_encoder_outputs_npz,
                     hidden_state=hidden_state_i,
                     attention_mask=attention_mask_i,

--- a/library/strategy_sd3.py
+++ b/library/strategy_sd3.py
@@ -365,7 +365,7 @@ class Sd3TextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
             apply_t5_attn_mask = self.apply_t5_attn_mask
 
             if self.cache_to_disk:
-                np.savez(
+                self.save_outputs_npz(
                     info.text_encoder_outputs_npz,
                     lg_out=lg_out_i,
                     lg_pooled=lg_pooled_i,

--- a/library/strategy_sdxl.py
+++ b/library/strategy_sdxl.py
@@ -296,7 +296,7 @@ class SdxlTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
             pool2_i = pool2[i]
 
             if self.cache_to_disk:
-                np.savez(
+                self.save_outputs_npz(
                     info.text_encoder_outputs_npz,
                     hidden_state1=hidden_state1_i,
                     hidden_state2=hidden_state2_i,

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1156,6 +1156,23 @@ class BaseDataset(torch.utils.data.Dataset):
         num_processes = accelerator.num_processes
         process_index = accelerator.process_index
 
+        # Diagnostic: show how many images this process will actually encode
+        total_images = len(image_infos)
+        if caching_strategy.cache_to_disk and num_processes > 1:
+            my_image_count = sum(1 for i in range(total_images) if i % num_processes == process_index)
+        else:
+            my_image_count = total_images
+        logger.info(
+            f"[Process {process_index + 1}/{num_processes}] device={accelerator.device}, "
+            f"will encode {my_image_count}/{total_images} images"
+        )
+        if num_processes == 1 and torch.cuda.is_available() and torch.cuda.device_count() > 1:
+            logger.warning(
+                f"Only 1 process running while {torch.cuda.device_count()} GPUs are visible. "
+                f"Launch with 'accelerate launch --num_processes {torch.cuda.device_count()}' "
+                f"to distribute caching across all GPUs."
+            )
+
         # define a function to submit a batch to cache
         def submit_batch(batch, cond):
             for info in batch:
@@ -1172,6 +1189,15 @@ class BaseDataset(torch.utils.data.Dataset):
         max_workers = max(1, max_workers // num_processes)  # consider multi-gpu
         max_workers = min(max_workers, caching_strategy.batch_size)  # max_workers should be less than batch_size
         executor = ThreadPoolExecutor(max_workers)
+
+        # Background thread pool for disk writes: lets the GPU encode the next batch
+        # while the previous batch's latents are being written to disk.
+        write_executor = None
+        if caching_strategy.cache_to_disk:
+            write_workers = max(1, os.cpu_count() // num_processes)
+            write_workers = min(write_workers, caching_strategy.batch_size)
+            write_executor = ThreadPoolExecutor(max_workers=write_workers)
+            caching_strategy.set_async_write_executor(write_executor)
 
         try:
             # iterate images
@@ -1224,8 +1250,14 @@ class BaseDataset(torch.utils.data.Dataset):
             if len(batch) > 0:
                 submit_batch(batch, current_condition)
 
+            if write_executor is not None:
+                caching_strategy.wait_for_async_writes()
+
         finally:
             executor.shutdown()
+            if write_executor is not None:
+                caching_strategy.set_async_write_executor(None)
+                write_executor.shutdown(wait=True)
 
     def cache_latents(self, vae, vae_batch_size=1, cache_to_disk=False, is_main_process=True, file_suffix=".npz"):
         # マルチGPUには対応していないので、そちらはtools/cache_latents.pyを使うこと
@@ -1352,11 +1384,26 @@ class BaseDataset(torch.utils.data.Dataset):
             logger.info("no Text Encoder outputs to cache")
             return
 
-        # iterate batches
-        logger.info("caching Text Encoder outputs...")
-        for batch in tqdm(batches, smoothing=1, total=len(batches)):
-            # cache_batch_latents(vae, cache_to_disk, batch, subset.flip_aug, subset.alpha_mask, subset.random_crop)
-            caching_strategy.cache_batch_outputs(tokenize_strategy, models, text_encoding_strategy, batch)
+        # Background thread pool for disk writes (same pattern as VAE latent caching)
+        write_executor = None
+        if caching_strategy.cache_to_disk:
+            write_workers = max(1, os.cpu_count() // num_processes)
+            write_workers = min(write_workers, batch_size)
+            write_executor = ThreadPoolExecutor(max_workers=write_workers)
+            caching_strategy.set_async_write_executor(write_executor)
+
+        try:
+            # iterate batches
+            logger.info("caching Text Encoder outputs...")
+            for batch in tqdm(batches, smoothing=1, total=len(batches)):
+                caching_strategy.cache_batch_outputs(tokenize_strategy, models, text_encoding_strategy, batch)
+
+            if write_executor is not None:
+                caching_strategy.wait_for_async_writes()
+        finally:
+            if write_executor is not None:
+                caching_strategy.set_async_write_executor(None)
+                write_executor.shutdown(wait=True)
 
     # if weight_dtype is specified, Text Encoder itself and output will be converted to the dtype
     # this method is only for SDXL, but it should be implemented here because it needs to be a method of dataset


### PR DESCRIPTION
Hi @kohya-ss 

Problem: after encoding each batch on GPU, the process synchronously called
np.savez / save_latents_to_disk, leaving the GPU idle for the full duration of
the disk write before starting the next encode. With multiple GPUs each writing
N/num_processes files simultaneously, total disk throughput was saturated, so
adding more GPUs did not reduce wall time.

Fix: add a background ThreadPoolExecutor (write_executor) in both
new_cache_latents and new_cache_text_encoder_outputs. Disk writes are submitted
to this pool immediately after encoding, allowing the GPU to begin the next
batch encode concurrently. All writes are flushed before the function returns.

strategy_base.py:
- LatentsCachingStrategy: add set_async_write_executor / wait_for_async_writes;
  split save_latents_to_disk into async dispatch + _save_latents_to_disk_impl;
  tensors are cloned on CPU before handoff to prevent races
- TextEncoderOutputsCachingStrategy: same helpers plus save_outputs_npz()
  which copies numpy arrays and dispatches to the write pool
- Module-level _write_npz helper (avoids lambda/closure issues)

train_util.py (new_cache_latents):
- Create write_executor sized to cpu_count//num_processes capped at batch_size
- Log [Process X/N] device=... will encode M/total images at start
- Warn when num_processes=1 but multiple GPUs are visible

train_util.py (new_cache_text_encoder_outputs):
- Same write_executor pattern as VAE caching

strategy_flux/sd3/sdxl/lumina/hunyuan_image/anima:
- Replace np.savez(...) with self.save_outputs_npz(...)