### PR TITLE
Fix caption token rejoining to respect custom caption_separator

### DIFF
--- a/library/dataset.py
+++ b/library/dataset.py
@@ -592,7 +592,7 @@ class BaseDataset(torch.utils.data.Dataset):
 
                 flex_tokens = dropout_tags(flex_tokens)
 
-                caption = ", ".join(fixed_tokens + flex_tokens + fixed_suffix_tokens)
+                caption = f"{subset.caption_separator} ".join(fixed_tokens + flex_tokens + fixed_suffix_tokens)
 
             # process secondary separator
             if subset.secondary_separator:


### PR DESCRIPTION
This pull request makes a small but important change to how captions are generated in the `dropout_tags` function. The update ensures that the caption uses the `caption_separator` defined in the `subset` object, rather than always using a comma.

* Changed the caption joining logic in `dropout_tags` to use `subset.caption_separator` instead of a hardcoded comma, allowing for customizable caption formatting.