### PR TITLE
fix: respect caption_separator when rejoining shuffled caption tokens

### DIFF
--- a/library/dataset.py
+++ b/library/dataset.py
@@ -592,7 +592,7 @@ class BaseDataset(torch.utils.data.Dataset):
 
                 flex_tokens = dropout_tags(flex_tokens)
 
-                caption = ", ".join(fixed_tokens + flex_tokens + fixed_suffix_tokens)
+                caption = f"{subset.caption_separator} ".join(fixed_tokens + flex_tokens + fixed_suffix_tokens)
 
             # process secondary separator
             if subset.secondary_separator:


### PR DESCRIPTION
Caption tokens were split using caption_separator but rejoined with a hard-coded ", ", so a custom caption_separator was lost whenever shuffle_caption / keep_tokens / tag dropout / token warmup was active.

Join with "{caption_separator} " to preserve backward compatibility for the default comma separator while respecting custom separators.

Fixes #1304