### PR TITLE
feat: Add Condition Embedding Perturbation (CEP) noise support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ GEMINI.md
 MagicMock
 .codex-tmp
 references
+tasks/
+
 
 # inpainting test artefacts (synthetic data, training outputs, downloads, mask viz)
 tests/test_data/

--- a/flux_train.py
+++ b/flux_train.py
@@ -640,6 +640,10 @@ def train(args):
                 guidance_vec = torch.full((bsz,), float(args.guidance_scale), device=accelerator.device)
 
                 # call model
+                if args.cep_noise > 0.0:
+                    text_encoder_conds = train_util.apply_cep_noise(
+                        text_encoder_conds, args.cep_noise, args.cep_noise_type, batch_size=latents.shape[0]
+                    )
                 l_pooled, t5_out, txt_ids, t5_attn_mask = text_encoder_conds
                 if not args.apply_t5_attn_mask:
                     t5_attn_mask = None

--- a/flux_train_control_net.py
+++ b/flux_train_control_net.py
@@ -652,6 +652,10 @@ def train(args):
                 guidance_vec = torch.full((bsz,), float(args.guidance_scale), device=accelerator.device, dtype=weight_dtype)
 
                 # call model
+                if args.cep_noise > 0.0:
+                    text_encoder_conds = train_util.apply_cep_noise(
+                        text_encoder_conds, args.cep_noise, args.cep_noise_type, batch_size=latents.shape[0]
+                    )
                 l_pooled, t5_out, txt_ids, t5_attn_mask = text_encoder_conds
                 if not args.apply_t5_attn_mask:
                     t5_attn_mask = None

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4207,6 +4207,19 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         help="Use random strength between 0~ip_noise_gamma for input perturbation noise."
         + "/ input perturbation noiseにおいて、0からip_noise_gammaの間でランダムな強度を使用します。",
     )
+    parser.add_argument(
+        "--cep_noise",
+        type=float,
+        default=0.0,
+        help="enable condition embedding perturbation (CEP) noise. recommended value: 1.0 (from arxiv.org/abs/2405.20494) / 条件埋め込み摂動(CEP)ノイズを有効にする。推奨値: 1.0 (arxiv.org/abs/2405.20494 より)",
+    )
+    parser.add_argument(
+        "--cep_noise_type",
+        type=str,
+        default="gaussian",
+        choices=["gaussian", "uniform"],
+        help="noise type for condition embedding perturbation (CEP) / 条件埋め込み摂動(CEP)のノイズタイプ",
+    )
     # parser.add_argument(
     #     "--perlin_noise",
     #     type=int,
@@ -6218,6 +6231,57 @@ def get_timesteps(min_timestep: int, max_timestep: int, b_size: int, device: tor
         timesteps = torch.full((b_size,), max_timestep, device="cpu")
     timesteps = timesteps.long().to(device)
     return timesteps
+
+
+def apply_cep_noise(
+    conds: Union[List[Union[torch.Tensor, None]], Tuple[Union[torch.Tensor, None]], torch.Tensor],
+    cep_noise: float,
+    cep_noise_type: str = "gaussian",
+    batch_size: Optional[int] = None,
+) -> Union[List[Union[torch.Tensor, None]], Tuple[Union[torch.Tensor, None]], torch.Tensor]:
+    if cep_noise <= 0.0:
+        return conds
+
+    if isinstance(conds, torch.Tensor):
+        if not conds.dtype.is_floating_point:
+            return conds
+        d = conds.shape[-1]
+        if cep_noise_type == "gaussian":
+            noise = torch.randn_like(conds) * (cep_noise / math.sqrt(d))
+        elif cep_noise_type == "uniform":
+            noise = (torch.rand_like(conds) * 2.0 - 1.0) * (cep_noise / math.sqrt(d))
+        else:
+            raise ValueError(f"Unknown cep_noise_type: {cep_noise_type}")
+        return conds + noise
+
+    is_tuple = isinstance(conds, tuple)
+    conds_list = list(conds)
+    perturbed_conds = []
+
+    for cond in conds_list:
+        if cond is None or not isinstance(cond, torch.Tensor) or not cond.dtype.is_floating_point:
+            perturbed_conds.append(cond)
+            continue
+
+        if batch_size is not None and cond.shape[0] != batch_size:
+            perturbed_conds.append(cond)
+            continue
+
+        d = cond.shape[-1]
+        if d not in [768, 1024, 1152, 1280, 1536, 2048, 3072, 4096]:
+            perturbed_conds.append(cond)
+            continue
+
+        if cep_noise_type == "gaussian":
+            noise = torch.randn_like(cond) * (cep_noise / math.sqrt(d))
+        elif cep_noise_type == "uniform":
+            noise = (torch.rand_like(cond) * 2.0 - 1.0) * (cep_noise / math.sqrt(d))
+        else:
+            raise ValueError(f"Unknown cep_noise_type: {cep_noise_type}")
+
+        perturbed_conds.append(cond + noise)
+
+    return tuple(perturbed_conds) if is_tuple else perturbed_conds
 
 
 def get_noise_noisy_latents_and_timesteps(

--- a/lumina_train.py
+++ b/lumina_train.py
@@ -743,6 +743,13 @@ def train(args):
                     )
                 )
                 # call model
+                if args.cep_noise > 0.0:
+                    text_encoder_conds = train_util.apply_cep_noise(
+                        text_encoder_conds,
+                        args.cep_noise,
+                        args.cep_noise_type,
+                        batch_size=latents.shape[0],
+                    )
                 gemma2_hidden_states, input_ids, gemma2_attn_mask = text_encoder_conds
 
                 with accelerator.autocast():

--- a/sd3_train.py
+++ b/sd3_train.py
@@ -802,6 +802,13 @@ def train(args):
                             sd3_tokenize_strategy, [None, None, t5xxl], [None, None, input_ids_t5xxl, None, None, t5_attn_mask]
                         )
 
+                if args.cep_noise > 0.0:
+                    lg_out, t5_out, lg_pooled = train_util.apply_cep_noise(
+                        [lg_out, t5_out, lg_pooled],
+                        args.cep_noise,
+                        args.cep_noise_type,
+                        batch_size=latents.shape[0]
+                    )
                 context, lg_pooled = text_encoding_strategy.concat_encodings(lg_out, t5_out, lg_pooled)
 
                 # TODO support some features for noise implemented in get_noise_noisy_latents_and_timesteps

--- a/sdxl_train.py
+++ b/sdxl_train.py
@@ -691,6 +691,13 @@ def train(args):
                 embs = sdxl_train_util.get_size_embeddings(orig_size, crop_size, target_size, accelerator.device).to(weight_dtype)
 
                 # concat embeddings
+                if args.cep_noise > 0.0:
+                    encoder_hidden_states1, encoder_hidden_states2, pool2 = train_util.apply_cep_noise(
+                        [encoder_hidden_states1, encoder_hidden_states2, pool2],
+                        args.cep_noise,
+                        args.cep_noise_type,
+                        batch_size=latents.shape[0]
+                    )
                 vector_embedding = torch.cat([pool2, embs], dim=1).to(weight_dtype)
                 text_embedding = torch.cat([encoder_hidden_states1, encoder_hidden_states2], dim=2).to(weight_dtype)
 

--- a/sdxl_train_control_net.py
+++ b/sdxl_train_control_net.py
@@ -508,6 +508,13 @@ def train(args):
                 embs = sdxl_train_util.get_size_embeddings(orig_size, crop_size, target_size, accelerator.device).to(weight_dtype)
 
                 # concat embeddings
+                if args.cep_noise > 0.0:
+                    encoder_hidden_states1, encoder_hidden_states2, pool2 = train_util.apply_cep_noise(
+                        [encoder_hidden_states1, encoder_hidden_states2, pool2],
+                        args.cep_noise,
+                        args.cep_noise_type,
+                        batch_size=latents.shape[0]
+                    )
                 vector_embedding = torch.cat([pool2, embs], dim=1).to(weight_dtype)
                 text_embedding = torch.cat([encoder_hidden_states1, encoder_hidden_states2], dim=2).to(weight_dtype)
 

--- a/train_db.py
+++ b/train_db.py
@@ -383,6 +383,14 @@ def train(args):
                     if args.full_fp16:
                         encoder_hidden_states = encoder_hidden_states.to(weight_dtype)
 
+                if args.cep_noise > 0.0:
+                    encoder_hidden_states = train_util.apply_cep_noise(
+                        encoder_hidden_states,
+                        args.cep_noise,
+                        args.cep_noise_type,
+                        batch_size=latents.shape[0],
+                    )
+
                 # Sample noise, sample a random timestep for each image, and add noise to the latents,
                 # with noise offset and/or multires noise if specified
                 noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(args, noise_scheduler, latents)

--- a/train_network.py
+++ b/train_network.py
@@ -447,6 +447,11 @@ class NetworkTrainer:
                     if encoded_text_encoder_conds[i] is not None:
                         text_encoder_conds[i] = encoded_text_encoder_conds[i]
 
+        if args.cep_noise > 0.0 and is_train:
+            text_encoder_conds = train_util.apply_cep_noise(
+                text_encoder_conds, args.cep_noise, args.cep_noise_type, batch_size=latents.shape[0]
+            )
+
         # sample noise, call unet, get target
         noise_pred, target, timesteps, weighting = self.get_noise_pred_and_target(
             args,

--- a/train_textual_inversion.py
+++ b/train_textual_inversion.py
@@ -598,6 +598,14 @@ class TextualInversionTrainer:
                     if args.full_fp16:
                         text_encoder_conds = [c.to(weight_dtype) for c in text_encoder_conds]
 
+                    if args.cep_noise > 0.0:
+                        text_encoder_conds = train_util.apply_cep_noise(
+                            text_encoder_conds,
+                            args.cep_noise,
+                            args.cep_noise_type,
+                            batch_size=latents.shape[0],
+                        )
+
                     # Sample noise, sample a random timestep for each image, and add noise to the latents,
                     # with noise offset and/or multires noise if specified
                     noise, noisy_latents, timesteps = train_util.get_noise_noisy_latents_and_timesteps(


### PR DESCRIPTION
## Description
This PR implements **Condition Embedding Perturbation (CEP) Noise**, which is based on the paper: 
*"Slight Corruption in Pre-training Data Makes Better Diffusion Models"* ([arXiv:2405.20494](https://arxiv.org/abs/2405.20494)).

Adding slight perturbation/noise to condition/text embeddings during training has been shown to improve generative quality, diversity, and prompt adherence.

This feature is integrated into all main training scripts, including:
- `train_network.py` (LoRA/network trainers for SD 1.5, SDXL, SD3, Flux, Lumina, Anima, etc.)
- Full fine-tuning scripts: `flux_train.py`, `flux_train_control_net.py`, `sdxl_train.py`, `sdxl_train_control_net.py`, `sd3_train.py`, `lumina_train.py`
- DreamBooth (`train_db.py`)
- Textual Inversion (`train_textual_inversion.py`, `sdxl_train_textual_inversion.py`)

The implementation includes filtering logic to ensure that the perturbation noise is only applied to the actual floating-point text/conditioning embeddings, while keeping auxiliary variables like Attention Masks and Coordinate IDs intact.

## New Arguments
- `--cep_noise` (float, default: `0.0`): The perturbation noise strength ($\gamma$). Set to `0.0` to disable (default behavior). The paper recommends `1.0`.
- `--cep_noise_type` (str, default: `"gaussian"`): The type of perturbation noise. Choose between `gaussian` and `uniform`.

## Application on Small Datasets / LoRA / DreamBooth
CEP Noise serves as an effective regularizer to prevent **overfitting**, which is a common issue when training on small datasets (e.g., character/style LoRA, DreamBooth). 
- **Preventing Overfitting**: Adding slight perturbations helps prevent the model from memorizing the limited prompts, enhancing the generative diversity of the character/style.
- **Tuning for Small Datasets**: While the paper recommends $\gamma = 1.0$ for pre-training, a smaller value (e.g., `0.2` to `0.5`) is recommended when starting on small datasets to avoid breaking the text-image alignment. If you notice overfitting, you can gradually increase `--cep_noise` up to `1.0`.
