### PR TITLE
Support Frequency Aware Dropout 

### DIFF
--- a/library/args.py
+++ b/library/args.py
@@ -877,6 +877,39 @@ def add_dataset_arguments(
     parser.add_argument(
         "--shuffle_caption", action="store_true", help="shuffle separated caption / 区切られたcaptionの各要素をshuffleする"
     )
+    parser.add_argument(
+        "--enable_fad", action="store_true", help="enable Frequency-Aware Dropout (FAD) / Frequency-Aware Dropout (FAD) を有効にする"
+    )
+    parser.add_argument(
+        "--fad_curriculum", action="store_true", help="enable Curriculum-inspired Scheduling for FAD (sFAD) / sFAD (Curriculum-inspired Scheduling) を有効にする"
+    )
+    parser.add_argument(
+        "--fad_p_min", type=float, default=0.35, help="minimum dropout probability for FAD / FADの最小ドロップアウト確率"
+    )
+    parser.add_argument(
+        "--fad_p_max", type=float, default=1.0, help="maximum dropout probability for FAD / FADの最大ドロップアウト確率"
+    )
+    parser.add_argument(
+        "--fad_alpha", type=float, default=10.0, help="alpha value (sigmoid slope) for FAD / FADのシグモイドスロープのアルファ値"
+    )
+    parser.add_argument(
+        "--fad_c", type=float, default=0.5, help="center ratio for FAD / FADのセンター比率"
+    )
+    parser.add_argument(
+        "--fad_curriculum_start", type=float, default=0.1, help="warmup ratio (iw) for sFAD / sFADのウォームアップ比率"
+    )
+    parser.add_argument(
+        "--fad_curriculum_end", type=float, default=0.8, help="end ratio (if) for sFAD / sFADの終了比率"
+    )
+    parser.add_argument(
+        "--fad_curriculum_beta", type=float, default=3.0, help="beta value for sFAD / sFADのベータ値"
+    )
+    parser.add_argument(
+        "--fad_step_start", type=float, default=0.0, help="minimum p_step scaling factor for sFAD / sFADの最小p_stepスケーリング係数"
+    )
+    parser.add_argument(
+        "--fad_step_end", type=float, default=1.0, help="maximum p_step scaling factor for sFAD / sFADの最大p_stepスケーリング係数"
+    )
     parser.add_argument("--caption_separator", type=str, default=",", help="separator for caption / captionの区切り文字")
     parser.add_argument(
         "--caption_extension", type=str, default=".caption", help="extension of caption files / 読み込むcaptionファイルの拡張子"

--- a/library/config_util.py
+++ b/library/config_util.py
@@ -57,6 +57,8 @@ class BaseSubsetParams:
     image_dir: Optional[str] = None
     num_repeats: int = 1
     shuffle_caption: bool = False
+    enable_fad: bool = False
+    fad_curriculum: bool = False
     caption_separator: str = (",",)
     keep_tokens: int = 0
     keep_tokens_separator: str = (None,)
@@ -111,6 +113,17 @@ class BaseDatasetParams:
     validation_split: float = 0.0
     resize_interpolation: Optional[str] = None
     skip_image_resolution: Optional[Tuple[int, int]] = None
+    enable_fad: bool = False
+    fad_curriculum: bool = False
+    fad_p_min: float = 0.35
+    fad_p_max: float = 1.0
+    fad_alpha: float = 10.0
+    fad_c: float = 0.5
+    fad_curriculum_start: float = 0.1
+    fad_curriculum_end: float = 0.8
+    fad_curriculum_beta: float = 3.0
+    fad_step_start: float = 0.0
+    fad_step_end: float = 1.0
 
 @dataclass
 class DreamBoothDatasetParams(BaseDatasetParams):
@@ -190,6 +203,8 @@ class ConfigSanitizer:
         "num_repeats": int,
         "random_crop": bool,
         "shuffle_caption": bool,
+        "enable_fad": bool,
+        "fad_curriculum": bool,
         "keep_tokens": int,
         "keep_tokens_separator": str,
         "secondary_separator": str,
@@ -248,6 +263,17 @@ class ConfigSanitizer:
         "network_multiplier": float,
         "resize_interpolation": str,
         "skip_image_resolution": functools.partial(__validate_and_convert_scalar_or_twodim.__func__, int),
+        "enable_fad": bool,
+        "fad_curriculum": bool,
+        "fad_p_min": Any(float, int),
+        "fad_p_max": Any(float, int),
+        "fad_alpha": Any(float, int),
+        "fad_c": Any(float, int),
+        "fad_curriculum_start": Any(float, int),
+        "fad_curriculum_end": Any(float, int),
+        "fad_curriculum_beta": Any(float, int),
+        "fad_step_start": Any(float, int),
+        "fad_step_end": Any(float, int),
     }
 
     # options handled by argparse but not handled by user config
@@ -537,6 +563,17 @@ def generate_dataset_group_by_blueprint(dataset_group_blueprint: DatasetGroupBlu
                   skip_image_resolution: {dataset.skip_image_resolution}
                   resize_interpolation: {dataset.resize_interpolation}
                   enable_bucket: {dataset.enable_bucket}
+                  enable_fad: {getattr(dataset, "enable_fad", False)}
+                  fad_curriculum: {getattr(dataset, "fad_curriculum", False)}
+                  fad_p_min: {getattr(dataset, "fad_p_min", 0.35)}
+                  fad_p_max: {getattr(dataset, "fad_p_max", 1.0)}
+                  fad_alpha: {getattr(dataset, "fad_alpha", 10.0)}
+                  fad_c: {getattr(dataset, "fad_c", 0.5)}
+                  fad_curriculum_start: {getattr(dataset, "fad_curriculum_start", 0.1)}
+                  fad_curriculum_end: {getattr(dataset, "fad_curriculum_end", 0.8)}
+                  fad_curriculum_beta: {getattr(dataset, "fad_curriculum_beta", 3.0)}
+                  fad_step_start: {getattr(dataset, "fad_step_start", 0.0)}
+                  fad_step_end: {getattr(dataset, "fad_step_end", 1.0)}
             """)
 
             if dataset.enable_bucket:
@@ -556,6 +593,8 @@ def generate_dataset_group_by_blueprint(dataset_group_blueprint: DatasetGroupBlu
                     image_count: {subset.img_count}
                     num_repeats: {subset.num_repeats}
                     shuffle_caption: {subset.shuffle_caption}
+                    enable_fad: {subset.enable_fad}
+                    fad_curriculum: {subset.fad_curriculum}
                     keep_tokens: {subset.keep_tokens}
                     caption_dropout_rate: {subset.caption_dropout_rate}
                     caption_dropout_every_n_epochs: {subset.caption_dropout_every_n_epochs}

--- a/library/controlnet_dataset.py
+++ b/library/controlnet_dataset.py
@@ -44,6 +44,17 @@ class ControlNetDataset(BaseDataset):
         validation_seed: Optional[int],
         resize_interpolation: Optional[str] = None,
         skip_image_resolution: Optional[Tuple[int, int]] = None,
+        enable_fad: bool = False,
+        fad_curriculum: bool = False,
+        fad_p_min: float = 0.35,
+        fad_p_max: float = 1.0,
+        fad_alpha: float = 10.0,
+        fad_c: float = 0.5,
+        fad_curriculum_start: float = 0.1,
+        fad_curriculum_end: float = 0.8,
+        fad_curriculum_beta: float = 3.0,
+        fad_step_start: float = 0.0,
+        fad_step_end: float = 1.0,
     ) -> None:
         super().__init__(
             resolution,
@@ -52,6 +63,17 @@ class ControlNetDataset(BaseDataset):
             debug_dataset,
             resize_interpolation,
             skip_image_resolution,
+            enable_fad,
+            fad_curriculum,
+            fad_p_min,
+            fad_p_max,
+            fad_alpha,
+            fad_c,
+            fad_curriculum_start,
+            fad_curriculum_end,
+            fad_curriculum_beta,
+            fad_step_start,
+            fad_step_end,
         )
 
         db_subsets = []
@@ -85,6 +107,8 @@ class ControlNetDataset(BaseDataset):
                 subset.token_warmup_min,
                 subset.token_warmup_step,
                 resize_interpolation=subset.resize_interpolation,
+                enable_fad=subset.enable_fad,
+                fad_curriculum=subset.fad_curriculum,
             )
             db_subsets.append(db_subset)
 
@@ -106,6 +130,17 @@ class ControlNetDataset(BaseDataset):
             validation_seed,
             resize_interpolation,
             skip_image_resolution,
+            enable_fad,
+            fad_curriculum,
+            fad_p_min,
+            fad_p_max,
+            fad_alpha,
+            fad_c,
+            fad_curriculum_start,
+            fad_curriculum_end,
+            fad_curriculum_beta,
+            fad_step_start,
+            fad_step_end,
         )
 
         # config_util等から参照される値をいれておく（若干微妙なのでなんとかしたい）

--- a/library/dataset.py
+++ b/library/dataset.py
@@ -368,6 +368,17 @@ class BaseDataset(torch.utils.data.Dataset):
         debug_dataset: bool,
         resize_interpolation: Optional[str] = None,
         skip_image_resolution: Optional[Tuple[int, int]] = None,
+        enable_fad: bool = False,
+        fad_curriculum: bool = False,
+        fad_p_min: float = 0.35,
+        fad_p_max: float = 1.0,
+        fad_alpha: float = 10.0,
+        fad_c: float = 0.5,
+        fad_curriculum_start: float = 0.1,
+        fad_curriculum_end: float = 0.8,
+        fad_curriculum_beta: float = 3.0,
+        fad_step_start: float = 0.0,
+        fad_step_end: float = 1.0,
     ) -> None:
         super().__init__()
 
@@ -421,6 +432,18 @@ class BaseDataset(torch.utils.data.Dataset):
         self.tokenize_strategy = None
         self.text_encoder_output_caching_strategy = None
         self.latents_caching_strategy = None
+
+        self.enable_fad = enable_fad
+        self.fad_curriculum = fad_curriculum
+        self.fad_p_min = fad_p_min
+        self.fad_p_max = fad_p_max
+        self.fad_alpha = fad_alpha
+        self.fad_c = fad_c
+        self.fad_curriculum_start = fad_curriculum_start
+        self.fad_curriculum_end = fad_curriculum_end
+        self.fad_curriculum_beta = fad_curriculum_beta
+        self.fad_step_start = fad_step_start
+        self.fad_step_end = fad_step_end
 
     def set_current_strategies(self):
         self.tokenize_strategy = TokenizeStrategy.get_strategy()
@@ -498,6 +521,79 @@ class BaseDataset(torch.utils.data.Dataset):
     def add_replacement(self, str_from, str_to):
         self.replacements[str_from] = str_to
 
+    def get_fad_caption_variants(self, subset: BaseSubset, caption: str) -> List[Tuple[str, float]]:
+        if subset.caption_prefix:
+            caption = subset.caption_prefix + " " + caption
+        if subset.caption_suffix:
+            caption = caption + " " + subset.caption_suffix
+
+        if not subset.enable_wildcard:
+            return [(caption.split("\n")[0], 1.0)]
+
+        lines = caption.split("\n")
+        line_probability = 1.0 / len(lines)
+        variants: List[Tuple[str, float]] = []
+
+        for line in lines:
+            variants.extend(
+                [(expanded_caption, line_probability * wildcard_probability) for expanded_caption, wildcard_probability in self.expand_wildcards(line)]
+            )
+
+        return variants
+
+    def expand_wildcards(self, caption: str) -> List[Tuple[str, float]]:
+        replacer1 = "⦅"
+        replacer2 = "⦆"
+        while replacer1 in caption or replacer2 in caption:
+            replacer1 += "⦅"
+            replacer2 += "⦆"
+
+        caption = caption.replace("{{", replacer1).replace("}}", replacer2)
+
+        def expand_once(text: str) -> List[Tuple[str, float]]:
+            match = re.search(r"\{([^}]+)\}", text)
+            if match is None:
+                return [(text.replace(replacer1, "{").replace(replacer2, "}"), 1.0)]
+
+            choices = match.group(1).split("|")
+            choice_probability = 1.0 / len(choices)
+            variants: List[Tuple[str, float]] = []
+            for choice in choices:
+                expanded = text[: match.start()] + choice + text[match.end() :]
+                variants.extend([(variant, choice_probability * probability) for variant, probability in expand_once(expanded)])
+            return variants
+
+        return expand_once(caption)
+
+    def get_flex_tokens_from_caption(self, subset: BaseSubset, caption: str) -> List[str]:
+        fixed_tokens = []
+        flex_tokens = []
+        fixed_suffix_tokens = []
+        if (
+            hasattr(subset, "keep_tokens_separator")
+            and subset.keep_tokens_separator
+            and subset.keep_tokens_separator in caption
+        ):
+            fixed_part, flex_part = caption.split(subset.keep_tokens_separator, 1)
+            if subset.keep_tokens_separator in flex_part:
+                flex_part, fixed_suffix_part = flex_part.split(subset.keep_tokens_separator, 1)
+                fixed_suffix_tokens = [t.strip() for t in fixed_suffix_part.split(subset.caption_separator) if t.strip()]
+
+            fixed_tokens = [t.strip() for t in fixed_part.split(subset.caption_separator) if t.strip()]
+            flex_tokens = [t.strip() for t in flex_part.split(subset.caption_separator) if t.strip()]
+        else:
+            tokens = [t.strip() for t in caption.strip().split(subset.caption_separator)]
+            flex_tokens = tokens[:]
+            if subset.keep_tokens > 0:
+                fixed_tokens = flex_tokens[: subset.keep_tokens]
+                flex_tokens = tokens[subset.keep_tokens :]
+
+        return flex_tokens
+
+    def get_raw_flex_tokens(self, subset: BaseSubset, caption: str) -> List[str]:
+        caption_variant = self.get_fad_caption_variants(subset, caption)[0][0]
+        return self.get_flex_tokens_from_caption(subset, caption_variant)
+
     def process_caption(self, subset: BaseSubset, caption):
         # caption に prefix/suffix を付ける
         if subset.caption_prefix:
@@ -544,7 +640,7 @@ class BaseDataset(torch.utils.data.Dataset):
                 # if caption is multiline, use the first line
                 caption = caption.split("\n")[0]
 
-            if subset.shuffle_caption or subset.token_warmup_step > 0 or subset.caption_tag_dropout_rate > 0:
+            if subset.shuffle_caption or subset.token_warmup_step > 0 or subset.caption_tag_dropout_rate > 0 or getattr(subset, "enable_fad", False):
                 fixed_tokens = []
                 flex_tokens = []
                 fixed_suffix_tokens = []
@@ -590,6 +686,41 @@ class BaseDataset(torch.utils.data.Dataset):
                 if subset.shuffle_caption:
                     random.shuffle(flex_tokens)
 
+                if getattr(subset, "enable_fad", False):
+                    if getattr(self, "max_train_steps", 0) > 0:
+                        if subset.fad_curriculum:
+                            i = self.current_step
+                            N = self.max_train_steps
+                            iw = N * self.fad_curriculum_start
+                            if_ = N * self.fad_curriculum_end
+
+                            if i < iw:
+                                p_step = self.fad_step_start
+                            elif i >= if_:
+                                p_step = self.fad_step_end
+                            else:
+                                s = (i - iw) / (if_ - iw) if if_ != iw else 1.0
+                                p_step_normalized = 1.0 - math.exp(-self.fad_curriculum_beta * s)
+                                p_step = self.fad_step_start + (self.fad_step_end - self.fad_step_start) * p_step_normalized
+                        else:
+                            p_step = 1.0
+
+                        l = []
+                        for token in flex_tokens:
+                            r_w = subset.fad_tag_frequencies.get(token, 0.0)
+                            delta_p = self.fad_p_max - self.fad_p_min
+                            val = self.fad_alpha * (r_w - self.fad_c)
+                            try:
+                                sigmoid_val = 1.0 / (1.0 + math.exp(-val))
+                            except OverflowError:
+                                sigmoid_val = 0.0 if val < 0 else 1.0
+
+                            p_drop = self.fad_p_min + delta_p * sigmoid_val
+                            p_drop_final = p_drop * p_step
+
+                            if random.random() >= p_drop_final:
+                                l.append(token)
+                        flex_tokens = l
                 flex_tokens = dropout_tags(flex_tokens)
 
                 caption = ", ".join(fixed_tokens + flex_tokens + fixed_suffix_tokens)
@@ -620,6 +751,44 @@ class BaseDataset(torch.utils.data.Dataset):
         bucketingを行わない場合も呼び出し必須（ひとつだけbucketを作る）
         min_size and max_size are ignored when enable_bucket is False
         """
+        # Frequency-Aware Dropout (FAD) Co-occurrence frequency computation
+        for subset in self.subsets:
+            if not getattr(subset, "enable_fad", False):
+                continue
+
+            logger.info(f"Initializing Frequency-Aware Dropout (FAD) statistics for subset: {subset.image_dir or getattr(subset, 'metadata_file', '')}")
+
+            # Find subset image infos
+            subset_image_infos = [
+                info for info in self.image_data.values()
+                if self.image_to_subset.get(info.image_key) == subset
+            ]
+
+            if not subset_image_infos:
+                logger.warning(f"No images found for subset, skipping FAD initialization.")
+                continue
+
+            # Token occurrences expectation computation
+            token_expected_counts = {}
+            N_t = len(subset_image_infos)
+
+            for info in subset_image_infos:
+                raw_caption = info.caption
+                for caption_variant, probability in self.get_fad_caption_variants(subset, raw_caption):
+                    flex_tokens = self.get_flex_tokens_from_caption(subset, caption_variant)
+                    unique_flex_tokens = set(flex_tokens)
+                    for token in unique_flex_tokens:
+                        token_expected_counts[token] = token_expected_counts.get(token, 0.0) + probability
+
+            # Calculate r(w) = count[w] / N_t
+            fad_tag_frequencies = {}
+            for token, count in token_expected_counts.items():
+                r_w = count / N_t
+                fad_tag_frequencies[token] = min(r_w, 1.0)
+
+            subset.fad_tag_frequencies = fad_tag_frequencies
+            logger.info(f"FAD initialized: {len(fad_tag_frequencies)} unique flex tokens registered.")
+
         logger.info("loading image sizes.")
         for info in tqdm(self.image_data.values()):
             if info.image_size is None:
@@ -739,6 +908,7 @@ class BaseDataset(torch.utils.data.Dataset):
                     or subset.shuffle_caption
                     or subset.token_warmup_step > 0
                     or subset.caption_tag_dropout_rate > 0
+                    or getattr(subset, "enable_fad", False)
                 )
                 for subset in self.subsets
             ]

--- a/library/dreambooth_dataset.py
+++ b/library/dreambooth_dataset.py
@@ -52,6 +52,17 @@ class DreamBoothDataset(BaseDataset):
         validation_seed: Optional[int],
         resize_interpolation: Optional[str],
         skip_image_resolution: Optional[Tuple[int, int]] = None,
+        enable_fad: bool = False,
+        fad_curriculum: bool = False,
+        fad_p_min: float = 0.35,
+        fad_p_max: float = 1.0,
+        fad_alpha: float = 10.0,
+        fad_c: float = 0.5,
+        fad_curriculum_start: float = 0.1,
+        fad_curriculum_end: float = 0.8,
+        fad_curriculum_beta: float = 3.0,
+        fad_step_start: float = 0.0,
+        fad_step_end: float = 1.0,
     ) -> None:
         super().__init__(
             resolution,
@@ -60,6 +71,17 @@ class DreamBoothDataset(BaseDataset):
             debug_dataset,
             resize_interpolation,
             skip_image_resolution,
+            enable_fad,
+            fad_curriculum,
+            fad_p_min,
+            fad_p_max,
+            fad_alpha,
+            fad_c,
+            fad_curriculum_start,
+            fad_curriculum_end,
+            fad_curriculum_beta,
+            fad_step_start,
+            fad_step_end,
         )
 
         assert resolution is not None, f"resolution is required / resolution（解像度）指定は必須です"

--- a/library/finetuning_dataset.py
+++ b/library/finetuning_dataset.py
@@ -42,6 +42,17 @@ class FineTuningDataset(BaseDataset):
         validation_split: float,
         resize_interpolation: Optional[str],
         skip_image_resolution: Optional[Tuple[int, int]] = None,
+        enable_fad: bool = False,
+        fad_curriculum: bool = False,
+        fad_p_min: float = 0.35,
+        fad_p_max: float = 1.0,
+        fad_alpha: float = 10.0,
+        fad_c: float = 0.5,
+        fad_curriculum_start: float = 0.1,
+        fad_curriculum_end: float = 0.8,
+        fad_curriculum_beta: float = 3.0,
+        fad_step_start: float = 0.0,
+        fad_step_end: float = 1.0,
     ) -> None:
         super().__init__(
             resolution,
@@ -50,6 +61,17 @@ class FineTuningDataset(BaseDataset):
             debug_dataset,
             resize_interpolation,
             skip_image_resolution,
+            enable_fad,
+            fad_curriculum,
+            fad_p_min,
+            fad_p_max,
+            fad_alpha,
+            fad_c,
+            fad_curriculum_start,
+            fad_curriculum_end,
+            fad_curriculum_beta,
+            fad_step_start,
+            fad_step_end,
         )
 
         self.batch_size = batch_size

--- a/library/subset.py
+++ b/library/subset.py
@@ -36,6 +36,8 @@ class BaseSubset:
         validation_seed: Optional[int] = None,
         validation_split: Optional[float] = 0.0,
         resize_interpolation: Optional[str] = None,
+        enable_fad: bool = False,
+        fad_curriculum: bool = False,
     ) -> None:
         self.image_dir = image_dir
         self.alpha_mask = alpha_mask if alpha_mask is not None else False
@@ -67,6 +69,10 @@ class BaseSubset:
         self.validation_split = validation_split
 
         self.resize_interpolation = resize_interpolation
+
+        self.enable_fad = enable_fad
+        self.fad_curriculum = fad_curriculum
+        self.fad_tag_frequencies = {}
 
 
 class DreamBoothSubset(BaseSubset):
@@ -100,6 +106,7 @@ class DreamBoothSubset(BaseSubset):
         validation_seed: Optional[int] = None,
         validation_split: Optional[float] = 0.0,
         resize_interpolation: Optional[str] = None,
+        **kwargs,
     ) -> None:
         assert image_dir is not None, "image_dir must be specified / image_dirは指定が必須です"
 
@@ -128,6 +135,7 @@ class DreamBoothSubset(BaseSubset):
             validation_seed=validation_seed,
             validation_split=validation_split,
             resize_interpolation=resize_interpolation,
+            **kwargs,
         )
 
         self.is_reg = is_reg
@@ -171,6 +179,7 @@ class FineTuningSubset(BaseSubset):
         validation_seed: Optional[int] = None,
         validation_split: Optional[float] = 0.0,
         resize_interpolation: Optional[str] = None,
+        **kwargs,
     ) -> None:
         assert metadata_file is not None, "metadata_file must be specified / metadata_fileは指定が必須です"
 
@@ -199,6 +208,7 @@ class FineTuningSubset(BaseSubset):
             validation_seed=validation_seed,
             validation_split=validation_split,
             resize_interpolation=resize_interpolation,
+            **kwargs,
         )
 
         self.metadata_file = metadata_file
@@ -238,6 +248,7 @@ class ControlNetSubset(BaseSubset):
         validation_seed: Optional[int] = None,
         validation_split: Optional[float] = 0.0,
         resize_interpolation: Optional[str] = None,
+        **kwargs,
     ) -> None:
         assert image_dir is not None, "image_dir must be specified / image_dirは指定が必須です"
 
@@ -266,6 +277,7 @@ class ControlNetSubset(BaseSubset):
             validation_seed=validation_seed,
             validation_split=validation_split,
             resize_interpolation=resize_interpolation,
+            **kwargs,
         )
 
         self.conditioning_data_dir = conditioning_data_dir

--- a/tests/test_fad_implementation.py
+++ b/tests/test_fad_implementation.py
@@ -1,0 +1,372 @@
+import os
+import sys
+import unittest
+import math
+import random
+import types
+import importlib.machinery
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Avoid importing broken xformers CUDA extensions while importing diffusers in lightweight dataset tests.
+if "xformers" not in sys.modules:
+    xformers_module = types.ModuleType("xformers")
+    xformers_ops_module = types.ModuleType("xformers.ops")
+    xformers_module.__spec__ = importlib.machinery.ModuleSpec("xformers", loader=None)
+    xformers_ops_module.__spec__ = importlib.machinery.ModuleSpec("xformers.ops", loader=None)
+    xformers_module.ops = xformers_ops_module
+    sys.modules["xformers"] = xformers_module
+    sys.modules["xformers.ops"] = xformers_ops_module
+
+if "diffusers" not in sys.modules:
+    diffusers_module = types.ModuleType("diffusers")
+    diffusers_module.__spec__ = importlib.machinery.ModuleSpec("diffusers", loader=None)
+
+    class _DummyDiffusersClass:
+        pass
+
+    diffusers_module.AutoencoderKL = _DummyDiffusersClass
+    diffusers_module.DDIMScheduler = _DummyDiffusersClass
+    diffusers_module.EulerAncestralDiscreteScheduler = _DummyDiffusersClass
+    diffusers_module.StableDiffusionPipeline = _DummyDiffusersClass
+    sys.modules["diffusers"] = diffusers_module
+    diffusers_schedulers_module = types.ModuleType("diffusers.schedulers")
+    diffusers_schedulers_module.__spec__ = importlib.machinery.ModuleSpec("diffusers.schedulers", loader=None)
+    diffusers_euler_module = types.ModuleType("diffusers.schedulers.scheduling_euler_ancestral_discrete")
+    diffusers_euler_module.__spec__ = importlib.machinery.ModuleSpec(
+        "diffusers.schedulers.scheduling_euler_ancestral_discrete", loader=None
+    )
+    diffusers_euler_module.EulerAncestralDiscreteSchedulerOutput = _DummyDiffusersClass
+    sys.modules["diffusers.schedulers"] = diffusers_schedulers_module
+    sys.modules["diffusers.schedulers.scheduling_euler_ancestral_discrete"] = diffusers_euler_module
+
+from library.subset import BaseSubset
+from library.dataset import BaseDataset, ImageInfo
+from library.dreambooth_dataset import DreamBoothDataset
+from library.finetuning_dataset import FineTuningDataset
+from library.controlnet_dataset import ControlNetDataset
+
+class TestFADImplementation(unittest.TestCase):
+    def setUp(self):
+        random.seed(42)
+
+    def test_fad_frequencies_no_wildcard(self):
+        # 1. Setup mock subset
+        subset = BaseSubset(
+            image_dir="/mock/img/dir",
+            alpha_mask=False,
+            num_repeats=1,
+            shuffle_caption=False,
+            caption_separator=",",
+            keep_tokens=0,
+            keep_tokens_separator=None,
+            secondary_separator=None,
+            enable_wildcard=False,
+            color_aug=False,
+            flip_aug=False,
+            face_crop_aug_range=None,
+            random_crop=False,
+            caption_dropout_rate=0.0,
+            caption_dropout_every_n_epochs=0,
+            caption_tag_dropout_rate=0.0,
+            caption_prefix=None,
+            caption_suffix=None,
+            token_warmup_min=0,
+            token_warmup_step=0,
+            enable_fad=True,
+            fad_curriculum=False,
+        )
+
+        # 2. Setup BaseDataset
+        dataset = BaseDataset(
+            resolution=(512, 512),
+            network_multiplier=1.0,
+            train_inpainting=False,
+            debug_dataset=False,
+            enable_fad=True,
+            fad_curriculum=False,
+        )
+        dataset.batch_size = 1
+        dataset.subsets = [subset]
+
+        # 3. Register mock images and captions
+        # Total 3 images
+        # Caption 1: "trigger, cat, animal"
+        # Caption 2: "trigger, dog, animal"
+        # Caption 3: "trigger, bird"
+        # Since keep_tokens = 0, all tokens are flex_tokens
+        captions = [
+            "trigger, cat, animal",
+            "trigger, dog, animal",
+            "trigger, bird",
+        ]
+        
+        for idx, caption in enumerate(captions):
+            info = ImageInfo(
+                image_key=f"img_{idx}",
+                num_repeats=1,
+                caption=caption,
+                is_reg=False,
+                absolute_path=f"/mock/img/dir/img_{idx}.jpg",
+            )
+            # mock get_image_size to avoid calling PIL
+            info.image_size = (512, 512)
+            dataset.register_image(info, subset)
+
+        # 4. Run make_buckets to initialize FAD statistics
+        dataset.make_buckets()
+
+        # 5. Check computed frequencies r(w)
+        # N_t = 3
+        # "trigger" appears in all 3 -> 3/3 = 1.0
+        # "animal" appears in 2 -> 2/3 = 0.6666...
+        # "cat", "dog", "bird" each appear in 1 -> 1/3 = 0.3333...
+        freq = subset.fad_tag_frequencies
+        
+        self.assertAlmostEqual(freq.get("trigger", 0.0), 1.0)
+        self.assertAlmostEqual(freq.get("animal", 0.0), 2.0 / 3.0)
+        self.assertAlmostEqual(freq.get("cat", 0.0), 1.0 / 3.0)
+        self.assertAlmostEqual(freq.get("dog", 0.0), 1.0 / 3.0)
+        self.assertAlmostEqual(freq.get("bird", 0.0), 1.0 / 3.0)
+
+    def test_fad_frequencies_with_wildcard_uses_exact_expectation(self):
+        # 1. Setup mock subset with enable_wildcard=True
+        subset = BaseSubset(
+            image_dir="/mock/img/dir",
+            alpha_mask=False,
+            num_repeats=1,
+            shuffle_caption=False,
+            caption_separator=",",
+            keep_tokens=0,
+            keep_tokens_separator=None,
+            secondary_separator=None,
+            enable_wildcard=True,
+            color_aug=False,
+            flip_aug=False,
+            face_crop_aug_range=None,
+            random_crop=False,
+            caption_dropout_rate=0.0,
+            caption_dropout_every_n_epochs=0,
+            caption_tag_dropout_rate=0.0,
+            caption_prefix=None,
+            caption_suffix=None,
+            token_warmup_min=0,
+            token_warmup_step=0,
+            enable_fad=True,
+            fad_curriculum=True,
+        )
+
+        dataset = BaseDataset(
+            resolution=(512, 512),
+            network_multiplier=1.0,
+            train_inpainting=False,
+            debug_dataset=False,
+            enable_fad=True,
+            fad_curriculum=True,
+        )
+        dataset.batch_size = 1
+        dataset.subsets = [subset]
+
+        # Register 1 image with multiline and {choice} wildcard
+        # Line 1: "trigger, cat"
+        # Line 2: "trigger, {dog|bird}"
+        # Expected occurrences:
+        # Line 1: 0.5 probability
+        #   "cat" -> 0.5 * 1.0 = 0.5 expected count
+        # Line 2: 0.5 probability
+        #   "dog" -> 0.5 * 0.5 = 0.25 expected count
+        #   "bird" -> 0.5 * 0.5 = 0.25 expected count
+        #   "trigger" -> 0.5 * 1.0 (from line 1) + 0.5 * 1.0 (from line 2) = 1.0 expected count
+        caption = "trigger, cat\ntrigger, {dog|bird}"
+        info = ImageInfo(
+            image_key="img_wildcard",
+            num_repeats=1,
+            caption=caption,
+            is_reg=False,
+            absolute_path="/mock/img/dir/img_wildcard.jpg",
+        )
+        info.image_size = (512, 512)
+        dataset.register_image(info, subset)
+
+        dataset.make_buckets()
+
+        freq = subset.fad_tag_frequencies
+        
+        self.assertAlmostEqual(freq.get("trigger", 0.0), 1.0)
+        self.assertAlmostEqual(freq.get("cat", 0.0), 0.5)
+        self.assertAlmostEqual(freq.get("dog", 0.0), 0.25)
+        self.assertAlmostEqual(freq.get("bird", 0.0), 0.25)
+
+    def test_fad_curriculum_steps(self):
+        # Setup FAD with curriculum enabled
+        subset = BaseSubset(
+            image_dir="/mock/img/dir",
+            alpha_mask=False,
+            num_repeats=1,
+            shuffle_caption=False,
+            caption_separator=",",
+            keep_tokens=0,
+            keep_tokens_separator=None,
+            secondary_separator=None,
+            enable_wildcard=False,
+            color_aug=False,
+            flip_aug=False,
+            face_crop_aug_range=None,
+            random_crop=False,
+            caption_dropout_rate=0.0,
+            caption_dropout_every_n_epochs=0,
+            caption_tag_dropout_rate=0.0,
+            caption_prefix=None,
+            caption_suffix=None,
+            token_warmup_min=0,
+            token_warmup_step=0,
+            enable_fad=True,
+            fad_curriculum=True,
+        )
+
+        dataset = BaseDataset(
+            resolution=(512, 512),
+            network_multiplier=1.0,
+            train_inpainting=False,
+            debug_dataset=False,
+            enable_fad=True,
+            fad_curriculum=True,
+            fad_curriculum_start=0.1,
+            fad_curriculum_end=0.8,
+            fad_curriculum_beta=3.0,
+            fad_step_start=0.0,
+            fad_step_end=1.0,
+            fad_p_min=0.35,
+            fad_p_max=1.0,
+            fad_alpha=10.0,
+            fad_c=0.5,
+        )
+        dataset.batch_size = 1
+        dataset.subsets = [subset]
+
+        # Register 1 image
+        info = ImageInfo(
+            image_key="img",
+            num_repeats=1,
+            caption="trigger, cat",
+            is_reg=False,
+            absolute_path="/mock/img/dir/img.jpg",
+        )
+        info.image_size = (512, 512)
+        dataset.register_image(info, subset)
+        dataset.make_buckets()
+
+        # Set max training steps to 1000
+        dataset.set_max_train_steps(1000)
+
+        # 1. At step 50 (below warmup 0.1 * 1000 = 100)
+        # p_step should be fad_step_start = 0.0 by Eq. (7)
+        dataset.set_current_step(50)
+        
+        # We'll run process_caption multiple times to observe dropout rate for "cat"
+        # "cat" frequency is 1.0. 
+        # p_drop = 0.35 + 0.65 * sigmoid(10 * (1.0 - 0.5)) = 0.35 + 0.65 * sigmoid(5) = 0.35 + 0.65 * 0.9933 = 0.9956
+        # p_drop_final = p_drop * p_step = 0.9956 * 0.0 = 0
+        # Expectation of cat survival: 100%
+        survived = 0
+        for _ in range(500):
+            res = dataset.process_caption(subset, "trigger, cat")
+            if "cat" in res:
+                survived += 1
+        
+        survival_rate = survived / 500
+        self.assertEqual(survival_rate, 1.0, f"Survival rate: {survival_rate}")
+
+        # 2. At step 900 (above end 0.8 * 1000 = 800)
+        # p_step should be fad_step_end = 1.0 by Eq. (7)
+        # p_drop_final = 0.9956 * 1.0 = 0.9956
+        # Expectation of cat survival: near 0%
+        dataset.set_current_step(900)
+        survived = 0
+        for _ in range(500):
+            res = dataset.process_caption(subset, "trigger, cat")
+            if "cat" in res:
+                survived += 1
+        
+        survival_rate = survived / 500
+        self.assertTrue(0.0 <= survival_rate < 0.03, f"Survival rate: {survival_rate}")
+
+    def test_fad_makes_text_encoder_output_uncacheable(self):
+        subset = BaseSubset(
+            image_dir="/mock/img/dir",
+            alpha_mask=False,
+            num_repeats=1,
+            shuffle_caption=False,
+            caption_separator=",",
+            keep_tokens=0,
+            keep_tokens_separator=None,
+            secondary_separator=None,
+            enable_wildcard=False,
+            color_aug=False,
+            flip_aug=False,
+            face_crop_aug_range=None,
+            random_crop=False,
+            caption_dropout_rate=0.0,
+            caption_dropout_every_n_epochs=0,
+            caption_tag_dropout_rate=0.0,
+            caption_prefix=None,
+            caption_suffix=None,
+            token_warmup_min=0,
+            token_warmup_step=0,
+            enable_fad=True,
+            fad_curriculum=False,
+        )
+        dataset = BaseDataset(
+            resolution=(512, 512),
+            network_multiplier=1.0,
+            train_inpainting=False,
+            debug_dataset=False,
+            enable_fad=True,
+            fad_curriculum=False,
+        )
+        dataset.subsets = [subset]
+
+        self.assertFalse(dataset.is_text_encoder_output_cacheable(cache_supports_dropout=True))
+
+    def test_dataset_classes_accept_dataset_level_fad_params(self):
+        common_params = dict(
+            subsets=[],
+            batch_size=1,
+            resolution=(512, 512),
+            network_multiplier=1.0,
+            enable_bucket=False,
+            min_bucket_reso=256,
+            max_bucket_reso=1024,
+            bucket_reso_steps=64,
+            bucket_no_upscale=False,
+            train_inpainting=False,
+            debug_dataset=False,
+            validation_split=0.0,
+            validation_seed=None,
+            resize_interpolation=None,
+            skip_image_resolution=None,
+            enable_fad=True,
+            fad_curriculum=True,
+            fad_p_min=0.2,
+            fad_p_max=0.9,
+            fad_alpha=8.0,
+            fad_c=0.4,
+            fad_curriculum_start=0.2,
+            fad_curriculum_end=0.7,
+            fad_curriculum_beta=2.0,
+            fad_step_start=0.0,
+            fad_step_end=1.0,
+        )
+
+        dreambooth_dataset = DreamBoothDataset(is_training_dataset=True, prior_loss_weight=1.0, **common_params)
+        finetuning_dataset = FineTuningDataset(**common_params)
+        controlnet_dataset = ControlNetDataset(**common_params)
+
+        self.assertTrue(dreambooth_dataset.enable_fad)
+        self.assertTrue(finetuning_dataset.enable_fad)
+        self.assertTrue(controlnet_dataset.enable_fad)
+        self.assertEqual(dreambooth_dataset.fad_p_min, 0.2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
https://arxiv.org/abs/2603.27199

The previous branch added FAD options to the dataset config dataclasses, but the concrete DreamBooth, fine-tuning, and ControlNet dataset constructors did not accept those dataset-level parameters. As a result, normal dataset creation could fail before training started. The sFAD flag also defaulted to enabled through argparse, which made it difficult to opt out, and the step schedule used 0.1 to 0.8 instead of the paper's 0 to 1 scaling.

Wildcard frequency statistics were also estimated by random sampling, which made the per-subset token frequencies non-deterministic. Finally, FAD captions were still considered text-encoder-output cacheable, which could freeze a dynamic caption path.
