### PR TITLE
fix: restore tags-only caption handling in FineTuningDataset with enable_wildcard

### DIFF
--- a/library/finetuning_dataset.py
+++ b/library/finetuning_dataset.py
@@ -189,9 +189,11 @@ class FineTuningDataset(BaseDataset):
 
                     # add tags to each line of caption
                     if tags is not None:
-                        caption = "\n".join(
-                            [f"{line}{subset.caption_separator}{tags}" for line in caption.split("\n") if line.strip() != ""]
-                        )
+                        caption_lines = [line for line in caption.split("\n") if line.strip() != ""]
+                        if caption_lines:
+                            caption = "\n".join([f"{line}{subset.caption_separator}{tags}" for line in caption_lines])
+                        else:
+                            caption = tags  # no caption lines (e.g. tags-only metadata), use tags as is
                         tags_list.append(tags)
                 else:
                     # use as is


### PR DESCRIPTION
## Summary

Fixes #2388. When a FineTuning metadata file contains only `"tags"` (no `"caption"`) and the subset has `enable_wildcard = true`, tags were silently dropped, so captions reached `process_caption` empty and training ran effectively tagless.

## Root cause

In `library/finetuning_dataset.py`, when `caption` is absent it is set to `""`. In the `enable_wildcard` branch the caption is rebuilt by appending tags to each non-empty caption line:

```python
caption = "\n".join(
    [f"{line}{sep}{tags}" for line in caption.split("\n") if line.strip() != ""]
)
```

With an empty caption, `"".split("\n")` → `[""]`, the `line.strip() != ""` filter removes it → `[]`, and `"\n".join([])` → `""`. The tags are lost.

This is a regression from #2186 (`c6bc632`): the earlier code promoted `caption = tags; tags = None` when no caption was present, so tags-only metadata survived. That promotion was dropped during the JSONL rework.

`enable_wildcard = false` is unaffected — its branch already handles an empty caption correctly. The issue is not Anima-specific; any model using the standard JSON / JSONL FineTuning dataset with tags-only metadata + `enable_wildcard` is affected.

## Fix

Fall back to using `tags` as the caption when there are no non-empty caption lines. Existing multiline-caption + tags behavior is unchanged.

## Test

Verified by the reporter (kohya-ss): tags-only metadata, normal caption-present metadata, and the all-blank-lines case all behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
