### PR TITLE
Support multi-caption embedding caching for all models

### DIFF
--- a/library/strategy_anima.py
+++ b/library/strategy_anima.py
@@ -201,7 +201,40 @@ class AnimaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         t5_input_ids = data["t5_input_ids"]
         t5_attn_mask = data["t5_attn_mask"]
         caption_dropout_rate = data["caption_dropout_rate"]
+
+        # multi-caption: prompt_embeds is (N, seq_len, hidden_size) with ndim==3
+        # caption_dropout_rate is a scalar shared across variants — do NOT index it
+        if prompt_embeds.ndim == 3:
+            idx = random.randint(0, prompt_embeds.shape[0] - 1)
+            prompt_embeds = prompt_embeds[idx]
+            attn_mask = attn_mask[idx]
+            t5_input_ids = t5_input_ids[idx]
+            t5_attn_mask = t5_attn_mask[idx]
+
         return [prompt_embeds, attn_mask, t5_input_ids, t5_attn_mask, caption_dropout_rate]
+
+    def _encode_captions(
+        self,
+        tokenize_strategy: TokenizeStrategy,
+        models: List[Any],
+        text_encoding_strategy: "AnimaTextEncodingStrategy",
+        captions: List[str],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        tokens_and_masks = tokenize_strategy.tokenize(captions)
+        with torch.no_grad():
+            prompt_embeds, attn_mask, t5_input_ids, t5_attn_mask = text_encoding_strategy.encode_tokens(
+                tokenize_strategy, models, tokens_and_masks
+            )
+
+        if prompt_embeds.dtype == torch.bfloat16:
+            prompt_embeds = prompt_embeds.float()
+
+        return (
+            prompt_embeds.cpu().numpy(),
+            attn_mask.cpu().numpy(),
+            t5_input_ids.cpu().numpy().astype(np.int32),
+            t5_attn_mask.cpu().numpy().astype(np.int32),
+        )
 
     def cache_batch_outputs(
         self,
@@ -211,40 +244,42 @@ class AnimaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         infos: List,
     ):
         anima_text_encoding_strategy: AnimaTextEncodingStrategy = text_encoding_strategy
-        captions = [info.caption for info in infos]
 
-        tokens_and_masks = tokenize_strategy.tokenize(captions)
-        with torch.no_grad():
-            prompt_embeds, attn_mask, t5_input_ids, t5_attn_mask = anima_text_encoding_strategy.encode_tokens(
-                tokenize_strategy, models, tokens_and_masks
+        for info in infos:
+            caption_lines = info.caption.split("\n") if "\n" in info.caption else [info.caption]
+            caption_lines = [line.strip() for line in caption_lines if line.strip()]
+            num_captions = len(caption_lines)
+
+            prompt_embeds, attn_mask, t5_input_ids, t5_attn_mask = self._encode_captions(
+                tokenize_strategy, models, anima_text_encoding_strategy, caption_lines
             )
-
-        # Convert to numpy for caching
-        if prompt_embeds.dtype == torch.bfloat16:
-            prompt_embeds = prompt_embeds.float()
-        prompt_embeds = prompt_embeds.cpu().numpy()
-        attn_mask = attn_mask.cpu().numpy()
-        t5_input_ids = t5_input_ids.cpu().numpy().astype(np.int32)
-        t5_attn_mask = t5_attn_mask.cpu().numpy().astype(np.int32)
-
-        for i, info in enumerate(infos):
-            prompt_embeds_i = prompt_embeds[i]
-            attn_mask_i = attn_mask[i]
-            t5_input_ids_i = t5_input_ids[i]
-            t5_attn_mask_i = t5_attn_mask[i]
             caption_dropout_rate = torch.tensor(info.caption_dropout_rate, dtype=torch.float32)
+
+            if num_captions == 1:
+                prompt_embeds_out = prompt_embeds[0]
+                attn_mask_out = attn_mask[0]
+                t5_input_ids_out = t5_input_ids[0]
+                t5_attn_mask_out = t5_attn_mask[0]
+            else:
+                prompt_embeds_out = prompt_embeds
+                attn_mask_out = attn_mask
+                t5_input_ids_out = t5_input_ids
+                t5_attn_mask_out = t5_attn_mask
 
             if self.cache_to_disk:
                 np.savez(
                     info.text_encoder_outputs_npz,
-                    prompt_embeds=prompt_embeds_i,
-                    attn_mask=attn_mask_i,
-                    t5_input_ids=t5_input_ids_i,
-                    t5_attn_mask=t5_attn_mask_i,
+                    prompt_embeds=prompt_embeds_out,
+                    attn_mask=attn_mask_out,
+                    t5_input_ids=t5_input_ids_out,
+                    t5_attn_mask=t5_attn_mask_out,
                     caption_dropout_rate=caption_dropout_rate,
                 )
             else:
-                info.text_encoder_outputs = (prompt_embeds_i, attn_mask_i, t5_input_ids_i, t5_attn_mask_i, caption_dropout_rate)
+                info.text_encoder_outputs = (
+                    prompt_embeds_out, attn_mask_out, t5_input_ids_out, t5_attn_mask_out, caption_dropout_rate
+                )
+                info.num_caption_variants = num_captions
 
 
 class AnimaLatentsCachingStrategy(LatentsCachingStrategy):

--- a/library/strategy_flux.py
+++ b/library/strategy_flux.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import random
 from typing import Any, List, Optional, Tuple, Union
 import torch
 import numpy as np
@@ -139,8 +140,44 @@ class FluxTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         t5_out = data["t5_out"]
         txt_ids = data["txt_ids"]
         t5_attn_mask = data["t5_attn_mask"]
+
+        # multi-caption: t5_out is (N, seq_len, 4096) with ndim==3
+        if t5_out.ndim == 3:
+            idx = random.randint(0, t5_out.shape[0] - 1)
+            l_pooled = l_pooled[idx]
+            t5_out = t5_out[idx]
+            txt_ids = txt_ids[idx]
+            t5_attn_mask = t5_attn_mask[idx]
+
         # apply_t5_attn_mask should be same as self.apply_t5_attn_mask
         return [l_pooled, t5_out, txt_ids, t5_attn_mask]
+
+    def _encode_captions(
+        self,
+        tokenize_strategy: TokenizeStrategy,
+        models: List[Any],
+        text_encoding_strategy: "FluxTextEncodingStrategy",
+        captions: List[str],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        tokens_and_masks = tokenize_strategy.tokenize(captions)
+        with torch.no_grad():
+            l_pooled, t5_out, txt_ids, _ = text_encoding_strategy.encode_tokens(
+                tokenize_strategy, models, tokens_and_masks
+            )
+
+        if l_pooled.dtype == torch.bfloat16:
+            l_pooled = l_pooled.float()
+        if t5_out.dtype == torch.bfloat16:
+            t5_out = t5_out.float()
+        if txt_ids.dtype == torch.bfloat16:
+            txt_ids = txt_ids.float()
+
+        return (
+            l_pooled.cpu().numpy(),
+            t5_out.cpu().numpy(),
+            txt_ids.cpu().numpy(),
+            tokens_and_masks[2].cpu().numpy(),
+        )
 
     def cache_batch_outputs(
         self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
@@ -154,44 +191,39 @@ class FluxTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
             self.warn_fp8_weights = True
 
         flux_text_encoding_strategy: FluxTextEncodingStrategy = text_encoding_strategy
-        captions = [info.caption for info in infos]
 
-        tokens_and_masks = tokenize_strategy.tokenize(captions)
-        with torch.no_grad():
-            # attn_mask is applied in text_encoding_strategy.encode_tokens if apply_t5_attn_mask is True
-            l_pooled, t5_out, txt_ids, _ = flux_text_encoding_strategy.encode_tokens(tokenize_strategy, models, tokens_and_masks)
+        for info in infos:
+            caption_lines = info.caption.split("\n") if "\n" in info.caption else [info.caption]
+            caption_lines = [line.strip() for line in caption_lines if line.strip()]
+            num_captions = len(caption_lines)
 
-        if l_pooled.dtype == torch.bfloat16:
-            l_pooled = l_pooled.float()
-        if t5_out.dtype == torch.bfloat16:
-            t5_out = t5_out.float()
-        if txt_ids.dtype == torch.bfloat16:
-            txt_ids = txt_ids.float()
+            l_pooled, t5_out, txt_ids, t5_attn_mask = self._encode_captions(
+                tokenize_strategy, models, flux_text_encoding_strategy, caption_lines
+            )
 
-        l_pooled = l_pooled.cpu().numpy()
-        t5_out = t5_out.cpu().numpy()
-        txt_ids = txt_ids.cpu().numpy()
-        t5_attn_mask = tokens_and_masks[2].cpu().numpy()
-
-        for i, info in enumerate(infos):
-            l_pooled_i = l_pooled[i]
-            t5_out_i = t5_out[i]
-            txt_ids_i = txt_ids[i]
-            t5_attn_mask_i = t5_attn_mask[i]
-            apply_t5_attn_mask_i = self.apply_t5_attn_mask
+            if num_captions == 1:
+                l_pooled_out = l_pooled[0]
+                t5_out_out = t5_out[0]
+                txt_ids_out = txt_ids[0]
+                t5_attn_mask_out = t5_attn_mask[0]
+            else:
+                l_pooled_out = l_pooled
+                t5_out_out = t5_out
+                txt_ids_out = txt_ids
+                t5_attn_mask_out = t5_attn_mask
 
             if self.cache_to_disk:
                 np.savez(
                     info.text_encoder_outputs_npz,
-                    l_pooled=l_pooled_i,
-                    t5_out=t5_out_i,
-                    txt_ids=txt_ids_i,
-                    t5_attn_mask=t5_attn_mask_i,
-                    apply_t5_attn_mask=apply_t5_attn_mask_i,
+                    l_pooled=l_pooled_out,
+                    t5_out=t5_out_out,
+                    txt_ids=txt_ids_out,
+                    t5_attn_mask=t5_attn_mask_out,
+                    apply_t5_attn_mask=self.apply_t5_attn_mask,
                 )
             else:
-                # it's fine that attn mask is not None. it's overwritten before calling the model if necessary
-                info.text_encoder_outputs = (l_pooled_i, t5_out_i, txt_ids_i, t5_attn_mask_i)
+                info.text_encoder_outputs = (l_pooled_out, t5_out_out, txt_ids_out, t5_attn_mask_out)
+                info.num_caption_variants = num_captions
 
 
 class FluxLatentsCachingStrategy(LatentsCachingStrategy):

--- a/library/strategy_hunyuan_image.py
+++ b/library/strategy_hunyuan_image.py
@@ -1,4 +1,5 @@
 import os
+import random
 from typing import Any, List, Optional, Tuple, Union
 import torch
 import numpy as np
@@ -121,22 +122,33 @@ class HunyuanImageTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStr
 
     def load_outputs_npz(self, npz_path: str) -> List[np.ndarray]:
         data = np.load(npz_path)
-        vln_embed = data["vlm_embed"]
+        vlm_embed = data["vlm_embed"]
         vlm_mask = data["vlm_mask"]
         byt5_embed = data["byt5_embed"]
         byt5_mask = data["byt5_mask"]
         ocr_mask = data["ocr_mask"]
-        return [vln_embed, vlm_mask, byt5_embed, byt5_mask, ocr_mask]
 
-    def cache_batch_outputs(
-        self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
-    ):
-        huyuan_image_text_encoding_strategy: HunyuanImageTextEncodingStrategy = text_encoding_strategy
-        captions = [info.caption for info in infos]
+        # multi-caption: vlm_embed is (N, seq_len, hidden_size) with ndim==3
+        if vlm_embed.ndim == 3:
+            idx = random.randint(0, vlm_embed.shape[0] - 1)
+            vlm_embed = vlm_embed[idx]
+            vlm_mask = vlm_mask[idx]
+            byt5_embed = byt5_embed[idx]
+            byt5_mask = byt5_mask[idx]
+            ocr_mask = ocr_mask[idx]
 
+        return [vlm_embed, vlm_mask, byt5_embed, byt5_mask, ocr_mask]
+
+    def _encode_captions(
+        self,
+        tokenize_strategy: TokenizeStrategy,
+        models: List[Any],
+        text_encoding_strategy: "HunyuanImageTextEncodingStrategy",
+        captions: List[str],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         tokens_and_masks = tokenize_strategy.tokenize(captions)
         with torch.no_grad():
-            vlm_embed, vlm_mask, byt5_embed, byt5_mask, ocr_mask = huyuan_image_text_encoding_strategy.encode_tokens(
+            vlm_embed, vlm_mask, byt5_embed, byt5_mask, ocr_mask = text_encoding_strategy.encode_tokens(
                 tokenize_strategy, models, tokens_and_masks
             )
 
@@ -145,30 +157,53 @@ class HunyuanImageTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStr
         if byt5_embed.dtype == torch.bfloat16:
             byt5_embed = byt5_embed.float()
 
-        vlm_embed = vlm_embed.cpu().numpy()
-        vlm_mask = vlm_mask.cpu().numpy()
-        byt5_embed = byt5_embed.cpu().numpy()
-        byt5_mask = byt5_mask.cpu().numpy()
-        ocr_mask = ocr_mask.cpu().numpy()
+        return (
+            vlm_embed.cpu().numpy(),
+            vlm_mask.cpu().numpy(),
+            byt5_embed.cpu().numpy(),
+            byt5_mask.cpu().numpy(),
+            ocr_mask.cpu().numpy(),
+        )
 
-        for i, info in enumerate(infos):
-            vlm_embed_i = vlm_embed[i]
-            vlm_mask_i = vlm_mask[i]
-            byt5_embed_i = byt5_embed[i]
-            byt5_mask_i = byt5_mask[i]
-            ocr_mask_i = ocr_mask[i]
+    def cache_batch_outputs(
+        self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
+    ):
+        hunyuan_image_text_encoding_strategy: HunyuanImageTextEncodingStrategy = text_encoding_strategy
+
+        for info in infos:
+            caption_lines = info.caption.split("\n") if "\n" in info.caption else [info.caption]
+            caption_lines = [line.strip() for line in caption_lines if line.strip()]
+            num_captions = len(caption_lines)
+
+            vlm_embed, vlm_mask, byt5_embed, byt5_mask, ocr_mask = self._encode_captions(
+                tokenize_strategy, models, hunyuan_image_text_encoding_strategy, caption_lines
+            )
+
+            if num_captions == 1:
+                vlm_embed_out = vlm_embed[0]
+                vlm_mask_out = vlm_mask[0]
+                byt5_embed_out = byt5_embed[0]
+                byt5_mask_out = byt5_mask[0]
+                ocr_mask_out = ocr_mask[0]
+            else:
+                vlm_embed_out = vlm_embed
+                vlm_mask_out = vlm_mask
+                byt5_embed_out = byt5_embed
+                byt5_mask_out = byt5_mask
+                ocr_mask_out = ocr_mask
 
             if self.cache_to_disk:
                 np.savez(
                     info.text_encoder_outputs_npz,
-                    vlm_embed=vlm_embed_i,
-                    vlm_mask=vlm_mask_i,
-                    byt5_embed=byt5_embed_i,
-                    byt5_mask=byt5_mask_i,
-                    ocr_mask=ocr_mask_i,
+                    vlm_embed=vlm_embed_out,
+                    vlm_mask=vlm_mask_out,
+                    byt5_embed=byt5_embed_out,
+                    byt5_mask=byt5_mask_out,
+                    ocr_mask=ocr_mask_out,
                 )
             else:
-                info.text_encoder_outputs = (vlm_embed_i, vlm_mask_i, byt5_embed_i, byt5_mask_i, ocr_mask_i)
+                info.text_encoder_outputs = (vlm_embed_out, vlm_mask_out, byt5_embed_out, byt5_mask_out, ocr_mask_out)
+                info.num_caption_variants = num_captions
 
 
 class HunyuanImageLatentsCachingStrategy(LatentsCachingStrategy):

--- a/library/strategy_lumina.py
+++ b/library/strategy_lumina.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import random
 from typing import Any, List, Optional, Tuple, Union
 
 import torch
@@ -198,7 +199,8 @@ class LuminaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy)
 
     def load_outputs_npz(self, npz_path: str) -> List[np.ndarray]:
         """
-        Load outputs from a npz file
+        Load outputs from a npz file. If the arrays have an extra leading
+        dimension (multi-caption), randomly select one variant.
 
         Returns:
             List[np.ndarray]: hidden_state, input_ids, attention_mask
@@ -207,7 +209,38 @@ class LuminaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy)
         hidden_state = data["hidden_state"]
         attention_mask = data["attention_mask"]
         input_ids = data["input_ids"]
+
+        # multi-caption: hidden_state is (N, seq_len, hidden_size) with ndim==3
+        if hidden_state.ndim == 3:
+            idx = random.randint(0, hidden_state.shape[0] - 1)
+            hidden_state = hidden_state[idx]
+            attention_mask = attention_mask[idx]
+            input_ids = input_ids[idx]
+
         return [hidden_state, input_ids, attention_mask]
+
+    def _encode_captions(
+        self,
+        tokenize_strategy: "LuminaTokenizeStrategy",
+        models: List[Any],
+        text_encoding_strategy: "LuminaTextEncodingStrategy",
+        captions: List[str],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if self.is_weighted:
+            tokens, attention_masks, weights_list = tokenize_strategy.tokenize_with_weights(captions)
+            hidden_state, input_ids, attention_masks = text_encoding_strategy.encode_tokens_with_weights(
+                tokenize_strategy, models, (tokens, attention_masks), weights_list
+            )
+        else:
+            tokens = tokenize_strategy.tokenize(captions)
+            hidden_state, input_ids, attention_masks = text_encoding_strategy.encode_tokens(
+                tokenize_strategy, models, tokens
+            )
+
+        if hidden_state.dtype != torch.float32:
+            hidden_state = hidden_state.float()
+
+        return hidden_state.cpu().numpy(), input_ids.cpu().numpy(), attention_masks.cpu().numpy()
 
     @torch.no_grad()
     def cache_batch_outputs(
@@ -217,68 +250,40 @@ class LuminaTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy)
         text_encoding_strategy: TextEncodingStrategy,
         batch: List[train_util.ImageInfo],
     ) -> None:
-        """
-        Args:
-            tokenize_strategy (LuminaTokenizeStrategy): Tokenize strategy
-            models (List[Any]): Text encoders
-            text_encoding_strategy (LuminaTextEncodingStrategy):
-            infos (List): List of ImageInfo
-
-        Returns:
-            None
-        """
         assert isinstance(text_encoding_strategy, LuminaTextEncodingStrategy)
         assert isinstance(tokenize_strategy, LuminaTokenizeStrategy)
 
-        captions = [info.caption for info in batch]
+        for info in batch:
+            caption_lines = info.caption.split("\n") if "\n" in info.caption else [info.caption]
+            caption_lines = [line.strip() for line in caption_lines if line.strip()]
+            num_captions = len(caption_lines)
 
-        if self.is_weighted:
-            tokens, attention_masks, weights_list = (
-                tokenize_strategy.tokenize_with_weights(captions)
-            )
-            hidden_state, input_ids, attention_masks = (
-                text_encoding_strategy.encode_tokens_with_weights(
-                    tokenize_strategy,
-                    models,
-                    (tokens, attention_masks),
-                    weights_list,
-                )
-            )
-        else:
-            tokens = tokenize_strategy.tokenize(captions)
-            hidden_state, input_ids, attention_masks = (
-                text_encoding_strategy.encode_tokens(
-                    tokenize_strategy, models, tokens
-                )
+            hidden_state, input_ids, attention_mask = self._encode_captions(
+                tokenize_strategy, models, text_encoding_strategy, caption_lines
             )
 
-        if hidden_state.dtype != torch.float32:
-            hidden_state = hidden_state.float()
-
-        hidden_state = hidden_state.cpu().numpy()
-        attention_mask = attention_masks.cpu().numpy() # (B, S)
-        input_ids = input_ids.cpu().numpy() # (B, S) 
-
-
-        for i, info in enumerate(batch):
-            hidden_state_i = hidden_state[i]
-            attention_mask_i = attention_mask[i]
-            input_ids_i = input_ids[i]
+            if num_captions == 1:
+                hidden_state_out = hidden_state[0]
+                input_ids_out = input_ids[0]
+                attention_mask_out = attention_mask[0]
+            else:
+                hidden_state_out = hidden_state
+                input_ids_out = input_ids
+                attention_mask_out = attention_mask
 
             if self.cache_to_disk:
-                assert info.text_encoder_outputs_npz is not None, f"Text encoder cache outputs to disk not found for image {info.image_key}"
+                assert info.text_encoder_outputs_npz is not None, (
+                    f"Text encoder cache outputs to disk not found for image {info.image_key}"
+                )
                 np.savez(
                     info.text_encoder_outputs_npz,
-                    hidden_state=hidden_state_i,
-                    attention_mask=attention_mask_i,
-                    input_ids=input_ids_i,
+                    hidden_state=hidden_state_out,
+                    attention_mask=attention_mask_out,
+                    input_ids=input_ids_out,
                 )
             else:
-                info.text_encoder_outputs = [
-                    hidden_state_i,
-                    input_ids_i,
-                    attention_mask_i,
-                ]
+                info.text_encoder_outputs = [hidden_state_out, input_ids_out, attention_mask_out]
+                info.num_caption_variants = num_captions
 
 
 class LuminaLatentsCachingStrategy(LatentsCachingStrategy):

--- a/library/strategy_sd3.py
+++ b/library/strategy_sd3.py
@@ -313,24 +313,33 @@ class Sd3TextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         lg_out = data["lg_out"]
         lg_pooled = data["lg_pooled"]
         t5_out = data["t5_out"]
-
         l_attn_mask = data["clip_l_attn_mask"]
         g_attn_mask = data["clip_g_attn_mask"]
         t5_attn_mask = data["t5_attn_mask"]
 
+        # multi-caption: lg_out is (N, seq_len, 2048) with ndim==3
+        if lg_out.ndim == 3:
+            idx = random.randint(0, lg_out.shape[0] - 1)
+            lg_out = lg_out[idx]
+            lg_pooled = lg_pooled[idx]
+            t5_out = t5_out[idx]
+            l_attn_mask = l_attn_mask[idx]
+            g_attn_mask = g_attn_mask[idx]
+            t5_attn_mask = t5_attn_mask[idx]
+
         # apply_t5_attn_mask and apply_lg_attn_mask are same as self.apply_t5_attn_mask and self.apply_lg_attn_mask
         return [lg_out, t5_out, lg_pooled, l_attn_mask, g_attn_mask, t5_attn_mask]
 
-    def cache_batch_outputs(
-        self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
-    ):
-        sd3_text_encoding_strategy: Sd3TextEncodingStrategy = text_encoding_strategy
-        captions = [info.caption for info in infos]
-
+    def _encode_captions(
+        self,
+        tokenize_strategy: TokenizeStrategy,
+        models: List[Any],
+        text_encoding_strategy: "Sd3TextEncodingStrategy",
+        captions: List[str],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         tokens_and_masks = tokenize_strategy.tokenize(captions)
         with torch.no_grad():
-            # always disable dropout during caching
-            lg_out, t5_out, lg_pooled, l_attn_mask, g_attn_mask, t5_attn_mask = sd3_text_encoding_strategy.encode_tokens(
+            lg_out, t5_out, lg_pooled, l_attn_mask, g_attn_mask, t5_attn_mask = text_encoding_strategy.encode_tokens(
                 tokenize_strategy,
                 models,
                 tokens_and_masks,
@@ -346,39 +355,51 @@ class Sd3TextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         if t5_out.dtype == torch.bfloat16:
             t5_out = t5_out.float()
 
-        lg_out = lg_out.cpu().numpy()
-        lg_pooled = lg_pooled.cpu().numpy()
-        t5_out = t5_out.cpu().numpy()
+        return (
+            lg_out.cpu().numpy(),
+            t5_out.cpu().numpy(),
+            lg_pooled.cpu().numpy(),
+            tokens_and_masks[3].cpu().numpy(),
+            tokens_and_masks[4].cpu().numpy(),
+            tokens_and_masks[5].cpu().numpy(),
+        )
 
-        l_attn_mask = tokens_and_masks[3].cpu().numpy()
-        g_attn_mask = tokens_and_masks[4].cpu().numpy()
-        t5_attn_mask = tokens_and_masks[5].cpu().numpy()
+    def cache_batch_outputs(
+        self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
+    ):
+        sd3_text_encoding_strategy: Sd3TextEncodingStrategy = text_encoding_strategy
 
-        for i, info in enumerate(infos):
-            lg_out_i = lg_out[i]
-            t5_out_i = t5_out[i]
-            lg_pooled_i = lg_pooled[i]
-            l_attn_mask_i = l_attn_mask[i]
-            g_attn_mask_i = g_attn_mask[i]
-            t5_attn_mask_i = t5_attn_mask[i]
-            apply_lg_attn_mask = self.apply_lg_attn_mask
-            apply_t5_attn_mask = self.apply_t5_attn_mask
+        for info in infos:
+            caption_lines = info.caption.split("\n") if "\n" in info.caption else [info.caption]
+            caption_lines = [line.strip() for line in caption_lines if line.strip()]
+            num_captions = len(caption_lines)
+
+            lg_out, t5_out, lg_pooled, l_attn_mask, g_attn_mask, t5_attn_mask = self._encode_captions(
+                tokenize_strategy, models, sd3_text_encoding_strategy, caption_lines
+            )
+
+            if num_captions == 1:
+                lg_out_o, t5_out_o, lg_pooled_o = lg_out[0], t5_out[0], lg_pooled[0]
+                l_attn_mask_o, g_attn_mask_o, t5_attn_mask_o = l_attn_mask[0], g_attn_mask[0], t5_attn_mask[0]
+            else:
+                lg_out_o, t5_out_o, lg_pooled_o = lg_out, t5_out, lg_pooled
+                l_attn_mask_o, g_attn_mask_o, t5_attn_mask_o = l_attn_mask, g_attn_mask, t5_attn_mask
 
             if self.cache_to_disk:
                 np.savez(
                     info.text_encoder_outputs_npz,
-                    lg_out=lg_out_i,
-                    lg_pooled=lg_pooled_i,
-                    t5_out=t5_out_i,
-                    clip_l_attn_mask=l_attn_mask_i,
-                    clip_g_attn_mask=g_attn_mask_i,
-                    t5_attn_mask=t5_attn_mask_i,
-                    apply_lg_attn_mask=apply_lg_attn_mask,
-                    apply_t5_attn_mask=apply_t5_attn_mask,
+                    lg_out=lg_out_o,
+                    lg_pooled=lg_pooled_o,
+                    t5_out=t5_out_o,
+                    clip_l_attn_mask=l_attn_mask_o,
+                    clip_g_attn_mask=g_attn_mask_o,
+                    t5_attn_mask=t5_attn_mask_o,
+                    apply_lg_attn_mask=self.apply_lg_attn_mask,
+                    apply_t5_attn_mask=self.apply_t5_attn_mask,
                 )
             else:
-                # it's fine that attn mask is not None. it's overwritten before calling the model if necessary
-                info.text_encoder_outputs = (lg_out_i, t5_out_i, lg_pooled_i, l_attn_mask_i, g_attn_mask_i, t5_attn_mask_i)
+                info.text_encoder_outputs = (lg_out_o, t5_out_o, lg_pooled_o, l_attn_mask_o, g_attn_mask_o, t5_attn_mask_o)
+                info.num_caption_variants = num_captions
 
 
 class Sd3LatentsCachingStrategy(LatentsCachingStrategy):

--- a/library/strategy_sdxl.py
+++ b/library/strategy_sdxl.py
@@ -1,4 +1,5 @@
 import os
+import random
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
@@ -258,24 +259,33 @@ class SdxlTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         hidden_state1 = data["hidden_state1"]
         hidden_state2 = data["hidden_state2"]
         pool2 = data["pool2"]
+
+        # multi-caption: hidden_state1 is (N, seq_len, 768) with ndim==3
+        if hidden_state1.ndim == 3:
+            idx = random.randint(0, hidden_state1.shape[0] - 1)
+            hidden_state1 = hidden_state1[idx]
+            hidden_state2 = hidden_state2[idx]
+            pool2 = pool2[idx]
+
         return [hidden_state1, hidden_state2, pool2]
 
-    def cache_batch_outputs(
-        self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
-    ):
-        sdxl_text_encoding_strategy = text_encoding_strategy  # type: SdxlTextEncodingStrategy
-        captions = [info.caption for info in infos]
-
+    def _encode_captions(
+        self,
+        tokenize_strategy: TokenizeStrategy,
+        models: List[Any],
+        text_encoding_strategy: "SdxlTextEncodingStrategy",
+        captions: List[str],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         if self.is_weighted:
             tokens_list, weights_list = tokenize_strategy.tokenize_with_weights(captions)
             with torch.no_grad():
-                hidden_state1, hidden_state2, pool2 = sdxl_text_encoding_strategy.encode_tokens_with_weights(
+                hidden_state1, hidden_state2, pool2 = text_encoding_strategy.encode_tokens_with_weights(
                     tokenize_strategy, models, tokens_list, weights_list
                 )
         else:
             tokens1, tokens2 = tokenize_strategy.tokenize(captions)
             with torch.no_grad():
-                hidden_state1, hidden_state2, pool2 = sdxl_text_encoding_strategy.encode_tokens(
+                hidden_state1, hidden_state2, pool2 = text_encoding_strategy.encode_tokens(
                     tokenize_strategy, models, [tokens1, tokens2]
                 )
 
@@ -286,21 +296,38 @@ class SdxlTextEncoderOutputsCachingStrategy(TextEncoderOutputsCachingStrategy):
         if pool2.dtype == torch.bfloat16:
             pool2 = pool2.float()
 
-        hidden_state1 = hidden_state1.cpu().numpy()
-        hidden_state2 = hidden_state2.cpu().numpy()
-        pool2 = pool2.cpu().numpy()
+        return hidden_state1.cpu().numpy(), hidden_state2.cpu().numpy(), pool2.cpu().numpy()
 
-        for i, info in enumerate(infos):
-            hidden_state1_i = hidden_state1[i]
-            hidden_state2_i = hidden_state2[i]
-            pool2_i = pool2[i]
+    def cache_batch_outputs(
+        self, tokenize_strategy: TokenizeStrategy, models: List[Any], text_encoding_strategy: TextEncodingStrategy, infos: List
+    ):
+        sdxl_text_encoding_strategy = text_encoding_strategy  # type: SdxlTextEncodingStrategy
+
+        for info in infos:
+            caption_lines = info.caption.split("\n") if "\n" in info.caption else [info.caption]
+            caption_lines = [line.strip() for line in caption_lines if line.strip()]
+            num_captions = len(caption_lines)
+
+            hidden_state1, hidden_state2, pool2 = self._encode_captions(
+                tokenize_strategy, models, sdxl_text_encoding_strategy, caption_lines
+            )
+
+            if num_captions == 1:
+                hidden_state1_out = hidden_state1[0]
+                hidden_state2_out = hidden_state2[0]
+                pool2_out = pool2[0]
+            else:
+                hidden_state1_out = hidden_state1
+                hidden_state2_out = hidden_state2
+                pool2_out = pool2
 
             if self.cache_to_disk:
                 np.savez(
                     info.text_encoder_outputs_npz,
-                    hidden_state1=hidden_state1_i,
-                    hidden_state2=hidden_state2_i,
-                    pool2=pool2_i,
+                    hidden_state1=hidden_state1_out,
+                    hidden_state2=hidden_state2_out,
+                    pool2=pool2_out,
                 )
             else:
-                info.text_encoder_outputs = [hidden_state1_i, hidden_state2_i, pool2_i]
+                info.text_encoder_outputs = [hidden_state1_out, hidden_state2_out, pool2_out]
+                info.num_caption_variants = num_captions

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -209,6 +209,7 @@ class ImageInfo:
         self.text_encoder_outputs2: Optional[torch.Tensor] = None
         self.text_encoder_pool2: Optional[torch.Tensor] = None
 
+        self.num_caption_variants: int = 1  # number of caption variants for multi-caption caching
         self.alpha_mask: Optional[torch.Tensor] = None  # alpha mask can be flipped in runtime
         self.resize_interpolation: Optional[str] = None
 
@@ -1723,6 +1724,12 @@ class BaseDataset(torch.utils.data.Dataset):
             if image_info.text_encoder_outputs is not None:
                 # cached
                 text_encoder_outputs = image_info.text_encoder_outputs
+                if image_info.num_caption_variants > 1:
+                    idx = random.randint(0, image_info.num_caption_variants - 1)
+                    text_encoder_outputs = [
+                        arr[idx] if hasattr(arr, "ndim") and arr.ndim > 0 else arr
+                        for arr in text_encoder_outputs
+                    ]
             elif image_info.text_encoder_outputs_npz is not None:
                 # on disk
                 text_encoder_outputs = self.text_encoder_output_caching_strategy.load_outputs_npz(

--- a/tests/test_flux_anima_multi_caption_cache.py
+++ b/tests/test_flux_anima_multi_caption_cache.py
@@ -1,0 +1,314 @@
+"""
+Tests for multi-caption text encoder output caching in Flux and Anima strategies.
+Covers both disk cache (NPZ) and memory cache paths, including backward compatibility.
+"""
+
+import numpy as np
+import pytest
+
+from library.strategy_flux import FluxTextEncoderOutputsCachingStrategy
+from library.strategy_anima import AnimaTextEncoderOutputsCachingStrategy
+
+
+class ImageInfo:
+    """Minimal stub for testing multi-caption caching without importing train_util."""
+    def __init__(self, image_key, num_repeats, caption, is_reg, absolute_path):
+        self.image_key = image_key
+        self.caption = caption
+        self.num_caption_variants = 1
+        self.text_encoder_outputs = None
+
+
+# --- Flux Constants ---
+FLUX_SEQ_LEN = 512
+FLUX_T5_HIDDEN = 4096
+FLUX_CLIP_POOLED = 768
+
+
+def _make_flux_single_npz(npz_path: str):
+    """Create a single-caption Flux NPZ file (old format)."""
+    np.savez(
+        npz_path,
+        l_pooled=np.random.randn(FLUX_CLIP_POOLED).astype(np.float32),
+        t5_out=np.random.randn(FLUX_SEQ_LEN, FLUX_T5_HIDDEN).astype(np.float32),
+        txt_ids=np.zeros((FLUX_SEQ_LEN, 3), dtype=np.float32),
+        t5_attn_mask=np.ones(FLUX_SEQ_LEN, dtype=np.float32),
+        apply_t5_attn_mask=False,
+    )
+
+
+def _make_flux_multi_npz(npz_path: str, num_captions: int = 3):
+    """Create a multi-caption Flux NPZ file (new format)."""
+    np.savez(
+        npz_path,
+        l_pooled=np.random.randn(num_captions, FLUX_CLIP_POOLED).astype(np.float32),
+        t5_out=np.random.randn(num_captions, FLUX_SEQ_LEN, FLUX_T5_HIDDEN).astype(np.float32),
+        txt_ids=np.zeros((num_captions, FLUX_SEQ_LEN, 3), dtype=np.float32),
+        t5_attn_mask=np.ones((num_captions, FLUX_SEQ_LEN), dtype=np.float32),
+        apply_t5_attn_mask=False,
+    )
+
+
+# --- Anima Constants ---
+ANIMA_SEQ_LEN = 512
+ANIMA_HIDDEN = 2048
+
+
+def _make_anima_single_npz(npz_path: str):
+    """Create a single-caption Anima NPZ file (old format)."""
+    np.savez(
+        npz_path,
+        prompt_embeds=np.random.randn(ANIMA_SEQ_LEN, ANIMA_HIDDEN).astype(np.float32),
+        attn_mask=np.ones(ANIMA_SEQ_LEN, dtype=np.float32),
+        t5_input_ids=np.ones(ANIMA_SEQ_LEN, dtype=np.int32),
+        t5_attn_mask=np.ones(ANIMA_SEQ_LEN, dtype=np.int32),
+        caption_dropout_rate=np.float32(0.0),
+    )
+
+
+def _make_anima_multi_npz(npz_path: str, num_captions: int = 3):
+    """Create a multi-caption Anima NPZ file (new format)."""
+    np.savez(
+        npz_path,
+        prompt_embeds=np.random.randn(num_captions, ANIMA_SEQ_LEN, ANIMA_HIDDEN).astype(np.float32),
+        attn_mask=np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.float32),
+        t5_input_ids=np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.int32),
+        t5_attn_mask=np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.int32),
+        caption_dropout_rate=np.float32(0.0),
+    )
+
+
+# ==================== Flux Tests ====================
+
+
+class TestFluxLoadOutputsNpz:
+
+    def setup_method(self):
+        self.strategy = FluxTextEncoderOutputsCachingStrategy(
+            cache_to_disk=True, batch_size=1, skip_disk_cache_validity_check=False, apply_t5_attn_mask=False,
+        )
+
+    def test_load_single_caption(self, tmp_path):
+        npz_path = str(tmp_path / "test_flux_te.npz")
+        _make_flux_single_npz(npz_path)
+
+        result = self.strategy.load_outputs_npz(npz_path)
+        assert len(result) == 4
+        l_pooled, t5_out, txt_ids, t5_attn_mask = result
+        assert l_pooled.shape == (FLUX_CLIP_POOLED,)
+        assert t5_out.shape == (FLUX_SEQ_LEN, FLUX_T5_HIDDEN)
+        assert txt_ids.shape == (FLUX_SEQ_LEN, 3)
+        assert t5_attn_mask.shape == (FLUX_SEQ_LEN,)
+
+    def test_load_multi_caption_returns_single(self, tmp_path):
+        npz_path = str(tmp_path / "test_flux_te.npz")
+        _make_flux_multi_npz(npz_path, num_captions=5)
+
+        result = self.strategy.load_outputs_npz(npz_path)
+        assert len(result) == 4
+        l_pooled, t5_out, txt_ids, t5_attn_mask = result
+        assert l_pooled.shape == (FLUX_CLIP_POOLED,)
+        assert t5_out.shape == (FLUX_SEQ_LEN, FLUX_T5_HIDDEN)
+        assert txt_ids.shape == (FLUX_SEQ_LEN, 3)
+        assert t5_attn_mask.shape == (FLUX_SEQ_LEN,)
+
+    def test_load_multi_caption_randomness(self, tmp_path):
+        npz_path = str(tmp_path / "test_flux_te.npz")
+        num_captions = 10
+        l_pooled_data = np.arange(num_captions, dtype=np.float32).reshape(num_captions, 1) * np.ones(
+            (1, FLUX_CLIP_POOLED), dtype=np.float32
+        )
+        np.savez(
+            npz_path,
+            l_pooled=l_pooled_data,
+            t5_out=np.random.randn(num_captions, FLUX_SEQ_LEN, FLUX_T5_HIDDEN).astype(np.float32),
+            txt_ids=np.zeros((num_captions, FLUX_SEQ_LEN, 3), dtype=np.float32),
+            t5_attn_mask=np.ones((num_captions, FLUX_SEQ_LEN), dtype=np.float32),
+            apply_t5_attn_mask=False,
+        )
+
+        selected_values = set()
+        for _ in range(50):
+            result = self.strategy.load_outputs_npz(npz_path)
+            selected_values.add(float(result[0][0]))
+
+        assert len(selected_values) > 1, "Random selection should produce different results"
+
+
+class TestFluxCacheValidity:
+
+    def setup_method(self):
+        self.strategy = FluxTextEncoderOutputsCachingStrategy(
+            cache_to_disk=True, batch_size=1, skip_disk_cache_validity_check=False, apply_t5_attn_mask=False,
+        )
+
+    def test_single_caption_valid(self, tmp_path):
+        npz_path = str(tmp_path / "test_flux_te.npz")
+        _make_flux_single_npz(npz_path)
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is True
+
+    def test_multi_caption_valid(self, tmp_path):
+        npz_path = str(tmp_path / "test_flux_te.npz")
+        _make_flux_multi_npz(npz_path, num_captions=3)
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is True
+
+    def test_missing_file(self, tmp_path):
+        npz_path = str(tmp_path / "nonexistent.npz")
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is False
+
+
+# ==================== Anima Tests ====================
+
+
+class TestAnimaLoadOutputsNpz:
+
+    def setup_method(self):
+        self.strategy = AnimaTextEncoderOutputsCachingStrategy(
+            cache_to_disk=True, batch_size=1, skip_disk_cache_validity_check=False,
+        )
+
+    def test_load_single_caption(self, tmp_path):
+        npz_path = str(tmp_path / "test_anima_te.npz")
+        _make_anima_single_npz(npz_path)
+
+        result = self.strategy.load_outputs_npz(npz_path)
+        assert len(result) == 5
+        prompt_embeds, attn_mask, t5_input_ids, t5_attn_mask, caption_dropout_rate = result
+        assert prompt_embeds.shape == (ANIMA_SEQ_LEN, ANIMA_HIDDEN)
+        assert attn_mask.shape == (ANIMA_SEQ_LEN,)
+        assert t5_input_ids.shape == (ANIMA_SEQ_LEN,)
+        assert t5_attn_mask.shape == (ANIMA_SEQ_LEN,)
+        assert caption_dropout_rate.shape == ()  # scalar
+
+    def test_load_multi_caption_returns_single(self, tmp_path):
+        npz_path = str(tmp_path / "test_anima_te.npz")
+        _make_anima_multi_npz(npz_path, num_captions=5)
+
+        result = self.strategy.load_outputs_npz(npz_path)
+        assert len(result) == 5
+        prompt_embeds, attn_mask, t5_input_ids, t5_attn_mask, caption_dropout_rate = result
+        assert prompt_embeds.shape == (ANIMA_SEQ_LEN, ANIMA_HIDDEN)
+        assert attn_mask.shape == (ANIMA_SEQ_LEN,)
+        assert t5_input_ids.shape == (ANIMA_SEQ_LEN,)
+        assert t5_attn_mask.shape == (ANIMA_SEQ_LEN,)
+        # caption_dropout_rate should remain scalar (NOT indexed)
+        assert caption_dropout_rate.shape == ()
+
+    def test_load_multi_caption_randomness(self, tmp_path):
+        npz_path = str(tmp_path / "test_anima_te.npz")
+        num_captions = 10
+        prompt_data = np.arange(num_captions, dtype=np.float32).reshape(num_captions, 1, 1) * np.ones(
+            (1, ANIMA_SEQ_LEN, ANIMA_HIDDEN), dtype=np.float32
+        )
+        np.savez(
+            npz_path,
+            prompt_embeds=prompt_data,
+            attn_mask=np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.float32),
+            t5_input_ids=np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.int32),
+            t5_attn_mask=np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.int32),
+            caption_dropout_rate=np.float32(0.1),
+        )
+
+        selected_values = set()
+        for _ in range(50):
+            result = self.strategy.load_outputs_npz(npz_path)
+            selected_values.add(float(result[0][0, 0]))
+
+        assert len(selected_values) > 1, "Random selection should produce different results"
+
+
+class TestAnimaCacheValidity:
+
+    def setup_method(self):
+        self.strategy = AnimaTextEncoderOutputsCachingStrategy(
+            cache_to_disk=True, batch_size=1, skip_disk_cache_validity_check=False,
+        )
+
+    def test_single_caption_valid(self, tmp_path):
+        npz_path = str(tmp_path / "test_anima_te.npz")
+        _make_anima_single_npz(npz_path)
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is True
+
+    def test_multi_caption_valid(self, tmp_path):
+        npz_path = str(tmp_path / "test_anima_te.npz")
+        _make_anima_multi_npz(npz_path, num_captions=3)
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is True
+
+
+# ==================== Memory Cache Tests ====================
+
+
+class TestMemoryCacheMultiCaptionFlux:
+
+    def test_single_caption_no_selection(self):
+        info = ImageInfo("key", 1, "a cat", False, "/path/to/img.png")
+        info.num_caption_variants = 1
+        info.text_encoder_outputs = (
+            np.random.randn(FLUX_CLIP_POOLED).astype(np.float32),
+            np.random.randn(FLUX_SEQ_LEN, FLUX_T5_HIDDEN).astype(np.float32),
+            np.zeros((FLUX_SEQ_LEN, 3), dtype=np.float32),
+            np.ones(FLUX_SEQ_LEN, dtype=np.float32),
+        )
+
+        text_encoder_outputs = info.text_encoder_outputs
+        if info.num_caption_variants > 1:
+            import random
+            idx = random.randint(0, info.num_caption_variants - 1)
+            text_encoder_outputs = [arr[idx] for arr in text_encoder_outputs]
+
+        assert text_encoder_outputs[0].shape == (FLUX_CLIP_POOLED,)
+        assert text_encoder_outputs[1].shape == (FLUX_SEQ_LEN, FLUX_T5_HIDDEN)
+
+    def test_multi_caption_selection(self):
+        import random
+        num_captions = 4
+        info = ImageInfo("key", 1, "l1\nl2\nl3\nl4", False, "/path/to/img.png")
+        info.num_caption_variants = num_captions
+        info.text_encoder_outputs = (
+            np.random.randn(num_captions, FLUX_CLIP_POOLED).astype(np.float32),
+            np.random.randn(num_captions, FLUX_SEQ_LEN, FLUX_T5_HIDDEN).astype(np.float32),
+            np.zeros((num_captions, FLUX_SEQ_LEN, 3), dtype=np.float32),
+            np.ones((num_captions, FLUX_SEQ_LEN), dtype=np.float32),
+        )
+
+        text_encoder_outputs = info.text_encoder_outputs
+        if info.num_caption_variants > 1:
+            idx = random.randint(0, info.num_caption_variants - 1)
+            text_encoder_outputs = [arr[idx] for arr in text_encoder_outputs]
+
+        assert text_encoder_outputs[0].shape == (FLUX_CLIP_POOLED,)
+        assert text_encoder_outputs[1].shape == (FLUX_SEQ_LEN, FLUX_T5_HIDDEN)
+        assert text_encoder_outputs[2].shape == (FLUX_SEQ_LEN, 3)
+        assert text_encoder_outputs[3].shape == (FLUX_SEQ_LEN,)
+
+
+class TestMemoryCacheMultiCaptionAnima:
+
+    def test_multi_caption_selection_preserves_scalar(self):
+        """caption_dropout_rate is the 5th element and is a scalar - should NOT be indexed."""
+        import random
+        import torch
+        num_captions = 3
+        info = ImageInfo("key", 1, "l1\nl2\nl3", False, "/path/to/img.png")
+        info.num_caption_variants = num_captions
+        info.text_encoder_outputs = (
+            np.random.randn(num_captions, ANIMA_SEQ_LEN, ANIMA_HIDDEN).astype(np.float32),
+            np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.float32),
+            np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.int32),
+            np.ones((num_captions, ANIMA_SEQ_LEN), dtype=np.int32),
+            torch.tensor(0.1, dtype=torch.float32),  # scalar caption_dropout_rate
+        )
+
+        # Simulate __getitem__ logic with ndim check (same as train_util.py)
+        text_encoder_outputs = info.text_encoder_outputs
+        if info.num_caption_variants > 1:
+            idx = random.randint(0, info.num_caption_variants - 1)
+            text_encoder_outputs = [arr[idx] if hasattr(arr, 'ndim') and arr.ndim > 0 else arr for arr in text_encoder_outputs]
+
+        assert text_encoder_outputs[0].shape == (ANIMA_SEQ_LEN, ANIMA_HIDDEN)
+        assert text_encoder_outputs[1].shape == (ANIMA_SEQ_LEN,)
+        assert text_encoder_outputs[2].shape == (ANIMA_SEQ_LEN,)
+        assert text_encoder_outputs[3].shape == (ANIMA_SEQ_LEN,)
+        # caption_dropout_rate should remain scalar (0-dim), not indexed
+        assert text_encoder_outputs[4].ndim == 0
+        assert float(text_encoder_outputs[4]) == pytest.approx(0.1)

--- a/tests/test_lumina_multi_caption_cache.py
+++ b/tests/test_lumina_multi_caption_cache.py
@@ -1,0 +1,184 @@
+"""
+Tests for multi-caption text encoder output caching in Lumina strategy.
+Covers both disk cache (NPZ) and memory cache paths, including backward compatibility.
+"""
+
+import numpy as np
+import pytest
+
+from library.strategy_lumina import LuminaTextEncoderOutputsCachingStrategy
+
+
+class ImageInfo:
+    """Minimal stub for testing multi-caption caching without importing train_util."""
+    def __init__(self, image_key, num_repeats, caption, is_reg, absolute_path):
+        self.image_key = image_key
+        self.caption = caption
+        self.num_caption_variants = 1
+        self.text_encoder_outputs = None
+
+
+SEQ_LEN = 256
+HIDDEN_SIZE = 2304
+
+
+def _make_single_caption_npz(npz_path: str):
+    """Create a single-caption NPZ file (old format, no num_captions key)."""
+    np.savez(
+        npz_path,
+        hidden_state=np.random.randn(SEQ_LEN, HIDDEN_SIZE).astype(np.float32),
+        attention_mask=np.ones(SEQ_LEN, dtype=np.float32),
+        input_ids=np.ones(SEQ_LEN, dtype=np.int64),
+    )
+
+
+def _make_multi_caption_npz(npz_path: str, num_captions: int = 3):
+    """Create a multi-caption NPZ file (new format, with num_captions key)."""
+    np.savez(
+        npz_path,
+        hidden_state=np.random.randn(num_captions, SEQ_LEN, HIDDEN_SIZE).astype(np.float32),
+        attention_mask=np.ones((num_captions, SEQ_LEN), dtype=np.float32),
+        input_ids=np.ones((num_captions, SEQ_LEN), dtype=np.int64),
+    )
+
+
+class TestLoadOutputsNpz:
+    """Tests for load_outputs_npz with single and multi-caption NPZ files."""
+
+    def setup_method(self):
+        self.strategy = LuminaTextEncoderOutputsCachingStrategy(
+            cache_to_disk=True, batch_size=1, skip_disk_cache_validity_check=False
+        )
+
+    def test_load_single_caption_npz(self, tmp_path):
+        """Old-format NPZ should return single arrays unchanged."""
+        npz_path = str(tmp_path / "test_lumina_te.npz")
+        _make_single_caption_npz(npz_path)
+
+        result = self.strategy.load_outputs_npz(npz_path)
+        assert len(result) == 3
+        hidden_state, input_ids, attention_mask = result
+        assert hidden_state.shape == (SEQ_LEN, HIDDEN_SIZE)
+        assert input_ids.shape == (SEQ_LEN,)
+        assert attention_mask.shape == (SEQ_LEN,)
+
+    def test_load_multi_caption_npz_returns_single(self, tmp_path):
+        """Multi-caption NPZ should return a single randomly selected caption."""
+        npz_path = str(tmp_path / "test_lumina_te.npz")
+        num_captions = 5
+        _make_multi_caption_npz(npz_path, num_captions)
+
+        result = self.strategy.load_outputs_npz(npz_path)
+        assert len(result) == 3
+        hidden_state, input_ids, attention_mask = result
+        assert hidden_state.shape == (SEQ_LEN, HIDDEN_SIZE)
+        assert input_ids.shape == (SEQ_LEN,)
+        assert attention_mask.shape == (SEQ_LEN,)
+
+    def test_load_multi_caption_npz_randomness(self, tmp_path):
+        """Multiple loads from multi-caption NPZ should not always return the same index."""
+        npz_path = str(tmp_path / "test_lumina_te.npz")
+        num_captions = 10
+        hidden_states = np.arange(num_captions).reshape(num_captions, 1, 1) * np.ones(
+            (1, SEQ_LEN, HIDDEN_SIZE), dtype=np.float32
+        )
+        np.savez(
+            npz_path,
+            hidden_state=hidden_states.astype(np.float32),
+            attention_mask=np.ones((num_captions, SEQ_LEN), dtype=np.float32),
+            input_ids=np.ones((num_captions, SEQ_LEN), dtype=np.int64),
+        )
+
+        selected_values = set()
+        for _ in range(50):
+            result = self.strategy.load_outputs_npz(npz_path)
+            selected_values.add(float(result[0][0, 0]))
+
+        assert len(selected_values) > 1, "Random selection should produce different results"
+
+
+class TestIsDiskCachedOutputsExpected:
+    """Tests for cache validity check with both old and new NPZ formats."""
+
+    def setup_method(self):
+        self.strategy = LuminaTextEncoderOutputsCachingStrategy(
+            cache_to_disk=True, batch_size=1, skip_disk_cache_validity_check=False
+        )
+
+    def test_single_caption_npz_valid(self, tmp_path):
+        npz_path = str(tmp_path / "test_lumina_te.npz")
+        _make_single_caption_npz(npz_path)
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is True
+
+    def test_multi_caption_npz_valid(self, tmp_path):
+        npz_path = str(tmp_path / "test_lumina_te.npz")
+        _make_multi_caption_npz(npz_path, num_captions=3)
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is True
+
+    def test_missing_file(self, tmp_path):
+        npz_path = str(tmp_path / "nonexistent_lumina_te.npz")
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is False
+
+    def test_incomplete_npz(self, tmp_path):
+        npz_path = str(tmp_path / "test_lumina_te.npz")
+        np.savez(npz_path, hidden_state=np.zeros(10))  # missing attention_mask and input_ids
+        assert self.strategy.is_disk_cached_outputs_expected(npz_path) is False
+
+
+class TestImageInfoMultiCaption:
+    """Tests for ImageInfo.num_caption_variants field."""
+
+    def test_default_num_caption_variants(self):
+        info = ImageInfo("key", 1, "a cat", False, "/path/to/img.png")
+        assert info.num_caption_variants == 1
+
+    def test_set_num_caption_variants(self):
+        info = ImageInfo("key", 1, "a cat", False, "/path/to/img.png")
+        info.num_caption_variants = 5
+        assert info.num_caption_variants == 5
+
+
+class TestMemoryCacheMultiCaption:
+    """Tests for memory cache random selection in __getitem__ pattern."""
+
+    def test_single_caption_memory_no_selection(self):
+        """Single caption (num_caption_variants=1) should return data as-is."""
+        info = ImageInfo("key", 1, "a cat", False, "/path/to/img.png")
+        info.num_caption_variants = 1
+        info.text_encoder_outputs = [
+            np.random.randn(SEQ_LEN, HIDDEN_SIZE).astype(np.float32),
+            np.ones(SEQ_LEN, dtype=np.int64),
+            np.ones(SEQ_LEN, dtype=np.float32),
+        ]
+
+        text_encoder_outputs = info.text_encoder_outputs
+        if info.num_caption_variants > 1:
+            import random
+            idx = random.randint(0, info.num_caption_variants - 1)
+            text_encoder_outputs = [arr[idx] for arr in text_encoder_outputs]
+
+        assert text_encoder_outputs[0].shape == (SEQ_LEN, HIDDEN_SIZE)
+        assert text_encoder_outputs[1].shape == (SEQ_LEN,)
+        assert text_encoder_outputs[2].shape == (SEQ_LEN,)
+
+    def test_multi_caption_memory_selection(self):
+        """Multi-caption (num_caption_variants>1) should select one variant."""
+        import random
+
+        num_captions = 4
+        info = ImageInfo("key", 1, "line1\nline2\nline3\nline4", False, "/path/to/img.png")
+        info.num_caption_variants = num_captions
+        info.text_encoder_outputs = [
+            np.random.randn(num_captions, SEQ_LEN, HIDDEN_SIZE).astype(np.float32),
+            np.ones((num_captions, SEQ_LEN), dtype=np.int64),
+            np.ones((num_captions, SEQ_LEN), dtype=np.float32),
+        ]
+
+        text_encoder_outputs = info.text_encoder_outputs
+        if info.num_caption_variants > 1:
+            idx = random.randint(0, info.num_caption_variants - 1)
+            text_encoder_outputs = [arr[idx] for arr in text_encoder_outputs]
+
+        assert text_encoder_outputs[0].shape == (SEQ_LEN, HIDDEN_SIZE)
+        assert text_encoder_outputs[1].shape == (SEQ_LEN,)
+        assert text_encoder_outputs[2].shape == (SEQ_LEN,)

--- a/tests/test_sdxl_sd3_hunyuan_multi_caption_cache.py
+++ b/tests/test_sdxl_sd3_hunyuan_multi_caption_cache.py
@@ -1,0 +1,188 @@
+"""
+Tests for multi-caption text encoder output caching in SDXL, SD3, and HunyuanImage strategies.
+"""
+
+import numpy as np
+import pytest
+
+from library.strategy_sdxl import SdxlTextEncoderOutputsCachingStrategy
+from library.strategy_sd3 import Sd3TextEncoderOutputsCachingStrategy
+from library.strategy_hunyuan_image import HunyuanImageTextEncoderOutputsCachingStrategy
+
+
+# ==================== SDXL ====================
+
+SDXL_SEQ = 77
+SDXL_H1 = 768
+SDXL_H2 = 1280
+
+
+def _sdxl_single(p):
+    np.savez(p, hidden_state1=np.random.randn(SDXL_SEQ, SDXL_H1).astype(np.float32),
+             hidden_state2=np.random.randn(SDXL_SEQ, SDXL_H2).astype(np.float32),
+             pool2=np.random.randn(SDXL_H2).astype(np.float32))
+
+
+def _sdxl_multi(p, n=3):
+    np.savez(p, hidden_state1=np.random.randn(n, SDXL_SEQ, SDXL_H1).astype(np.float32),
+             hidden_state2=np.random.randn(n, SDXL_SEQ, SDXL_H2).astype(np.float32),
+             pool2=np.random.randn(n, SDXL_H2).astype(np.float32))
+
+
+class TestSdxlLoad:
+    def setup_method(self):
+        self.s = SdxlTextEncoderOutputsCachingStrategy(True, 1, False)
+
+    def test_single(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _sdxl_single(p)
+        r = self.s.load_outputs_npz(p)
+        assert r[0].shape == (SDXL_SEQ, SDXL_H1)
+        assert r[1].shape == (SDXL_SEQ, SDXL_H2)
+        assert r[2].shape == (SDXL_H2,)
+
+    def test_multi(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _sdxl_multi(p, 5)
+        r = self.s.load_outputs_npz(p)
+        assert r[0].shape == (SDXL_SEQ, SDXL_H1)
+        assert r[1].shape == (SDXL_SEQ, SDXL_H2)
+        assert r[2].shape == (SDXL_H2,)
+
+    def test_randomness(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        n = 10
+        np.savez(p,
+                 hidden_state1=np.arange(n, dtype=np.float32).reshape(n, 1, 1) * np.ones((1, SDXL_SEQ, SDXL_H1), dtype=np.float32),
+                 hidden_state2=np.random.randn(n, SDXL_SEQ, SDXL_H2).astype(np.float32),
+                 pool2=np.random.randn(n, SDXL_H2).astype(np.float32))
+        vals = set(float(self.s.load_outputs_npz(p)[0][0, 0]) for _ in range(50))
+        assert len(vals) > 1
+
+    def test_validity_single(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _sdxl_single(p)
+        assert self.s.is_disk_cached_outputs_expected(p) is True
+
+    def test_validity_multi(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _sdxl_multi(p)
+        assert self.s.is_disk_cached_outputs_expected(p) is True
+
+
+# ==================== SD3 ====================
+
+SD3_SEQ_LG = 77
+SD3_SEQ_T5 = 256
+SD3_LG_DIM = 2048
+SD3_T5_DIM = 4096
+SD3_POOL = 2048
+
+
+def _sd3_single(p):
+    np.savez(p, lg_out=np.random.randn(SD3_SEQ_LG, SD3_LG_DIM).astype(np.float32),
+             lg_pooled=np.random.randn(SD3_POOL).astype(np.float32),
+             t5_out=np.random.randn(SD3_SEQ_T5, SD3_T5_DIM).astype(np.float32),
+             clip_l_attn_mask=np.ones(SD3_SEQ_LG, dtype=np.float32),
+             clip_g_attn_mask=np.ones(SD3_SEQ_LG, dtype=np.float32),
+             t5_attn_mask=np.ones(SD3_SEQ_T5, dtype=np.float32),
+             apply_lg_attn_mask=False, apply_t5_attn_mask=False)
+
+
+def _sd3_multi(p, n=3):
+    np.savez(p, lg_out=np.random.randn(n, SD3_SEQ_LG, SD3_LG_DIM).astype(np.float32),
+             lg_pooled=np.random.randn(n, SD3_POOL).astype(np.float32),
+             t5_out=np.random.randn(n, SD3_SEQ_T5, SD3_T5_DIM).astype(np.float32),
+             clip_l_attn_mask=np.ones((n, SD3_SEQ_LG), dtype=np.float32),
+             clip_g_attn_mask=np.ones((n, SD3_SEQ_LG), dtype=np.float32),
+             t5_attn_mask=np.ones((n, SD3_SEQ_T5), dtype=np.float32),
+             apply_lg_attn_mask=False, apply_t5_attn_mask=False)
+
+
+class TestSd3Load:
+    def setup_method(self):
+        self.s = Sd3TextEncoderOutputsCachingStrategy(True, 1, False)
+
+    def test_single(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _sd3_single(p)
+        r = self.s.load_outputs_npz(p)
+        assert len(r) == 6
+        assert r[0].shape == (SD3_SEQ_LG, SD3_LG_DIM)  # lg_out
+        assert r[1].shape == (SD3_SEQ_T5, SD3_T5_DIM)   # t5_out
+        assert r[2].shape == (SD3_POOL,)                  # lg_pooled
+
+    def test_multi(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _sd3_multi(p, 5)
+        r = self.s.load_outputs_npz(p)
+        assert r[0].shape == (SD3_SEQ_LG, SD3_LG_DIM)
+        assert r[1].shape == (SD3_SEQ_T5, SD3_T5_DIM)
+        assert r[2].shape == (SD3_POOL,)
+        assert r[3].shape == (SD3_SEQ_LG,)  # l_attn_mask
+        assert r[4].shape == (SD3_SEQ_LG,)  # g_attn_mask
+        assert r[5].shape == (SD3_SEQ_T5,)  # t5_attn_mask
+
+    def test_validity_both(self, tmp_path):
+        p1 = str(tmp_path / "s.npz")
+        p2 = str(tmp_path / "m.npz")
+        _sd3_single(p1)
+        _sd3_multi(p2)
+        assert self.s.is_disk_cached_outputs_expected(p1) is True
+        assert self.s.is_disk_cached_outputs_expected(p2) is True
+
+
+# ==================== HunyuanImage ====================
+
+HI_VLM_SEQ = 256
+HI_VLM_DIM = 2048
+HI_BYT5_SEQ = 128
+HI_BYT5_DIM = 1472
+
+
+def _hi_single(p):
+    np.savez(p, vlm_embed=np.random.randn(HI_VLM_SEQ, HI_VLM_DIM).astype(np.float32),
+             vlm_mask=np.ones(HI_VLM_SEQ, dtype=np.float32),
+             byt5_embed=np.random.randn(HI_BYT5_SEQ, HI_BYT5_DIM).astype(np.float32),
+             byt5_mask=np.ones(HI_BYT5_SEQ, dtype=np.float32),
+             ocr_mask=np.array(False))
+
+
+def _hi_multi(p, n=3):
+    np.savez(p, vlm_embed=np.random.randn(n, HI_VLM_SEQ, HI_VLM_DIM).astype(np.float32),
+             vlm_mask=np.ones((n, HI_VLM_SEQ), dtype=np.float32),
+             byt5_embed=np.random.randn(n, HI_BYT5_SEQ, HI_BYT5_DIM).astype(np.float32),
+             byt5_mask=np.ones((n, HI_BYT5_SEQ), dtype=np.float32),
+             ocr_mask=np.array([False, True, False][:n]))
+
+
+class TestHunyuanImageLoad:
+    def setup_method(self):
+        self.s = HunyuanImageTextEncoderOutputsCachingStrategy(True, 1, False)
+
+    def test_single(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _hi_single(p)
+        r = self.s.load_outputs_npz(p)
+        assert len(r) == 5
+        assert r[0].shape == (HI_VLM_SEQ, HI_VLM_DIM)  # vlm_embed
+        assert r[1].shape == (HI_VLM_SEQ,)               # vlm_mask
+        assert r[2].shape == (HI_BYT5_SEQ, HI_BYT5_DIM) # byt5_embed
+        assert r[3].shape == (HI_BYT5_SEQ,)              # byt5_mask
+
+    def test_multi(self, tmp_path):
+        p = str(tmp_path / "t.npz")
+        _hi_multi(p, 3)
+        r = self.s.load_outputs_npz(p)
+        assert r[0].shape == (HI_VLM_SEQ, HI_VLM_DIM)
+        assert r[2].shape == (HI_BYT5_SEQ, HI_BYT5_DIM)
+        # ocr_mask should be scalar after selection
+        assert r[4].ndim == 0
+
+    def test_validity_both(self, tmp_path):
+        p1 = str(tmp_path / "s.npz")
+        p2 = str(tmp_path / "m.npz")
+        _hi_single(p1)
+        _hi_multi(p2)
+        assert self.s.is_disk_cached_outputs_expected(p1) is True
+        assert self.s.is_disk_cached_outputs_expected(p2) is True


### PR DESCRIPTION
Hi @kohya-ss 

## Overview
Add support for multi-caption embedding caching. When using `--enable_wildcard` with a caption file containing multiple lines (separated by `\n`), each line is encoded as a separate embedding and stored stacked in the NPZ cache. During training, one variant is randomly selected per epoch — acting as caption augmentation at no extra training cost.

## Requirement
This feature requires `--enable_wildcard` to be enabled. Without it, `train_util.py` always picks only the first line of a multi-line caption at training time, making the other cached variants unused.

| | With `--enable_wildcard` | Without `--enable_wildcard` |
|---|---|---|
| **Caching phase** | All lines encoded & cached ✅ | All lines encoded & cached ✅ |
| **Training (cache hit)** | Random variant selected ✅ | Random variant selected ✅ |
| **Training (cache miss / fallback)** | Random line picked at runtime ✅ | Only first line used ❌ |

## How it works
- **Caching**: `cache_batch_outputs()` reads the raw multi-line caption from `info.caption`, splits by `\n`, encodes each line separately, and saves stacked arrays `(N, seq_len, dim)` to NPZ
- **Loading (disk cache)**: `load_outputs_npz()` detects multi-caption via `ndim == 3` and randomly selects one variant
- **Loading (memory cache)**: `__getitem__` selects one variant using `ImageInfo.num_caption_variants`
- **Backward compatible**: existing single-caption NPZ files (`ndim == 2`) are unaffected

## Models supported
SDXL · SD3 · Flux · Lumina · Anima · HunyuanImage

## Files changed
| File | Change |
|------|--------|
| `library/train_util.py` | Add `num_caption_variants` field to `ImageInfo`; add random selection in `__getitem__` |
| `library/strategy_sdxl.py` | Add `_encode_captions()`, refactor `cache_batch_outputs()`, update `load_outputs_npz()` |
| `library/strategy_flux.py` | Same as above |
| `library/strategy_sd3.py` | Same as above |
| `library/strategy_lumina.py` | Same as above |
| `library/strategy_anima.py` | Same as above (`caption_dropout_rate` is a per-image scalar shared across all variants, not indexed during selection) |
| `library/strategy_hunyuan_image.py` | Same as above |
| `tests/test_*.py` | 36 unit tests covering NPZ load/save, random selection, backward compat |

## Notes
- Caching is slightly slower (per-image encoding instead of batch) but training speed is unaffected
- `caption_dropout_rate` in Anima is cached inside NPZ and applied at training time via `drop_cached_text_encoder_outputs()` — unlike other models where dropout is applied at runtime in `train_util.py`