### PR TITLE
fix: correctly reuse disk-cached latents in FineTuningDataset

### DIFF
--- a/library/finetuning_dataset.py
+++ b/library/finetuning_dataset.py
@@ -168,9 +168,11 @@ class FineTuningDataset(BaseDataset):
                 # search npz if image_size is not given
                 npz_path = None
                 if image_size is None:
-                    image_without_ext = os.path.splitext(image_key)[0]
+                    # match against the resolved absolute path and normalize separators, so that metadata
+                    # paths written with "/" still match glob results using the OS-native separator
+                    abs_path_without_ext = os.path.normpath(os.path.splitext(abs_path)[0])
                     for candidate in npz_paths:
-                        if candidate.startswith(image_without_ext):
+                        if os.path.normpath(candidate).startswith(abs_path_without_ext):
                             npz_path = candidate
                             break
                     if npz_path is not None:
@@ -215,6 +217,9 @@ class FineTuningDataset(BaseDataset):
                     w, h = strategy.get_image_size_from_disk_cache_path(abs_path, npz_path)
                     image_info.image_size = (w, h)
                     size_set_from_cache_filename += 1
+
+                    # use the discovered cache file directly for latent caching/loading
+                    image_info.latents_npz = npz_path
 
                 if self.skip_image_resolution is not None:
                     size = image_info.image_size


### PR DESCRIPTION
## Summary

Fixes #2362.

When training a `FineTuningDataset` (metadata json) with `--cache_latents_to_disk`, the **first** run succeeds, but the **second and later** runs crash while caching latents:

```
PIL.UnidentifiedImageError: cannot identify image file '...\file_name_0602x0429_anima.npz'
```

This affects every model whose latents caching strategy has **no legacy `.npz` fallback** — Anima, FLUX, SD3, Lumina, HunyuanImage. SD / SDXL happen to work because `SdSdxlLatentsCachingStrategy.get_latents_npz_path()` returns the old `.npz` file when one already exists, which accidentally hides the bug.

## Root cause

When `image_size` is missing from the metadata, `FineTuningDataset` looks up the cache file on disk by filename prefix and overwrites `abs_path` with the discovered `.npz` path — but it never sets `image_info.latents_npz`.

As a result, the latent caching code (`BaseDataset.new_cache_latents`) sees `latents_npz is None` and recomputes the path from `absolute_path`, which is now already the `.npz` file. `get_latents_npz_path()` then appends the resolution and suffix a second time:

```
file_name_0602x0429_anima.npz
  -> file_name_0602x0429_anima_0602x0429_anima.npz   # does not exist
```

The cache is considered missing, so it tries to re-encode the image — but `absolute_path` points at the `.npz`, which `PIL` cannot open. SD/SDXL escape this only because the legacy `.npz` fallback collapses the doubled name back to the real file.

This regression was introduced when latent caching moved to the strategy-based `latents_npz` mechanism; `FineTuningDataset` was not updated to populate it.

## Fix

`library/finetuning_dataset.py`:

1. **Wire up `latents_npz`.** When an existing cache file is discovered, set `image_info.latents_npz` so the caching path reuses it directly instead of recomputing (and duplicating) the npz path.
2. **Robust path matching.** Match the discovered cache against the resolved **absolute path** and normalize separators with `os.path.normpath` on both sides. Without this, metadata paths written with `/` do not match glob results that use the OS-native separator (e.g. `\` on Windows), so the cache is not found at all. Keying off `abs_path` (instead of the raw metadata key) also makes relative metadata paths match.

## Testing

- `pytest` — 150 passed, 2 skipped.
- Manually verified with `anima_train.py --cache_latents_to_disk` using both relative and absolute metadata paths: reverting the `latents_npz` change reproduces the error on the second run, and the fix restores correct cache reuse.