### PR TITLE
[Fix] lora_flux: ValueError unpacking get_qkv_mlp_split_dims()[:3] on qkv-only path (#2220)

### DIFF
--- a/networks/lora_flux.py
+++ b/networks/lora_flux.py
@@ -909,7 +909,7 @@ class LoRANetwork(torch.nn.Module):
                             split_dims = None
                             if is_flux and split_qkv:
                                 if "double" in lora_name and "qkv" in lora_name:
-                                    (split_dims,) = self.get_qkv_mlp_split_dims()[:3]  # qkv only
+                                    split_dims = self.get_qkv_mlp_split_dims()[:3]  # qkv only
                                 elif "single" in lora_name and "linear1" in lora_name:
                                     split_dims = self.get_qkv_mlp_split_dims()  # qkv + mlp
 


### PR DESCRIPTION
## Motivation

`networks/lora_flux.py` raises `ValueError: too many values to unpack (expected 1)` on the qkv-only split path, reported in #2220.

## Root cause

Line 912 uses tuple unpacking on a 3-element slice:

```python
(split_dims,) = self.get_qkv_mlp_split_dims()[:3]  # qkv only
```

`get_qkv_mlp_split_dims()[:3]` returns a 3-element list, so unpacking it into the single target `(split_dims,)` fails. The other two call sites assign the slice directly (and are correct):

```python
split_dims = self.get_qkv_mlp_split_dims()[:3]  # qkv only   # lines 1047, 1103
```

## Modifications

`networks/lora_flux.py` (line 912): drop the tuple-unpacking parentheses/comma so the qkv-only branch matches the other two usages.

## Duplicate-check

- Track A — `gh api "search/issues?q=repo:kohya-ss/sd-scripts+is:pr+2220+in:body"` → no open PR references the issue.
- Track B — issue #2220 (state OPEN) has no comments and no in-progress claim.
