### PR TITLE
Add configurable LoRA-Squeeze training support

### DIFF
--- a/.ai/context/01-overview.md
+++ b/.ai/context/01-overview.md
@@ -23,6 +23,11 @@ The shared training utilities (formerly a single large `train_util.py`) are spli
 | `library/args.py` | All `add_*_arguments` parser registrations, `verify_*` validation, `read_config_from_file` |
 | `library/accelerator_setup.py` | `prepare_accelerator`, `prepare_dtype`, `HIGH_VRAM` flag |
 | `library/optimizer.py` | `get_optimizer` dispatcher (AdamW / 8-bit / Lion / DAdaptation / Prodigy / Adafactor / schedule-free), LR schedulers |
+| `library/lora_squeeze_schedule.py` | LoRA-Squeeze schedules, progress budgets, validation, and resume serialization |
+| `library/lora_squeeze_network.py` | LoRA-Squeeze network-facing protocols and standard Linear/Conv2d factor validation/replacement |
+| `library/lora_squeeze_compression.py` | LoRA-Squeeze protocol/network validation, optimizer parameter-layout validation, and SVD compression |
+| `library/lora_squeeze_optimizer.py` | Optimizer-specific LoRA-Squeeze state transformations |
+| `library/lora_squeeze_training.py` | LoRA-Squeeze runtime integration, training budgets, metadata/logging, optimizer/scheduler rebuilding, and Accelerate lifecycle |
 | `library/model_io.py` | Checkpoint loading (`load_target_model`), model hashes, safetensors metadata, SAI model spec |
 | `library/checkpoint_io.py` | Save / rotate checkpoints and train state (`save_sd_model_on_*`, filename templates) |
 | `library/loss.py` | Per-step loss building blocks: timestep sampling, noise, `conditional_loss` |

--- a/docs/lora_squeeze.md
+++ b/docs/lora_squeeze.md
@@ -1,0 +1,299 @@
+# LoRA-Squeeze training / LoRA-Squeeze学習
+
+LoRA-Squeeze trains a LoRA at a higher starting rank and compresses its effective weight update into progressively lower ranks during the same training run. The implementation uses the memory-efficient QR and core-SVD transformation described in [LoRA-Squeeze](https://arxiv.org/abs/2602.10993), without materializing the full model-sized weight update.
+
+The final `network_dim` and `network_alpha` remain the deployment rank and alpha. `lora_squeeze_start_dim` selects the higher initial training rank.
+
+The implementation follows sd-scripts' library boundaries: CLI registration is in `library/args.py`, scheduling and resume state are in `library/lora_squeeze_schedule.py`, network-facing factor protocols are in `library/lora_squeeze_network.py`, compression is in `library/lora_squeeze_compression.py`, optimizer mathematics are in `library/lora_squeeze_optimizer.py`, and runtime integration, metadata/logging, and Accelerate lifecycle handling are in `library/lora_squeeze_training.py`.
+
+<details>
+<summary>日本語</summary>
+
+LoRA-Squeezeは高い初期ランクでLoRAの学習を開始し、同じ学習実行中に有効な重み更新を段階的に低いランクへ圧縮します。この実装では、モデルと同じ大きさの重み更新全体を生成せず、[LoRA-Squeeze](https://arxiv.org/abs/2602.10993)で説明されているメモリ効率の良いQR分解とコアSVD変換を使用します。
+
+最終的な`network_dim`と`network_alpha`は、配布時に使用するランクとalphaです。`lora_squeeze_start_dim`で学習開始時の高いランクを指定します。
+
+実装はsd-scriptsのライブラリ境界に従っています。CLI引数は`library/args.py`、スケジュールと再開状態は`library/lora_squeeze_schedule.py`、ネットワーク側の因子プロトコルは`library/lora_squeeze_network.py`、圧縮処理は`library/lora_squeeze_compression.py`、オプティマイザの計算は`library/lora_squeeze_optimizer.py`、実行時統合・メタデータ・ログ・Accelerateのライフサイクル処理は`library/lora_squeeze_training.py`にあります。
+
+</details>
+
+## In-Squeeze example / In-Squeezeの例
+
+```toml
+network_dim = 8
+network_alpha = 4
+
+lora_squeeze_start_dim = 64
+lora_squeeze_num_squeezes = 3
+```
+
+This produces a `64 -> 32 -> 16 -> 8` rank schedule. The total configured `max_train_steps` is divided between the four rank stages, and training continues at rank 8 after the final squeeze.
+
+The default LoRA-Squeeze behavior is:
+
+- `lora_squeeze_rank_schedule = "geometric"`
+- `lora_squeeze_step_schedule = "equal"`
+- `lora_squeeze_train_after_final_squeeze = true`
+- `lora_squeeze_optimizer_mode = "per_squeeze"`
+- `lora_squeeze_scheduler_mode = "global"`
+- `lora_squeeze_alpha_schedule = "proportional"`
+- `lora_squeeze_first_segment_ratio = 1.0`
+- `lora_squeeze_final_segment_ratio = 1.0`
+
+<details>
+<summary>日本語</summary>
+
+上の設定では、ランクは`64 -> 32 -> 16 -> 8`の順に変化します。`max_train_steps`で設定した総ステップ数は4つのランク区間に配分され、最後の圧縮後もランク8で学習を続けます。
+
+LoRA-Squeezeのデフォルトは、ランク配置が`geometric`、ステップ配分が`equal`、最終圧縮後の学習が有効、オプティマイザが`per_squeeze`、スケジューラが`global`、alphaスケジュールが`proportional`、最初と最後の区間倍率がともに`1.0`です。
+
+</details>
+
+## Post-Squeeze and Cont-Squeeze / Post-SqueezeとCont-Squeeze
+
+Post-Squeeze trains at the source rank for the full training budget and performs one final compression before saving:
+
+```toml
+network_dim = 8
+network_alpha = 4
+lora_squeeze_start_dim = 64
+lora_squeeze_num_squeezes = 1
+lora_squeeze_train_after_final_squeeze = false
+```
+
+When no Accelerator state is requested, this terminal compression does not rebuild an optimizer or scheduler that can never take another step. It first switches optimizers such as schedule-free variants to their evaluation point so the compressed network matches the weights that sd-scripts would normally save. If `save_state` or `save_state_on_train_end` is enabled, the optimizer and scheduler are rebuilt so the terminal state remains loadable.
+
+Cont-Squeeze performs one compression and then continues training at the target rank:
+
+```toml
+network_dim = 8
+network_alpha = 4
+lora_squeeze_start_dim = 64
+lora_squeeze_num_squeezes = 1
+lora_squeeze_train_after_final_squeeze = true
+```
+
+<details>
+<summary>日本語</summary>
+
+Post-Squeezeでは、学習予算の全体を元のランクで学習し、保存直前に1回だけ圧縮します。Accelerator状態を保存しない場合、以後使われないオプティマイザとスケジューラは再構築しません。schedule-free系のオプティマイザは、sd-scriptsが通常保存する重みと一致するよう、先に評価時の点へ切り替えます。`save_state`または`save_state_on_train_end`を有効にした場合は、保存した状態を読み込めるようにオプティマイザとスケジューラも再構築します。
+
+Cont-Squeezeでは1回圧縮した後、ターゲットランクで学習を続けます。Post-Squeezeでは`lora_squeeze_train_after_final_squeeze = false`、Cont-Squeezeでは`true`を指定します。
+
+</details>
+
+## Rank and alpha schedules / ランクとalphaのスケジュール
+
+`lora_squeeze_rank_schedule` controls intermediate ranks:
+
+- `geometric` (default): approximately equal compression ratios.
+- `linear`: approximately equal rank differences.
+
+`lora_squeeze_alpha_schedule` controls pre-final-rank alpha values:
+
+- `proportional` (default): keeps the same `alpha / rank` ratio as the final target rank:
+
+```text
+network_alpha * r / network_dim
+```
+
+For example, if the final rank/alpha is `9/3`, proportional scheduling gives rank `45` an alpha of `15`.
+
+- `sqrt`: uses rank-stabilized square-root scaling. For a rank `r`, alpha is:
+
+```text
+network_alpha / sqrt(network_dim) * sqrt(r)
+```
+
+With the same final rank/alpha of `9/3`, square-root scheduling gives rank `45` an alpha of `sqrt(45)`, approximately `6.708`.
+
+Each compression operates on the scaled effective LoRA update. Singular values are split evenly between the new up and down factors, and the factors are adjusted for the new alpha/rank scale.
+
+The numerical rank is reported at every squeeze. If the target rank includes numerically zero singular directions, LoRA-Squeeze keeps the up factor at zero and initializes the corresponding down direction to a nonzero value. This leaves the effective update unchanged while allowing that channel to receive an up-factor gradient and recover during later training.
+
+<details>
+<summary>日本語</summary>
+
+`lora_squeeze_rank_schedule`は中間ランクの配置を制御します。`geometric`（デフォルト）は各段階の圧縮率をほぼ均等にし、`linear`はランク差をほぼ均等にします。
+
+`lora_squeeze_alpha_schedule`は最終ランクより前のalphaを制御します。`proportional`（デフォルト）は`alpha / rank`を最終ターゲットと同じ比率に保ち、`network_alpha * r / network_dim`で計算します。`sqrt`は`network_alpha / sqrt(network_dim) * sqrt(r)`を使用します。
+
+各圧縮はスケーリング後の有効なLoRA更新に対して実行されます。特異値は新しいup因子とdown因子へ均等に分配され、新しいalphaとランクのスケールに合わせて調整されます。各圧縮時には数値ランクも報告されます。ターゲットランクに数値的にゼロの特異方向が含まれる場合、有効な更新を変えずに後の学習で回復できるよう、up因子をゼロのままにして対応するdown方向を非ゼロで初期化します。
+
+</details>
+
+## Step distribution / ステップ配分
+
+`lora_squeeze_step_schedule` controls how the total training budget is divided:
+
+- `equal` (default): equal-length rank stages.
+- `rank_proportional`: more steps at larger ranks.
+- `sqrt_rank_proportional`: a milder preference for larger ranks.
+- `inverse_rank_proportional`: more steps at smaller ranks.
+- `inverse_sqrt_rank_proportional`: a milder preference for smaller ranks.
+
+`lora_squeeze_first_segment_ratio` multiplies the relative length of the initial, highest-rank training stage. When the final target rank has a training stage, `lora_squeeze_final_segment_ratio` multiplies the relative length of that final stage. Both ratios may be used together.
+
+<details>
+<summary>日本語</summary>
+
+`lora_squeeze_step_schedule`は総学習ステップを各ランク区間へ配分する方法を制御します。
+
+- `equal`（デフォルト）: 各ランク区間を同じ長さにします。
+- `rank_proportional`: 大きいランクにより多くのステップを配分します。
+- `sqrt_rank_proportional`: 大きいランクを優先しますが、差を緩やかにします。
+- `inverse_rank_proportional`: 小さいランクにより多くのステップを配分します。
+- `inverse_sqrt_rank_proportional`: 小さいランクを優先しますが、差を緩やかにします。
+
+`lora_squeeze_first_segment_ratio`は最初の高ランク区間の相対的な長さに掛ける倍率です。最終ターゲットランクにも学習区間がある場合、`lora_squeeze_final_segment_ratio`はその最後の区間に掛ける倍率です。両方を同時に使用できます。
+
+</details>
+
+## Optimizer and scheduler behavior / オプティマイザとスケジューラの動作
+
+`lora_squeeze_optimizer_mode` controls optimizer state across rank changes:
+
+- `per_squeeze` (default): rebuilds the optimizer with fresh state after each rank change. This is supported for every optimizer.
+- `global`: uses an optimizer-specific transfer policy. Gradient moments, parameter-space update buffers, parameter anchors, and optimizer-wide statistics are handled according to their different meanings. Unknown state is rejected before changing the network unless the optimizer has an explicitly documented coherent warm-restart policy below.
+
+Global mode currently requires every optimizer parameter to be a squeezeable `lora_down.weight` or `lora_up.weight` factor. Factors intentionally omitted through a zero learning rate are allowed. Additional trainable gates, biases, embeddings, or other parameters are rejected before training because their state cannot yet be continued safely across optimizer rebuilding. Factor group membership and ordering must also remain stable after every squeeze. `per_squeeze` mode intentionally resets state and does not have this restriction.
+
+Global mode currently supports:
+
+- PyTorch Adam-family, SGD, Adagrad, RMSprop, Adamax, Adadelta, and ASGD optimizers, plus `lion-pytorch` Lion.
+- bitsandbytes AdamW, SGD, and Lion variants used by sd-scripts. Block-wise 8-bit state is dequantized, projected, and requantized; 32-bit and paged variants use the same policy. Other bitsandbytes algorithms are rejected.
+- Adafactor. Its factored second moment is reconstructed, projected, and factored again, while its relative-step counter is preserved.
+- `AdamWScheduleFree`, `RAdamScheduleFree`, and `SGDScheduleFree`. Their auxiliary parameter point and averaging/warmup progress are preserved.
+- Prodigy. With `slice_p=1`, moments, the accumulated `s` statistic, the `p0` anchor, learned `d`, and step progress are continued. A sliced `slice_p>1` state cannot be inverted after rank mixing, so it uses a coherent warm restart: learned `d`/`d_max` are kept while moments and the estimator history restart together.
+- ProdigyPlusScheduleFree. Its fixed sliced Prodigy statistics, schedule-free point, and optional factored state cannot be transformed jointly. Global mode therefore performs the same kind of coherent warm restart, preserving each parameter group's learned `d` while restarting all coupled per-parameter and averaging state together.
+- D-Adaptation Adam, AdaGrad, Adan, AdanIP, Lion, and SGD variants. Their learned `d` is preserved and their algorithm-specific state and estimator totals are transformed consistently.
+
+Projecting a diagonal second moment through a rank-coordinate change is necessarily an approximation because the optimizer does not store cross-coordinate covariance. First moments and parameter-space displacements use their corresponding covector/vector transformations.
+
+In global mode, projected state is staged on CPU one module at a time. Once projection succeeds, the old optimizer state is moved to CPU and the replacement state is moved back beside its new parameters. This avoids retaining complete old and new optimizer-state copies on the GPU at the same time; if rebuilding fails, the original state and LoRA layers are restored. If CPU staging or offload itself fails, the transition is rolled back and retried once with optimizer state kept on the parameter devices, at the cost of higher peak VRAM usage.
+
+`lora_squeeze_scheduler_mode` controls an external LR scheduler independently:
+
+- `global` (default): continues one LR scheduler curve over the full training run.
+- `per_squeeze`: restarts the LR scheduler for each rank stage using that stage's configured step budget.
+
+For example, `lora_squeeze_optimizer_mode = "per_squeeze"` with `lora_squeeze_scheduler_mode = "global"` resets AdamW moments at each squeeze while preserving progress through a cosine LR curve. Global optimizer-mode logs include projected, warm-restarted, reset, and empty optimizer-state counts.
+
+Optimizers that own their learning-rate or averaging schedule cannot split these two lifecycles. Schedule-free optimizers, ProdigyPlusScheduleFree, and Adafactor with `relative_step=True` therefore require optimizer and scheduler mode to be equal: either both `global` or both `per_squeeze`. This is validated before training starts.
+
+<details>
+<summary>日本語</summary>
+
+`lora_squeeze_optimizer_mode`はランク変更前後のオプティマイザ状態を制御します。
+
+- `per_squeeze`（デフォルト）: ランク変更後に新しい状態でオプティマイザを再構築します。すべてのオプティマイザで使用できます。
+- `global`: オプティマイザ固有の変換方針で状態を引き継ぎます。勾配モーメント、パラメータ空間の更新バッファ、アンカー、オプティマイザ全体の統計は、それぞれの意味に応じて処理します。未知の状態はネットワークを変更する前に拒否します。ただし、下記の一貫したウォームリスタート方針が明記されている場合を除きます。
+
+`global`では、すべてのオプティマイザパラメータが圧縮可能な`lora_down.weight`または`lora_up.weight`である必要があります。学習率0によって意図的に除外した因子は使用できますが、追加のgate、bias、embeddingなどの学習パラメータは未対応です。圧縮後も因子のパラメータグループ構成と順序が同じでなければなりません。`per_squeeze`は状態をリセットするため、この制約はありません。
+
+`global`で現在対応しているオプティマイザは次のとおりです。
+
+- PyTorchのAdam系、SGD、Adagrad、RMSprop、Adamax、Adadelta、ASGD、および`lion-pytorch`のLion。
+- sd-scriptsで使用するbitsandbytesのAdamW、SGD、Lion系。block-wise 8-bit状態は逆量子化、射影、再量子化され、32-bit版とpaged版も同じ方針を使用します。
+- Adafactor。factor化された2次モーメントを復元して射影し、再度factor化します。relative-stepのカウンタは維持します。
+- `AdamWScheduleFree`、`RAdamScheduleFree`、`SGDScheduleFree`。補助パラメータ点と平均化・ウォームアップの進行を維持します。
+- Prodigy。`slice_p=1`ではmoments、累積`s`、`p0`アンカー、学習済み`d`、stepを引き継ぎます。`slice_p>1`はランク混合後に逆変換できないため、`d`と`d_max`を維持し、momentsと推定履歴をまとめて再開します。
+- ProdigyPlusScheduleFree。学習済み`d`を維持し、結合されたパラメータ別状態と平均化状態を一貫して再開します。
+- D-AdaptationのAdam、AdaGrad、Adan、AdanIP、Lion、SGD系。学習済み`d`を維持し、アルゴリズム固有の状態と推定値の合計を整合するよう変換します。
+
+対角2次モーメントの射影は、オプティマイザが座標間の共分散を保持しないため近似になります。1次モーメントとパラメータ空間の変位には、それぞれ共変ベクトルとベクトルに対応する変換を使用します。
+
+`global`では射影した状態をモジュール単位でCPUへ一時配置します。射影成功後、古い状態をCPUへ移し、新しい状態を新しいパラメータと同じデバイスへ戻します。これにより古い状態と新しい状態の完全なコピーが同時にGPUへ存在することを避けます。再構築に失敗した場合は元の状態とLoRA層を復元します。CPUへの一時配置またはoffloadに失敗した場合も変更を取り消し、ピークVRAMの増加を許容してパラメータのデバイス上で1回だけ再試行します。
+
+`lora_squeeze_scheduler_mode`は外部LRスケジューラを独立に制御します。`global`（デフォルト）は学習全体で1つの曲線を継続し、`per_squeeze`は各ランク区間のステップ数で曲線を再開します。たとえばオプティマイザを`per_squeeze`、スケジューラを`global`にすると、AdamWのmomentsは圧縮ごとにリセットされますがcosine LR曲線は継続します。
+
+学習率または平均化スケジュールをオプティマイザ自身が持つ場合、この2つのライフサイクルは分離できません。そのためschedule-free系、ProdigyPlusScheduleFree、および`relative_step=True`のAdafactorでは、オプティマイザとスケジューラのmodeを両方`global`または両方`per_squeeze`にする必要があります。この条件は学習開始前に検証されます。
+
+</details>
+
+## Network compatibility / ネットワーク互換性
+
+LoRA-Squeeze is enabled only for network modules that explicitly declare support through `validate_lora_squeeze_support(network_args)`. This check happens before datasets, models, or caches are loaded. The instantiated network then returns the squeezeable modules it owns through `get_lora_squeeze_modules()`. Each returned module implements `lora_squeeze_get_spec()`, `lora_squeeze_replace_factors()`, `lora_squeeze_snapshot()`, and `lora_squeeze_restore()`. The built-in supported modules are:
+
+- `networks.lora`
+- `networks.lora_anima`
+
+Other network modules must implement both the early declaration and the structural protocol. The standard protocol mixin accepts direct Linear/Linear or Conv2d/Conv2d factors and rejects grouped convolutions, bias, custom factor subclasses, hooks, parametrizations, mixed devices/dtypes, and frozen factors before training. A custom network may preserve different semantics in its own protocol implementation. Split-QKV or `ModuleList` LoRA factors, such as the current `networks.lora_flux`, `networks.lora_lumina`, `networks.lora_sd3`, and `networks.lora_hunyuan_image` modules, are not supported yet. LoRA-FA is not supported yet.
+
+All LoRA modules in the instantiated network must match the schedule's homogeneous current rank and alpha. `network_args` that create different ranks or alphas for different blocks, such as block-specific dim settings, are not supported.
+
+`network_weights` may be used only when the weight file's rank and alpha match the current LoRA-Squeeze rank and alpha. For a new run, the current rank is `lora_squeeze_start_dim`. For a resumed run, it is the rank recorded in the LoRA-Squeeze resume state after the completed squeezes, which may be lower than `lora_squeeze_start_dim`. `dim_from_weights` is not supported because `network_dim` is the final target rank.
+
+LoRA alpha scalars follow the standard LoRA serialization behavior. When `save_precision` stores factor weights in FP16 or BF16, alpha is stored in the same dtype. Loading restores the runtime alpha buffer to FP32, but a fractional alpha retains any rounding introduced by the save dtype. Metadata records the configured LoRA-Squeeze alpha, so a low-precision alpha tensor can differ slightly from the metadata value after saving. Use FP32 save precision when an exact fractional alpha must survive a save/load round trip.
+
+<details>
+<summary>日本語</summary>
+
+LoRA-Squeezeは、`validate_lora_squeeze_support(network_args)`で明示的に対応を宣言したネットワークモジュールでのみ有効にできます。この検証はデータセット、モデル、キャッシュを読み込む前に行われます。生成されたネットワークは`get_lora_squeeze_modules()`で所有する圧縮対象モジュールを返し、各モジュールは`lora_squeeze_get_spec()`、`lora_squeeze_replace_factors()`、`lora_squeeze_snapshot()`、`lora_squeeze_restore()`を実装します。組み込みで対応しているのは`networks.lora`と`networks.lora_anima`です。
+
+標準プロトコルmixinは、直接接続されたLinear/LinearまたはConv2d/Conv2d因子に対応します。grouped convolution、bias、独自の因子subclass、hook、parametrization、異なるdevice/dtype、凍結された因子は学習前に拒否します。独自ネットワークは別の意味を維持する独自プロトコルを実装できます。現在の`networks.lora_flux`、`networks.lora_lumina`、`networks.lora_sd3`、`networks.lora_hunyuan_image`のようなsplit-QKVまたは`ModuleList`形式、およびLoRA-FAは未対応です。
+
+生成されたネットワーク内のすべてのLoRAモジュールは、現在のスケジュールと同じランクとalphaを持つ必要があります。blockごとに異なるdimまたはalphaを作る`network_args`は使用できません。
+
+`network_weights`を使用する場合、重みファイルのランクとalphaは現在のLoRA-Squeezeのランクとalphaに一致する必要があります。新しい学習では現在のランクは`lora_squeeze_start_dim`です。再開時は、完了した圧縮後のLoRA-Squeeze再開状態に記録されたランクであり、`lora_squeeze_start_dim`より小さい場合があります。`network_dim`は最終ターゲットランクなので、`dim_from_weights`は使用できません。
+
+LoRAのalpha scalarは通常のLoRA保存動作に従います。`save_precision`で因子をFP16またはBF16として保存すると、alphaも同じdtypeで保存されます。読み込み時のalpha bufferはFP32へ戻りますが、小数alphaには保存dtypeによる丸めが残ります。正確な小数alphaを保存と読み込みの往復で維持する必要がある場合は、FP32の保存精度を使用してください。
+
+</details>
+
+## Resuming / 再開
+
+LoRA-Squeeze can resume from an Accelerator state directory saved with LoRA-Squeeze metadata in `train_state.json`. The same LoRA-Squeeze rank, alpha, optimizer mode, scheduler mode, segment options, and total `max_train_steps` budget must be used when resuming so the generated squeeze boundaries remain identical.
+
+When LoRA-Squeeze is active, the restored update step remains the canonical absolute training step. It controls future squeeze events, checkpoint filenames, sampling and validation cadence, tracker steps, and `ss_steps` metadata. The data-loader resume position is tracked separately as an epoch and batch offset.
+
+The absolute step also controls the remaining progress-bar length and training termination. A resumed run therefore performs only `max_train_steps - saved_step` further optimizer updates and cannot pass the configured LoRA-Squeeze budget, including with gradient accumulation.
+
+Without `skip_until_initial_step`, sd-scripts starts at the beginning of the saved step's current epoch, so some data can be replayed within the remaining update budget. With `skip_until_initial_step`, LoRA-Squeeze maps the saved optimizer step to the corresponding epoch and batch offset, including partial gradient-accumulation windows at epoch boundaries, and discards the preceding batches. This preserves the update budget and squeeze schedule, but a shuffled data loader is not guaranteed to reproduce the uninterrupted run's exact sample order or bit-identical final weights. A completed state may be loaded with the same `max_train_steps`; it exits without another update.
+
+<details>
+<summary>日本語</summary>
+
+LoRA-Squeezeは、`train_state.json`にLoRA-Squeezeメタデータを含むAccelerator状態ディレクトリから再開できます。再開時は同じLoRA-Squeezeランク、alpha、オプティマイザmode、スケジューラmode、区間設定、および`max_train_steps`の総予算を指定し、生成される圧縮境界を一致させる必要があります。
+
+復元したupdate stepは学習全体の絶対stepとして扱われ、今後の圧縮、checkpoint名、samplingとvalidationの周期、tracker step、`ss_steps`メタデータを制御します。data loaderの再開位置はepochとbatchのoffsetとして別に管理します。
+
+再開後に実行するoptimizer updateは`max_train_steps - saved_step`だけで、設定したLoRA-Squeeze予算を超えません。gradient accumulationを使用する場合も同じです。
+
+`skip_until_initial_step`を使用しない場合、sd-scriptsは保存stepを含むepochの先頭から開始するため、残りのupdate予算内で一部のデータが再度使われることがあります。有効にした場合は、保存したoptimizer stepを対応するepochとbatch offsetへ変換し、epoch境界の途中のgradient accumulationも考慮して先行batchを破棄します。update予算と圧縮スケジュールは維持されますが、shuffleされたdata loaderで中断なしの学習と完全に同じsample順やbit単位で同じ最終重みになる保証はありません。完了済みの状態を同じ`max_train_steps`で読み込むと、追加のupdateを行わず終了します。
+
+</details>
+
+## Current limitations / 現在の制限事項
+
+- Single-process training only.
+- DeepSpeed is not supported.
+- `initial_step` and `initial_epoch` are not supported.
+- `torch.compile` options are not supported.
+- LoRA layers must match one homogeneous scheduled current rank and alpha.
+- LoRA-C3Lier is supported when `conv_dim` equals the target `network_dim` and `conv_alpha` equals the target `network_alpha`. LoRA-Squeeze automatically uses the scheduled current rank and alpha for those convolutional layers while training and resuming.
+- Network arguments that create other separate per-module ranks or alphas, such as block dims or Anima regex dims, are not supported.
+- Supported factors are Linear/Linear and Conv2d/Conv2d pairs with a 1x1 `lora_up` convolution.
+
+<details>
+<summary>日本語</summary>
+
+- single-process学習のみ対応しています。
+- DeepSpeedは未対応です。
+- `initial_step`と`initial_epoch`は未対応です。
+- `torch.compile`関連のoptionは未対応です。
+- すべてのLoRA層は、スケジュールされた現在のランクとalphaに統一されている必要があります。
+- LoRA-C3Lierは、`conv_dim`がターゲット`network_dim`と等しく、`conv_alpha`がターゲット`network_alpha`と等しい場合に対応します。学習中と再開時は、convolution層にもスケジュールされた現在のランクとalphaを自動的に使用します。
+- block dimsやAnima regex dimsなど、モジュールごとに異なるランクまたはalphaを作るnetwork引数は未対応です。
+- 対応する因子はLinear/Linear、および1x1の`lora_up`を持つConv2d/Conv2dの組み合わせです。
+
+</details>
+
+LoRA-Squeeze schedule and progress information is written to model metadata and training logs. At a squeeze boundary, logs distinguish the rank/alpha used for the completed optimizer step (`train_dim`/`train_alpha`) from the newly installed current rank/alpha, and record transition statistics separately. Learning-rate and optimizer-derived LR metrics use one snapshot taken after the optimizer and scheduler steps and before the squeeze transition.
+
+<details>
+<summary>日本語</summary>
+
+LoRA-Squeezeのスケジュールと進行状況はモデルメタデータと学習ログへ保存されます。圧縮境界のログでは、完了したoptimizer stepで使用したランクとalpha（`train_dim` / `train_alpha`）を、新しく設定した現在のランクとalphaから区別し、遷移統計も別に記録します。learning rateおよびオプティマイザ由来のLR metricsには、optimizer stepとscheduler stepの後、圧縮遷移の前に取得した1つのsnapshotを使用します。
+
+</details>

--- a/docs/train_network.md
+++ b/docs/train_network.md
@@ -143,6 +143,7 @@ Next, we'll explain the main command-line arguments.
   * Specifies the rank (dimension) of LoRA. Higher values increase expressiveness but also increase file size and computational cost. Values between 4 and 128 are commonly used. There is no default (module dependent).
 * `--network_alpha=1`
   * Specifies the alpha value for LoRA. This parameter is related to learning rate scaling. It is generally recommended to set it to about half the value of `network_dim`, but it can also be the same value as `network_dim`. The default is 1. Setting it to the same value as `network_dim` will result in behavior similar to older versions.
+  * To train at a higher rank and progressively compress to `network_dim`, see [LoRA-Squeeze training](./lora_squeeze.md). Check that guide for supported network modules and rank-layout limitations.
 * `--network_args`
   * Used to specify additional parameters specific to the LoRA module. For example, to use Conv2d (3x3) LoRA (LoRA-C3Lier), specify the following in `--network_args`. Use `conv_dim` to specify the rank for Conv2d (3x3) and `conv_alpha` for alpha.
     ```
@@ -231,6 +232,7 @@ Next, we'll explain the main command-line arguments.
     *   LoRA のランク (rank / 次元数) を指定します。値が大きいほど表現力は増しますが、ファイルサイズと計算コストが増加します。一般的には 4〜128 程度の値が使われます。デフォルトは指定されていません（モジュール依存）。
 *   `--network_alpha=1`
     *   LoRA のアルファ値 (alpha) を指定します。学習率のスケーリングに関係するパラメータで、一般的には `network_dim` の半分程度の値を指定することが推奨されますが、`network_dim` と同じ値を指定する場合もあります。デフォルトは 1 です。`network_dim` と同じ値に設定すると、旧バージョンと同様の挙動になります。
+    *   高い rank から学習を開始し、`network_dim` まで段階的に圧縮する方法は [LoRA-Squeeze training](./lora_squeeze.md) を参照してください。対応する network module と rank 構成の制限も確認してください。
 
 * `--network_args`
     *   LoRA モジュールに特有の追加パラメータを指定するために使用します。例えば、Conv2d (3x3) の LoRA  (LoRA-C3Lier) を使用する場合は`--network_args` に以下のように指定してください。`conv_dim` で Conv2d (3x3) の rank を、`conv_alpha` で alpha を指定します。

--- a/library/accelerator_utils.py
+++ b/library/accelerator_utils.py
@@ -1,0 +1,143 @@
+"""Helpers for training extensions that replace prepared optimizer state."""
+
+from typing import Any, Optional, Tuple
+
+import torch
+from torch.optim.lr_scheduler import LRScheduler
+
+
+class ReplaceableOptimizer(torch.optim.Optimizer):
+    """Stable optimizer identity whose implementation can be replaced in place.
+
+    Accelerate registers this object once and wraps it normally. LoRA-Squeeze can
+    then rebuild the underlying optimizer without modifying Accelerate's private
+    prepared-object registries.
+    """
+
+    def __init__(self, optimizer: torch.optim.Optimizer):
+        self.optimizer = optimizer
+
+    @property
+    def state(self):
+        return self.optimizer.state
+
+    @state.setter
+    def state(self, state):
+        self.optimizer.state = state
+
+    @property
+    def param_groups(self):
+        return self.optimizer.param_groups
+
+    @param_groups.setter
+    def param_groups(self, param_groups):
+        self.optimizer.param_groups = param_groups
+
+    @property
+    def defaults(self):
+        return self.optimizer.defaults
+
+    @defaults.setter
+    def defaults(self, defaults):
+        self.optimizer.defaults = defaults
+
+    def replace(self, optimizer: torch.optim.Optimizer):
+        self.optimizer = optimizer
+
+    def add_param_group(self, param_group):
+        return self.optimizer.add_param_group(param_group)
+
+    def load_state_dict(self, state_dict):
+        return self.optimizer.load_state_dict(state_dict)
+
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def zero_grad(self, set_to_none=None):
+        if set_to_none is None:
+            return self.optimizer.zero_grad()
+        return self.optimizer.zero_grad(set_to_none=set_to_none)
+
+    def step(self, closure=None):
+        if closure is None:
+            return self.optimizer.step()
+        return self.optimizer.step(closure)
+
+    def train(self):
+        if hasattr(self.optimizer, "train"):
+            return self.optimizer.train()
+
+    def eval(self):
+        if hasattr(self.optimizer, "eval"):
+            return self.optimizer.eval()
+
+    def __getattr__(self, name: str):
+        if name == "optimizer":
+            raise AttributeError(name)
+        return getattr(self.optimizer, name)
+
+
+class ReplaceableLRScheduler(LRScheduler):
+    """Stable scheduler identity paired with :class:`ReplaceableOptimizer`."""
+
+    def __init__(self, scheduler: LRScheduler):
+        self.scheduler = scheduler
+
+    @property
+    def optimizer(self):
+        return self.scheduler.optimizer
+
+    @property
+    def _step_count(self):
+        return self.scheduler._step_count
+
+    @_step_count.setter
+    def _step_count(self, value):
+        self.scheduler._step_count = value
+
+    def replace(self, scheduler: LRScheduler):
+        self.scheduler = scheduler
+
+    def step(self, *args, **kwargs):
+        return self.scheduler.step(*args, **kwargs)
+
+    def get_last_lr(self):
+        return self.scheduler.get_last_lr()
+
+    def get_lr(self):
+        return self.scheduler.get_lr()
+
+    def state_dict(self):
+        return self.scheduler.state_dict()
+
+    def load_state_dict(self, state_dict):
+        return self.scheduler.load_state_dict(state_dict)
+
+    def __getattr__(self, name: str):
+        if name == "scheduler":
+            raise AttributeError(name)
+        return getattr(self.scheduler, name)
+
+
+def make_replaceable_optimizer_scheduler(
+    optimizer: torch.optim.Optimizer, scheduler: Any
+) -> Tuple[ReplaceableOptimizer, Any]:
+    """Wrap dynamic training objects before passing them to Accelerator.prepare."""
+
+    replaceable_optimizer = ReplaceableOptimizer(optimizer)
+    replaceable_scheduler = ReplaceableLRScheduler(scheduler) if isinstance(scheduler, LRScheduler) else scheduler
+    return replaceable_optimizer, replaceable_scheduler
+
+
+def find_replaceable_optimizer(optimizer: Any) -> Optional[ReplaceableOptimizer]:
+    if isinstance(optimizer, ReplaceableOptimizer):
+        return optimizer
+    wrapped = getattr(optimizer, "optimizer", None)
+    return wrapped if isinstance(wrapped, ReplaceableOptimizer) else None
+
+
+def find_replaceable_scheduler(scheduler: Any) -> Optional[ReplaceableLRScheduler]:
+    if isinstance(scheduler, ReplaceableLRScheduler):
+        return scheduler
+    wrapped = getattr(scheduler, "scheduler", None)
+    return wrapped if isinstance(wrapped, ReplaceableLRScheduler) else None

--- a/library/args.py
+++ b/library/args.py
@@ -16,6 +16,7 @@ import toml
 from huggingface_hub import hf_hub_download
 
 import library.huggingface_util as huggingface_util
+from library.lora_squeeze_schedule import LoRASqueezeSchedule
 from library.utils import setup_logging
 
 setup_logging()
@@ -174,6 +175,115 @@ def add_optimizer_arguments(parser: argparse.ArgumentParser):
         default=None,
         help="The minimum learning rate as a ratio of the initial learning rate for cosine with min lr scheduler and warmup decay scheduler"
         + " / 初期学習率の比率としての最小学習率を指定する、cosine with min lr と warmup decay スケジューラ で有効",
+    )
+
+
+def add_lora_squeeze_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--lora_squeeze_start_dim",
+        type=int,
+        default=None,
+        help=(
+            "initial LoRA rank for LoRA-Squeeze; --network_dim remains the final target rank"
+            " / LoRA-Squeezeの初期LoRAランク。--network_dimは最終ターゲットランクのままです"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_num_squeezes",
+        type=int,
+        default=0,
+        help=(
+            "number of scheduled LoRA-Squeeze rank reductions to perform"
+            " / LoRA-Squeezeで予定するランク削減の回数"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_train_after_final_squeeze",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "continue training for one final segment after squeezing to --network_dim"
+            " / --network_dimまで圧縮した後も最後の区間の学習を続けます"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_optimizer_mode",
+        type=str,
+        default="per_squeeze",
+        choices=LoRASqueezeSchedule.STATE_MODE_CHOICES,
+        help=(
+            "choose optimizer continuity across squeezes: global uses an optimizer-specific state transfer; "
+            "per_squeeze resets optimizer state for each rank segment"
+            " / 圧縮前後のオプティマイザ状態を選択します。globalはオプティマイザ固有の状態変換を行い、"
+            "per_squeezeはランク区間ごとにオプティマイザ状態をリセットします"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_scheduler_mode",
+        type=str,
+        default="global",
+        choices=LoRASqueezeSchedule.STATE_MODE_CHOICES,
+        help=(
+            "choose LR scheduler continuity across squeezes: global continues one training curve; "
+            "per_squeeze restarts the curve for each rank segment"
+            " / 圧縮前後のLRスケジューラ状態を選択します。globalは学習全体で1つの曲線を継続し、"
+            "per_squeezeはランク区間ごとに曲線を再開します"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_rank_schedule",
+        type=str,
+        default="geometric",
+        choices=LoRASqueezeSchedule.RANK_SCHEDULE_CHOICES,
+        help=(
+            "choose how intermediate LoRA-Squeeze ranks are spaced; linear uses equal rank differences, "
+            "geometric uses approximately equal compression ratios"
+            " / LoRA-Squeezeの中間ランクの配置方法。linearはランク差を均等にし、"
+            "geometricは圧縮率をほぼ均等にします"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_step_schedule",
+        type=str,
+        default="equal",
+        choices=LoRASqueezeSchedule.STEP_SCHEDULE_CHOICES,
+        help=(
+            "spread LoRA-Squeeze training steps by current rank; equal uses equal segments. "
+            "Use inverse modes to give smaller ranks more steps"
+            " / LoRA-Squeezeの学習ステップを現在のランクに応じて配分します。equalは各区間を均等にし、"
+            "inverse系は小さいランクにより多くのステップを割り当てます"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_alpha_schedule",
+        type=str,
+        default="proportional",
+        choices=LoRASqueezeSchedule.ALPHA_SCHEDULE_CHOICES,
+        help=(
+            "choose how pre-final-rank alpha values are derived: proportional keeps alpha/rank equal to the "
+            "final network_alpha/network_dim ratio; sqrt uses rank-stabilized sqrt(rank) scaling"
+            " / 最終ランク前のalphaの計算方法。proportionalはalpha/rankを最終network_alpha/network_dimと"
+            "同じ比率に保ち、sqrtはsqrt(rank)によるランク安定化スケーリングを使用します"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_first_segment_ratio",
+        type=float,
+        default=1.0,
+        help=(
+            "multiply the relative length of the initial high-rank training segment"
+            " / 最初の高ランク学習区間の相対的な長さに掛ける倍率"
+        ),
+    )
+    parser.add_argument(
+        "--lora_squeeze_final_segment_ratio",
+        type=float,
+        default=1.0,
+        help=(
+            "multiply the final post-squeeze training segment length when "
+            "--lora_squeeze_train_after_final_squeeze is used"
+            " / --lora_squeeze_train_after_final_squeeze使用時に、圧縮後の最後の学習区間の長さに掛ける倍率"
+        ),
     )
 
 
@@ -739,8 +849,16 @@ def get_sanitized_config_or_none(args: argparse.Namespace):
         "output_dir",
         "logging_dir",
     ]
+    lora_squeeze_enabled = (
+        getattr(args, "lora_squeeze_start_dim", None) is not None
+        or getattr(args, "lora_squeeze_num_squeezes", 0) > 0
+    )
     filtered_args = {}
     for k, v in vars(args).items():
+        # Keep ordinary tracker configurations identical to the pre-LoRA-Squeeze
+        # schema. The feature-specific defaults are useful only when enabled.
+        if not lora_squeeze_enabled and k.startswith("lora_squeeze_"):
+            continue
         # filter out sensitive values and convert to string if necessary
         if k not in sensitive_args + sensitive_path_args:
             # Accelerate values need to have type `bool`,`str`, `float`, `int`, or `None`.
@@ -1186,16 +1304,13 @@ def read_config_from_file(args: argparse.Namespace, parser: argparse.ArgumentPar
     return args
 
 
-def resume_from_local_or_hf_if_specified(accelerator, args):
+def get_resume_state_dir(args):
     if not args.resume:
-        return
+        return None
 
     if not args.resume_from_huggingface:
-        logger.info(f"resume training from local state: {args.resume}")
-        accelerator.load_state(args.resume)
-        return
+        return args.resume
 
-    logger.info(f"resume training from huggingface state: {args.resume}")
     repo_id = args.resume.split("/")[0] + "/" + args.resume.split("/")[1]
     path_in_repo = "/".join(args.resume.split("/")[2:])
     revision = None
@@ -1235,5 +1350,18 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
         raise ValueError(
             "No files found in the specified repo id/path/revision / 指定されたリポジトリID/パス/リビジョンにファイルが見つかりませんでした"
         )
-    dirname = os.path.dirname(results[0])
-    accelerator.load_state(dirname)
+    return os.path.dirname(results[0])
+
+
+def resume_from_local_or_hf_if_specified(accelerator, args, resume_state_dir=None):
+    if not args.resume:
+        return
+
+    if not args.resume_from_huggingface:
+        logger.info(f"resume training from local state: {args.resume}")
+    else:
+        logger.info(f"resume training from huggingface state: {args.resume}")
+
+    if resume_state_dir is None:
+        resume_state_dir = get_resume_state_dir(args)
+    accelerator.load_state(resume_state_dir)

--- a/library/lora_squeeze_compression.py
+++ b/library/lora_squeeze_compression.py
@@ -1,0 +1,367 @@
+"""LoRA-Squeeze validation, rank compression, and optimizer-state projection."""
+
+import math
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+from library.lora_squeeze_schedule import LoRASqueezeSchedule
+from library.lora_squeeze_optimizer import prepare_optimizer_state_transfer, stage_optimizer_state
+from library.lora_squeeze_network import LoRASqueezeModuleProtocol, LoRASqueezeModuleSpec
+
+
+def _require_protocol_method(owner: Any, method_name: str, owner_name: str):
+    method = getattr(owner, method_name, None)
+    if not callable(method):
+        raise ValueError(f"{owner_name} does not implement required LoRA-Squeeze method {method_name}()")
+    return method
+
+
+def _validate_protocol_spec(spec: LoRASqueezeModuleSpec, registered_parameter_ids: set[int]):
+    if not isinstance(spec, LoRASqueezeModuleSpec):
+        raise ValueError("lora_squeeze_get_spec() must return LoRASqueezeModuleSpec")
+    if (
+        spec.rank <= 0
+        or not math.isfinite(spec.alpha)
+        or not math.isfinite(spec.scale)
+        or spec.alpha <= 0
+        or spec.scale <= 0
+    ):
+        raise ValueError(f"{spec.name} returned invalid rank, alpha, or scale")
+    if not math.isclose(spec.scale, spec.alpha / spec.rank, rel_tol=1e-5, abs_tol=1e-8):
+        raise ValueError(f"{spec.name} returned inconsistent alpha/rank scaling")
+    if spec.up_2d.ndim != 2 or spec.down_2d.ndim != 2:
+        raise ValueError(f"{spec.name} must expose two-dimensional factor matrices")
+    if spec.up_2d.shape[1] != spec.rank or spec.down_2d.shape[0] != spec.rank:
+        raise ValueError(f"{spec.name} factor matrices do not match declared rank {spec.rank}")
+    if spec.up_2d.device != spec.down_2d.device or spec.up_2d.dtype != spec.down_2d.dtype:
+        raise ValueError(f"{spec.name} exposed factor matrices on different devices or with different dtypes")
+    if not torch.isfinite(spec.up_2d).all() or not torch.isfinite(spec.down_2d).all():
+        raise ValueError(f"{spec.name} exposed non-finite LoRA factors")
+    if spec.up_parameter.numel() != spec.up_2d.numel() or spec.down_parameter.numel() != spec.down_2d.numel():
+        raise ValueError(f"{spec.name} factor parameters do not match exposed matrices")
+    if spec.up_parameter.ndim < 2 or spec.down_parameter.ndim < 2:
+        raise ValueError(f"{spec.name} factor parameters must have matrix-compatible layouts")
+    up_layout = (spec.up_parameter.shape[0], spec.up_parameter.numel() // spec.up_parameter.shape[0])
+    down_layout = (spec.down_parameter.shape[0], spec.down_parameter.numel() // spec.down_parameter.shape[0])
+    if up_layout != tuple(spec.up_2d.shape) or down_layout != tuple(spec.down_2d.shape):
+        raise ValueError(f"{spec.name} factor parameter layouts do not match exposed matrices")
+    if not spec.up_parameter.requires_grad or not spec.down_parameter.requires_grad:
+        raise ValueError(f"{spec.name} exposed frozen factor parameters")
+    if id(spec.up_parameter) not in registered_parameter_ids or id(spec.down_parameter) not in registered_parameter_ids:
+        raise ValueError(f"{spec.name} exposed factor parameters that are not registered on the network")
+
+
+def get_lora_squeeze_modules(network: torch.nn.Module) -> List[LoRASqueezeModuleProtocol]:
+    provider = _require_protocol_method(network, "get_lora_squeeze_modules", network.__class__.__name__)
+    modules = list(provider())
+    if not modules:
+        raise ValueError("LoRA-Squeeze network protocol returned no modules")
+    if len({id(module) for module in modules}) != len(modules):
+        raise ValueError("LoRA-Squeeze network protocol returned duplicate modules")
+    registered_parameter_ids = {id(parameter) for parameter in network.parameters()}
+    for module in modules:
+        if not isinstance(module, nn.Module):
+            raise ValueError("LoRA-Squeeze network protocol must return torch.nn.Module instances")
+        name = str(getattr(module, "lora_name", module.__class__.__name__))
+        _require_protocol_method(module, "lora_squeeze_get_spec", name)
+        _require_protocol_method(module, "lora_squeeze_replace_factors", name)
+        _require_protocol_method(module, "lora_squeeze_snapshot", name)
+        _require_protocol_method(module, "lora_squeeze_restore", name)
+        _validate_protocol_spec(module.lora_squeeze_get_spec(), registered_parameter_ids)
+    return modules
+
+
+def preserve_lora_squeeze_alpha_precision(network: torch.nn.Module) -> int:
+    preserved = 0
+    for module in get_lora_squeeze_modules(network):
+        preserve = getattr(module, "lora_squeeze_preserve_alpha_precision", None)
+        if callable(preserve):
+            preserve()
+            preserved += 1
+    return preserved
+
+
+def validate_lora_squeeze_optimizer_parameters(
+    network: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+):
+    modules = get_lora_squeeze_modules(network)
+    factor_parameters: Dict[int, str] = {}
+    for module_index, module in enumerate(modules):
+        spec = module.lora_squeeze_get_spec()
+        named_factors = (
+            (spec.up_parameter, f"{module_index}:{spec.name}.lora_up.weight"),
+            (spec.down_parameter, f"{module_index}:{spec.name}.lora_down.weight"),
+        )
+        for parameter, factor_name in named_factors:
+            if id(parameter) in factor_parameters:
+                raise ValueError(
+                    "LoRA-Squeeze global optimizer mode found a factor parameter shared by multiple protocol roles: "
+                    f"{factor_parameters[id(parameter)]} and {factor_name}"
+                )
+            factor_parameters[id(parameter)] = factor_name
+
+    raw_optimizer = getattr(optimizer, "optimizer", optimizer)
+    optimizer_parameters = [parameter for group in raw_optimizer.param_groups for parameter in group["params"]]
+    optimizer_parameter_ids = [id(parameter) for parameter in optimizer_parameters]
+    if len(set(optimizer_parameter_ids)) != len(optimizer_parameter_ids):
+        raise ValueError("LoRA-Squeeze global optimizer mode found duplicate parameters in optimizer groups")
+
+    named_parameters = {id(parameter): name for name, parameter in network.named_parameters()}
+    unexpected = [
+        named_parameters.get(id(parameter), f"unnamed parameter {tuple(parameter.shape)}")
+        for parameter in optimizer_parameters
+        if id(parameter) not in factor_parameters
+    ]
+    if unexpected:
+        raise ValueError(
+            "LoRA-Squeeze global optimizer mode requires every optimizer parameter to be a LoRA squeeze factor; "
+            "non-factor optimizer parameters: " + ", ".join(unexpected[:8]) + ". Use per_squeeze optimizer mode."
+        )
+
+
+def get_lora_squeeze_optimizer_parameter_layout(
+    network: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+) -> Tuple[Tuple[str, ...], ...]:
+    validate_lora_squeeze_optimizer_parameters(network, optimizer)
+    factor_parameters: Dict[int, str] = {}
+    for module_index, module in enumerate(get_lora_squeeze_modules(network)):
+        spec = module.lora_squeeze_get_spec()
+        factor_parameters[id(spec.up_parameter)] = f"{module_index}:{spec.name}.lora_up.weight"
+        factor_parameters[id(spec.down_parameter)] = f"{module_index}:{spec.name}.lora_down.weight"
+    raw_optimizer = getattr(optimizer, "optimizer", optimizer)
+    return tuple(
+        tuple(factor_parameters[id(parameter)] for parameter in group["params"])
+        for group in raw_optimizer.param_groups
+    )
+
+
+def validate_lora_squeeze_network(network: torch.nn.Module, schedule: LoRASqueezeSchedule) -> Dict[str, float]:
+    modules = get_lora_squeeze_modules(network)
+    specs = [module.lora_squeeze_get_spec() for module in modules]
+    source_ranks = {spec.rank for spec in specs}
+    if len(source_ranks) != 1:
+        raise ValueError(f"LoRA-Squeeze requires a homogeneous current rank, found ranks: {sorted(source_ranks)}")
+    source_rank = next(iter(source_ranks))
+    if schedule.enabled and source_rank != schedule.current_dim:
+        raise ValueError(
+            f"LoRA-Squeeze expected all LoRA modules to have current rank {schedule.current_dim}, "
+            f"but found rank {source_rank}. Check --network_args, --network_weights, and resume state."
+        )
+    if schedule.enabled:
+        mismatched_alphas = [
+            f"{spec.name}={spec.alpha:.8g}"
+            for spec in specs
+            if not math.isclose(spec.alpha, schedule.current_alpha, rel_tol=1e-5, abs_tol=1e-8)
+        ]
+        if mismatched_alphas:
+            raise ValueError(
+                f"LoRA-Squeeze expected every LoRA module to have current alpha {schedule.current_alpha:.8g}, "
+                "but found: " + ", ".join(mismatched_alphas[:8])
+            )
+    if schedule.enabled:
+        future_ranks = schedule.ranks[schedule.completed_squeezes + 1 :]
+        invalid_targets = [rank for rank in future_ranks if rank >= source_rank]
+        if invalid_targets:
+            raise ValueError(
+                f"LoRA-Squeeze target ranks must be less than current rank {source_rank}, found: {invalid_targets}"
+            )
+    return {"modules": float(len(modules)), "source_rank": float(source_rank)}
+
+
+def get_lora_factor_matrices(module: LoRASqueezeModuleProtocol):
+    spec = module.lora_squeeze_get_spec()
+    return spec.up_2d, spec.down_2d, spec.kind
+
+
+def compact_lora_product(
+    up_2d: torch.Tensor,
+    down_2d: torch.Tensor,
+    old_scale: float,
+    target_dim: int,
+    target_alpha: float,
+    build_optimizer_projections: bool = False,
+):
+    """Compress a scaled LoRA product through its rank-sized interaction core."""
+    a = up_2d
+    b = down_2d * old_scale
+    qa, ra = torch.linalg.qr(a, mode="reduced")
+    qb, rb = torch.linalg.qr(b.T, mode="reduced")
+    core = ra @ rb.T
+    u_core, singular_values, vh_core = torch.linalg.svd(core, full_matrices=False)
+
+    usable_dim = min(target_dim, singular_values.numel())
+    kept = singular_values[:usable_dim].clamp_min(0)
+    factor_scale = math.sqrt(target_dim / target_alpha)
+    sqrt_s = torch.sqrt(kept)
+    largest = singular_values.max() if singular_values.numel() > 0 else singular_values.new_zeros(())
+    tolerance = max(up_2d.shape[0], down_2d.shape[1]) * torch.finfo(singular_values.dtype).eps * largest
+    retained_active_mask = kept > tolerance
+    numerical_rank = int((singular_values > tolerance).sum().item())
+    revived_rank_mask = torch.ones(target_dim, device=ra.device, dtype=torch.bool)
+    revived_rank_mask[:usable_dim] = ~retained_active_mask
+
+    new_up_core = torch.zeros((ra.shape[0], target_dim), device=ra.device, dtype=ra.dtype)
+    new_down_core = torch.zeros((target_dim, rb.shape[0]), device=rb.device, dtype=rb.dtype)
+    if retained_active_mask.any():
+        active_indices = torch.nonzero(retained_active_mask, as_tuple=False).flatten()
+        active_scales = sqrt_s[active_indices] * factor_scale
+        new_up_core[:, active_indices] = u_core[:, active_indices] * active_scales.unsqueeze(0)
+        new_down_core[active_indices, :] = active_scales.unsqueeze(1) * vh_core[active_indices, :]
+
+    if revived_rank_mask.any():
+        active_factor_norms = sqrt_s[retained_active_mask] * factor_scale
+        old_down_norms = down_2d.norm(dim=1)
+        if active_factor_norms.numel() > 0:
+            revival_norm = active_factor_norms.median()
+        elif old_down_norms.numel() > 0:
+            revival_norm = old_down_norms.median()
+        else:
+            revival_norm = down_2d.new_tensor(1.0)
+        if not torch.isfinite(revival_norm) or revival_norm <= 0:
+            revival_norm = down_2d.new_tensor(1.0)
+        for revived_index in torch.nonzero(revived_rank_mask, as_tuple=False).flatten().tolist():
+            if revived_index < usable_dim:
+                direction = vh_core[revived_index]
+            else:
+                direction = torch.zeros(rb.shape[0], device=rb.device, dtype=rb.dtype)
+                direction[revived_index % rb.shape[0]] = 1.0
+            new_down_core[revived_index] = direction * revival_norm
+
+    new_up_2d = qa @ new_up_core
+    new_down_2d = new_down_core @ qb.T
+    up_grad_projection = None
+    down_grad_projection = None
+    if build_optimizer_projections:
+        new_scale = target_alpha / target_dim
+        up_grad_projection = new_scale * torch.linalg.pinv(rb) @ new_down_core.T
+        down_grad_projection = (new_scale / old_scale) * (torch.linalg.pinv(ra) @ new_up_core).T
+        if not torch.isfinite(up_grad_projection).all() or not torch.isfinite(down_grad_projection).all():
+            raise ValueError("LoRA-Squeeze optimizer-state projection produced non-finite values")
+    return (
+        new_up_2d,
+        singular_values,
+        new_down_2d,
+        up_grad_projection,
+        down_grad_projection,
+        numerical_rank,
+        revived_rank_mask,
+    )
+
+
+def snapshot_lora_module_layers(network: torch.nn.Module) -> List[Tuple[LoRASqueezeModuleProtocol, Any]]:
+    return [(module, module.lora_squeeze_snapshot()) for module in get_lora_squeeze_modules(network)]
+
+
+def restore_lora_module_layers(snapshots: List[Tuple[LoRASqueezeModuleProtocol, Any]]):
+    for module, snapshot in snapshots:
+        module.lora_squeeze_restore(snapshot)
+
+
+def squeeze_lora_network(
+    network: torch.nn.Module,
+    target_dim: int,
+    target_alpha: float,
+    optimizer_for_state_transfer: Optional[torch.optim.Optimizer] = None,
+    optimizer_state_staging_device: Optional[Union[str, torch.device]] = None,
+) -> Tuple[Dict[str, float], List[Tuple[torch.nn.Parameter, Dict[str, Any]]]]:
+    modules = get_lora_squeeze_modules(network)
+    source_ranks = {module.lora_squeeze_get_spec().rank for module in modules}
+    if len(source_ranks) != 1:
+        raise ValueError(f"LoRA-Squeeze requires a homogeneous current rank, found ranks: {sorted(source_ranks)}")
+    source_rank = next(iter(source_ranks))
+    if target_dim >= source_rank:
+        raise ValueError(f"LoRA-Squeeze target rank {target_dim} must be less than current rank {source_rank}")
+    optimizer_state_adapter = (
+        prepare_optimizer_state_transfer(optimizer_for_state_transfer)
+        if optimizer_for_state_transfer is not None
+        else None
+    )
+
+    retained_energies: List[float] = []
+    numerical_ranks: List[int] = []
+    revived_rank_channels = 0
+    rank_deficient_modules = 0
+    transfers: List[Tuple[torch.nn.Parameter, Dict[str, Any]]] = []
+    state_counts = {"projected": 0, "reset": 0, "empty": 0, "warm_restarted": 0}
+    with torch.no_grad():
+        for module in modules:
+            old_spec = module.lora_squeeze_get_spec()
+            (
+                new_up_2d,
+                singular_values,
+                new_down_2d,
+                up_projection,
+                down_projection,
+                numerical_rank,
+                revived_rank_mask,
+            ) = compact_lora_product(
+                old_spec.up_2d,
+                old_spec.down_2d,
+                old_spec.scale,
+                target_dim,
+                target_alpha,
+                build_optimizer_projections=optimizer_for_state_transfer is not None,
+            )
+            usable_dim = min(target_dim, singular_values.numel())
+            kept = singular_values[:usable_dim].clamp_min(0)
+            total_energy = torch.sum(singular_values * singular_values).item()
+            kept_energy = torch.sum(kept * kept).item()
+            retained_energies.append(1.0 if total_energy == 0.0 else kept_energy / total_energy)
+            numerical_ranks.append(numerical_rank)
+            revived_count = int(revived_rank_mask.sum().item())
+            revived_rank_channels += revived_count
+            rank_deficient_modules += int(revived_count > 0)
+
+            module.lora_squeeze_replace_factors(new_up_2d, new_down_2d, target_dim, target_alpha)
+            new_spec = module.lora_squeeze_get_spec()
+            _validate_protocol_spec(new_spec, {id(parameter) for parameter in network.parameters()})
+            if new_spec.rank != target_dim or not math.isclose(
+                new_spec.alpha, target_alpha, rel_tol=1e-5, abs_tol=1e-8
+            ):
+                raise ValueError(
+                    f"{new_spec.name} did not install the requested LoRA-Squeeze rank/alpha: "
+                    f"{new_spec.rank}/{new_spec.alpha:.8g} != {target_dim}/{target_alpha:.8g}"
+                )
+            if optimizer_state_adapter is not None:
+                new_up_state, up_status = optimizer_state_adapter.project_parameter_state(
+                    old_spec.up_parameter, new_spec.up_parameter, up_projection, "up"
+                )
+                new_up_state = stage_optimizer_state(new_up_state, optimizer_state_staging_device)
+                new_down_state, down_status = optimizer_state_adapter.project_parameter_state(
+                    old_spec.down_parameter, new_spec.down_parameter, down_projection, "down"
+                )
+                new_down_state = stage_optimizer_state(new_down_state, optimizer_state_staging_device)
+                for status in (up_status, down_status):
+                    if status == "projected":
+                        state_counts["projected"] += 1
+                    elif status == "empty":
+                        state_counts["empty"] += 1
+                    elif status.startswith("warm_restart:"):
+                        state_counts["warm_restarted"] += 1
+                    else:
+                        state_counts["reset"] += 1
+                transfers.append((new_spec.up_parameter, new_up_state))
+                transfers.append((new_spec.down_parameter, new_down_state))
+
+    return (
+        {
+            "modules": float(len(modules)),
+            "source_rank": float(source_rank),
+            "target_rank": float(target_dim),
+            "retained_energy_min": min(retained_energies),
+            "retained_energy_mean": sum(retained_energies) / len(retained_energies),
+            "numerical_rank_min": float(min(numerical_ranks)),
+            "numerical_rank_mean": float(sum(numerical_ranks) / len(numerical_ranks)),
+            "rank_deficient_modules": float(rank_deficient_modules),
+            "revived_rank_channels": float(revived_rank_channels),
+            "optimizer_state_projected": float(state_counts["projected"]),
+            "optimizer_state_reset": float(state_counts["reset"]),
+            "optimizer_state_empty": float(state_counts["empty"]),
+            "optimizer_state_warm_restarted": float(state_counts["warm_restarted"]),
+        },
+        transfers,
+    )

--- a/library/lora_squeeze_network.py
+++ b/library/lora_squeeze_network.py
@@ -1,0 +1,311 @@
+"""Network-facing LoRA-Squeeze protocols and standard factor implementation."""
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Protocol
+
+import torch
+import torch.nn as nn
+
+
+@dataclass(frozen=True)
+class LoRASqueezeModuleSpec:
+    """The factor data exposed by a network-owned squeeze module."""
+
+    name: str
+    rank: int
+    alpha: float
+    scale: float
+    kind: str
+    up_2d: torch.Tensor
+    down_2d: torch.Tensor
+    up_parameter: torch.nn.Parameter
+    down_parameter: torch.nn.Parameter
+
+
+class LoRASqueezeModuleProtocol(Protocol):
+    def lora_squeeze_get_spec(self) -> LoRASqueezeModuleSpec: ...
+
+    def lora_squeeze_replace_factors(
+        self,
+        up_2d: torch.Tensor,
+        down_2d: torch.Tensor,
+        target_dim: int,
+        target_alpha: float,
+    ) -> None: ...
+
+    def lora_squeeze_snapshot(self) -> Any: ...
+
+    def lora_squeeze_restore(self, snapshot: Any) -> None: ...
+
+
+class LoRASqueezeNetworkProtocol(Protocol):
+    def get_lora_squeeze_modules(self) -> Iterable[LoRASqueezeModuleProtocol]: ...
+
+
+def validate_lora_squeeze_network_module(network_module: Any, network_args: Dict[str, Any]):
+    """Require an explicit, early compatibility contract from a network module."""
+    validator = getattr(network_module, "validate_lora_squeeze_support", None)
+    if not callable(validator):
+        module_name = getattr(network_module, "__name__", network_module.__class__.__name__)
+        raise ValueError(
+            f"LoRA-Squeeze is not supported by {module_name}: the network module does not implement "
+            "validate_lora_squeeze_support(network_args)"
+        )
+    validator(dict(network_args))
+
+
+def _factor_layer_has_hooks(layer: nn.Module) -> bool:
+    hook_attributes = (
+        "_forward_pre_hooks",
+        "_forward_hooks",
+        "_backward_pre_hooks",
+        "_backward_hooks",
+    )
+    return any(bool(getattr(layer, attribute, None)) for attribute in hook_attributes)
+
+
+def _validate_standard_factor_layer(layer: nn.Module, name: str, role: str):
+    if type(layer) not in (nn.Linear, nn.Conv2d):
+        raise ValueError(
+            f"{name} has unsupported {role} type {type(layer).__name__}; "
+            "custom factor layers must implement their own LoRA-Squeeze protocol methods"
+        )
+    if layer.bias is not None:
+        raise ValueError(f"{name} has a biased {role}; standard LoRA-Squeeze factors must be bias-free")
+    if torch.nn.utils.parametrize.is_parametrized(layer):
+        raise ValueError(f"{name} has a parametrized {role}; replacement would discard its parametrization")
+    if _factor_layer_has_hooks(layer):
+        raise ValueError(f"{name} has hooks attached to {role}; replacement would discard those hooks")
+    if not layer.weight.requires_grad:
+        raise ValueError(f"{name} has a frozen {role} factor; LoRA-Squeeze requires trainable factors")
+
+
+def _get_device_rng_state(device: torch.device) -> Optional[torch.Tensor]:
+    if device.type == "cuda" and torch.cuda.is_available():
+        return torch.cuda.get_rng_state(device)
+    if device.type == "xpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
+        return torch.xpu.get_rng_state(device)
+    return None
+
+
+def _set_device_rng_state(device: torch.device, state: Optional[torch.Tensor]):
+    if state is None:
+        return
+    if device.type == "cuda":
+        torch.cuda.set_rng_state(state, device)
+    elif device.type == "xpu" and hasattr(torch, "xpu"):
+        torch.xpu.set_rng_state(state, device)
+
+
+class StandardLoRASqueezeModuleMixin:
+    """Protocol implementation for sd-scripts' ordinary Linear/Conv2d LoRA."""
+
+    @staticmethod
+    def _stored_alpha_matches_runtime_scale(alpha: Any, effective_alpha: float) -> bool:
+        if isinstance(alpha, torch.Tensor):
+            if alpha.numel() != 1:
+                return False
+            stored_alpha = float(alpha.detach().float().item())
+            if not math.isfinite(stored_alpha):
+                return False
+            if torch.is_floating_point(alpha):
+                serialized_dtypes = (alpha.dtype, torch.float16, torch.bfloat16)
+                for dtype in serialized_dtypes:
+                    expected = torch.tensor(effective_alpha, dtype=dtype)
+                    expected_alpha = float(expected.detach().float().item())
+                    if stored_alpha == expected_alpha:
+                        return True
+                return False
+            return stored_alpha == effective_alpha
+        return math.isclose(float(alpha), effective_alpha, rel_tol=1e-7, abs_tol=1e-8)
+
+    def lora_squeeze_get_spec(self) -> LoRASqueezeModuleSpec:
+        name = str(getattr(self, "lora_name", self.__class__.__name__))
+        if not hasattr(self, "lora_down") or not hasattr(self, "lora_up"):
+            raise ValueError(f"{name} must have both lora_down and lora_up")
+
+        down = self.lora_down
+        up = self.lora_up
+        _validate_standard_factor_layer(down, name, "lora_down")
+        _validate_standard_factor_layer(up, name, "lora_up")
+        if isinstance(down, nn.Linear) != isinstance(up, nn.Linear):
+            raise ValueError(f"{name} mixes Linear and Conv2d LoRA factors")
+        if down.weight.device != up.weight.device or down.weight.dtype != up.weight.dtype:
+            raise ValueError(f"{name} has LoRA factors on different devices or with different dtypes")
+
+        if isinstance(down, nn.Linear):
+            rank = int(down.out_features)
+            if up.in_features != rank:
+                raise ValueError(f"{name} lora_up input features do not match rank: {up.in_features} != {rank}")
+            up_2d = up.weight.detach().float()
+            down_2d = down.weight.detach().float()
+            kind = "linear"
+        else:
+            if down.groups != 1 or up.groups != 1:
+                raise ValueError(
+                    f"{name} uses grouped LoRA convolutions, which require a custom squeeze implementation"
+                )
+            if tuple(up.kernel_size) != (1, 1):
+                raise ValueError(f"{name} has unsupported lora_up kernel size: {tuple(up.kernel_size)}")
+            if tuple(up.stride) != (1, 1) or tuple(up.padding) != (0, 0) or tuple(up.dilation) != (1, 1):
+                raise ValueError(f"{name} has non-standard lora_up convolution semantics")
+            rank = int(down.out_channels)
+            if up.in_channels != rank:
+                raise ValueError(f"{name} lora_up input channels do not match rank: {up.in_channels} != {rank}")
+            up_2d = up.weight.detach().float()[:, :, 0, 0]
+            down_2d = down.weight.detach().float().reshape(rank, -1)
+            kind = "conv2d"
+
+        if rank <= 0:
+            raise ValueError(f"{name} has invalid LoRA rank: {rank}")
+        stored_alpha = getattr(self, "alpha", rank)
+        if isinstance(stored_alpha, torch.Tensor):
+            if stored_alpha.numel() != 1:
+                raise ValueError(f"{name} has a non-scalar LoRA alpha buffer")
+            stored_alpha_value = float(stored_alpha.detach().float().item())
+        else:
+            stored_alpha_value = float(stored_alpha)
+        scale = getattr(self, "scale", stored_alpha_value / rank)
+        if isinstance(scale, torch.Tensor):
+            scale = float(scale.detach().float().item())
+        else:
+            scale = float(scale)
+        effective_alpha = scale * rank
+        if not self._stored_alpha_matches_runtime_scale(stored_alpha, effective_alpha):
+            raise ValueError(
+                f"{name} has inconsistent LoRA alpha/scale values: scale={scale:.8g}, "
+                f"serialized_alpha/rank={stored_alpha_value / rank:.8g}. "
+                "Check --network_weights alpha compatibility."
+            )
+
+        return LoRASqueezeModuleSpec(
+            name=name,
+            rank=rank,
+            alpha=effective_alpha,
+            scale=scale,
+            kind=kind,
+            up_2d=up_2d,
+            down_2d=down_2d,
+            up_parameter=up.weight,
+            down_parameter=down.weight,
+        )
+
+    def lora_squeeze_preserve_alpha_precision(self):
+        if "alpha" not in getattr(self, "_buffers", {}):
+            return
+        alpha = self._buffers["alpha"]
+        if alpha is None:
+            return
+        spec = self.lora_squeeze_get_spec()
+        self._buffers["alpha"] = torch.tensor(spec.alpha, device=alpha.device, dtype=torch.float32)
+
+    def lora_squeeze_snapshot(self) -> Dict[str, Any]:
+        return {
+            "lora_down": self.lora_down,
+            "lora_up": self.lora_up,
+            "lora_dim": getattr(self, "lora_dim", None),
+            "scale": getattr(self, "scale", None),
+            "has_alpha": hasattr(self, "alpha"),
+            "alpha": getattr(self, "alpha", None),
+            "alpha_is_buffer": "alpha" in getattr(self, "_buffers", {}),
+        }
+
+    def lora_squeeze_restore(self, snapshot: Dict[str, Any]) -> None:
+        self.lora_down = snapshot["lora_down"]
+        self.lora_up = snapshot["lora_up"]
+        if snapshot["lora_dim"] is not None:
+            self.lora_dim = snapshot["lora_dim"]
+        if snapshot["scale"] is not None:
+            self.scale = snapshot["scale"]
+        if snapshot["alpha_is_buffer"]:
+            self._buffers["alpha"] = snapshot["alpha"]
+        elif snapshot["has_alpha"]:
+            self.alpha = snapshot["alpha"]
+        elif hasattr(self, "alpha"):
+            delattr(self, "alpha")
+
+    def lora_squeeze_replace_factors(
+        self,
+        up_2d: torch.Tensor,
+        down_2d: torch.Tensor,
+        target_dim: int,
+        target_alpha: float,
+    ) -> None:
+        spec = self.lora_squeeze_get_spec()
+        old_down = self.lora_down
+        old_up = self.lora_up
+        device = old_down.weight.device
+        cpu_rng_state = torch.get_rng_state()
+        device_rng_state = _get_device_rng_state(device)
+        try:
+            if spec.kind == "linear":
+                new_down = nn.Linear(
+                    old_down.in_features,
+                    target_dim,
+                    bias=False,
+                    device=device,
+                    dtype=old_down.weight.dtype,
+                )
+                new_up = nn.Linear(
+                    target_dim,
+                    old_up.out_features,
+                    bias=False,
+                    device=device,
+                    dtype=old_up.weight.dtype,
+                )
+                down_weight = down_2d
+                up_weight = up_2d
+            else:
+                new_down = nn.Conv2d(
+                    old_down.in_channels,
+                    target_dim,
+                    old_down.kernel_size,
+                    old_down.stride,
+                    old_down.padding,
+                    old_down.dilation,
+                    groups=1,
+                    bias=False,
+                    padding_mode=old_down.padding_mode,
+                    device=device,
+                    dtype=old_down.weight.dtype,
+                )
+                new_up = nn.Conv2d(
+                    target_dim,
+                    old_up.out_channels,
+                    old_up.kernel_size,
+                    old_up.stride,
+                    old_up.padding,
+                    old_up.dilation,
+                    groups=1,
+                    bias=False,
+                    padding_mode=old_up.padding_mode,
+                    device=device,
+                    dtype=old_up.weight.dtype,
+                )
+                down_weight = down_2d.reshape(target_dim, old_down.in_channels, *old_down.kernel_size)
+                up_weight = up_2d[:, :, None, None]
+        finally:
+            torch.set_rng_state(cpu_rng_state)
+            _set_device_rng_state(device, device_rng_state)
+
+        new_down.train(old_down.training)
+        new_up.train(old_up.training)
+        new_down.weight.requires_grad_(old_down.weight.requires_grad)
+        new_up.weight.requires_grad_(old_up.weight.requires_grad)
+        with torch.no_grad():
+            new_down.weight.copy_(down_weight.to(device=device, dtype=old_down.weight.dtype))
+            new_up.weight.copy_(up_weight.to(device=device, dtype=old_up.weight.dtype))
+
+        self.lora_down = new_down
+        self.lora_up = new_up
+        self.lora_dim = target_dim
+        self.scale = target_alpha / target_dim
+        old_alpha = getattr(self, "alpha", None)
+        alpha_tensor = torch.tensor(target_alpha, device=device, dtype=torch.float32)
+        if isinstance(old_alpha, torch.Tensor):
+            self.alpha = alpha_tensor
+        elif hasattr(self, "alpha"):
+            self.alpha = float(target_alpha)
+        else:
+            self.register_buffer("alpha", alpha_tensor)

--- a/library/lora_squeeze_optimizer.py
+++ b/library/lora_squeeze_optimizer.py
@@ -1,0 +1,876 @@
+"""Optimizer-aware state transfer for in-training LoRA rank changes.
+
+Optimizer tensors do not all live in the same coordinate space. Gradient moments
+are covectors, update/momentum buffers are vectors, and anchors/averages are
+points in parameter space.  LoRA-Squeeze therefore uses explicit optimizer
+policies instead of guessing from state-key names.
+"""
+
+import copy
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+import torch
+
+
+class OptimizerStateCPUStagingError(RuntimeError):
+    """Raised when optimizer state cannot be staged on CPU."""
+
+
+GRADIENT = "gradient"
+GRADIENT_SQUARED = "gradient_squared"
+GRADIENT_ABS_MAX = "gradient_abs_max"
+VECTOR = "vector"
+VECTOR_SQUARED = "vector_squared"
+POSITION = "position"
+MAX_VECTOR_PROJECTION_ABS = 1e6
+
+
+def _move_optimizer_state_value(value: Any, device: torch.device, move_scalar_tensors: bool = True) -> Any:
+    if isinstance(value, torch.Tensor):
+        # bitsandbytes paged optimizer buffers intentionally report a CPU
+        # device while being backed by CUDA managed memory. Moving them with
+        # Tensor.to() would replace them with ordinary CUDA allocations and
+        # silently disable paging after an optimizer rebuild.
+        if getattr(value, "is_paged", False):
+            return value
+        if not move_scalar_tensors and value.numel() == 1:
+            return value
+        return value.to(device=device)
+    if isinstance(value, dict):
+        return {
+            key: _move_optimizer_state_value(item, device, move_scalar_tensors)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_move_optimizer_state_value(item, device, move_scalar_tensors) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_optimizer_state_value(item, device, move_scalar_tensors) for item in value)
+    return value
+
+
+def stage_optimizer_state(state: Dict[str, Any], device: Optional[Union[str, torch.device]]) -> Dict[str, Any]:
+    if device is None or not state:
+        return state
+    target_device = torch.device(device)
+    try:
+        return {
+            key: _move_optimizer_state_value(value, target_device, move_scalar_tensors=False)
+            for key, value in state.items()
+        }
+    except Exception as error:
+        if target_device.type == "cpu":
+            raise OptimizerStateCPUStagingError("Failed to stage projected optimizer state on CPU") from error
+        raise
+
+
+def _move_optimizer_state_value_with_device_record(value: Any, device: torch.device):
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device), value.device
+    if isinstance(value, dict):
+        moved, devices = {}, {}
+        for key, item in value.items():
+            moved[key], devices[key] = _move_optimizer_state_value_with_device_record(item, device)
+        return moved, devices
+    if isinstance(value, list):
+        moved_items, device_items = [], []
+        for item in value:
+            moved, original_device = _move_optimizer_state_value_with_device_record(item, device)
+            moved_items.append(moved)
+            device_items.append(original_device)
+        return moved_items, device_items
+    if isinstance(value, tuple):
+        moved_items, device_items = [], []
+        for item in value:
+            moved, original_device = _move_optimizer_state_value_with_device_record(item, device)
+            moved_items.append(moved)
+            device_items.append(original_device)
+        return tuple(moved_items), tuple(device_items)
+    return value, None
+
+
+def _restore_optimizer_state_value_devices(value: Any, devices: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.to(device=devices) if devices is not None else value
+    if isinstance(value, dict):
+        return {key: _restore_optimizer_state_value_devices(item, devices[key]) for key, item in value.items()}
+    if isinstance(value, list):
+        return [
+            _restore_optimizer_state_value_devices(item, item_devices)
+            for item, item_devices in zip(value, devices)
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _restore_optimizer_state_value_devices(item, item_devices)
+            for item, item_devices in zip(value, devices)
+        )
+    return value
+
+
+def offload_optimizer_state_to_cpu(optimizer: torch.optim.Optimizer):
+    records = []
+    try:
+        for state in optimizer.state.values():
+            for key, value in list(state.items()):
+                moved, original_devices = _move_optimizer_state_value_with_device_record(value, torch.device("cpu"))
+                state[key] = moved
+                records.append((state, key, original_devices))
+    except Exception as error:
+        try:
+            restore_offloaded_optimizer_state(records)
+        except Exception as restore_error:
+            raise RuntimeError("CPU optimizer-state offload failed and could not be rolled back") from restore_error
+        raise OptimizerStateCPUStagingError("Failed to offload existing optimizer state to CPU") from error
+    return records
+
+
+def restore_offloaded_optimizer_state(records):
+    for state, key, original_devices in records:
+        if key in state:
+            state[key] = _restore_optimizer_state_value_devices(state[key], original_devices)
+
+
+def move_optimizer_state_to_parameter_devices(optimizer: torch.optim.Optimizer):
+    for parameter, state in optimizer.state.items():
+        for key, value in list(state.items()):
+            state[key] = _move_optimizer_state_value(value, parameter.device, move_scalar_tensors=False)
+
+
+def _qualified_name(optimizer: torch.optim.Optimizer) -> str:
+    optimizer_type = type(optimizer)
+    return f"{optimizer_type.__module__}.{optimizer_type.__name__}"
+
+
+def _clone_value(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.detach().clone()
+    return copy.deepcopy(value)
+
+
+def _state_tensor_to_parameter_shape(value: torch.Tensor, parameter: torch.nn.Parameter) -> Tuple[torch.Tensor, bool]:
+    if tuple(value.shape) == tuple(parameter.shape):
+        return value, False
+    if value.ndim == 1 and value.numel() == parameter.numel():
+        return value.reshape(parameter.shape), True
+    raise ValueError(
+        f"optimizer state shape {tuple(value.shape)} does not match parameter shape {tuple(parameter.shape)}"
+    )
+
+
+def _parameter_tensor_to_2d(tensor: torch.Tensor, role: str) -> torch.Tensor:
+    if tensor.ndim == 2:
+        return tensor
+    if tensor.ndim >= 3:
+        return tensor.reshape(tensor.shape[0], -1)
+    if tensor.ndim == 1:
+        return tensor.reshape(1, -1) if role == "down" else tensor.reshape(-1, 1)
+    raise ValueError(f"unsupported optimizer state tensor rank: {tensor.ndim}")
+
+
+def _restore_projected_layout(projected: torch.Tensor, target_shape: torch.Size, was_flat: bool) -> torch.Tensor:
+    projected = projected.reshape(target_shape)
+    return projected.flatten() if was_flat else projected
+
+
+def _project_2d(
+    tensor_2d: torch.Tensor,
+    projection: torch.Tensor,
+    role: str,
+) -> torch.Tensor:
+    if role == "up":
+        if tensor_2d.shape[1] != projection.shape[0]:
+            raise ValueError("up-state rank does not match the LoRA-Squeeze projection")
+        return tensor_2d @ projection
+    if role == "down":
+        if tensor_2d.shape[0] != projection.shape[1]:
+            raise ValueError("down-state rank does not match the LoRA-Squeeze projection")
+        return projection @ tensor_2d
+    raise ValueError(f"unknown LoRA optimizer-state role: {role}")
+
+
+def _vector_projection(projection: torch.Tensor) -> torch.Tensor:
+    # Gradients are covectors. Parameter displacements use the pseudoinverse of
+    # the transpose so that <gradient, displacement> is retained in the kept
+    # subspace as closely as possible.
+    result = torch.linalg.pinv(projection.T)
+    if not torch.isfinite(result).all():
+        raise ValueError("optimizer vector-state projection produced non-finite values")
+    if result.numel() > 0 and float(result.detach().abs().max()) > MAX_VECTOR_PROJECTION_ABS:
+        raise ValueError(
+            "optimizer vector-state projection is ill-conditioned; use "
+            "--lora_squeeze_optimizer_mode=per_squeeze"
+        )
+    return result
+
+
+def _project_full_state_tensor(
+    value: torch.Tensor,
+    old_parameter: torch.nn.Parameter,
+    new_parameter: torch.nn.Parameter,
+    projection: torch.Tensor,
+    role: str,
+    kind: str,
+) -> torch.Tensor:
+    shaped, was_flat = _state_tensor_to_parameter_shape(value, old_parameter)
+    state_2d = _parameter_tensor_to_2d(shaped.detach().float(), role)
+    projection = projection.detach().to(device=state_2d.device, dtype=state_2d.dtype)
+
+    if kind in (VECTOR, VECTOR_SQUARED):
+        projection = _vector_projection(projection)
+    if kind in (GRADIENT_SQUARED, VECTOR_SQUARED):
+        projection = projection.square()
+
+    if kind == GRADIENT_ABS_MAX:
+        # Adamax stores a component-wise maximum absolute gradient. Coordinate
+        # mixing has no exact diagonal representation, so retain a conservative
+        # envelope using the absolute projection coefficients.
+        projected = _project_2d(state_2d.abs(), projection.abs(), role).clamp_min_(0)
+    else:
+        projected = _project_2d(state_2d, projection, role)
+        if kind in (GRADIENT_SQUARED, VECTOR_SQUARED):
+            projected.clamp_min_(0)
+
+    if projected.numel() != new_parameter.numel() or not torch.isfinite(projected).all():
+        raise ValueError("optimizer state projection produced an invalid target tensor")
+    projected = _restore_projected_layout(projected, new_parameter.shape, was_flat)
+    return projected.to(device=new_parameter.device, dtype=value.dtype)
+
+
+def _project_position_state(
+    value: torch.Tensor,
+    old_parameter: torch.nn.Parameter,
+    new_parameter: torch.nn.Parameter,
+    projection: torch.Tensor,
+    role: str,
+) -> torch.Tensor:
+    was_flat = value.ndim == 1 and value.numel() == old_parameter.numel()
+    if value.numel() == 1 and value.item() == 0:
+        # Prodigy stores an all-zero anchor as a scalar to save memory.
+        shaped = torch.zeros_like(old_parameter)
+        was_flat = True
+    else:
+        shaped, was_flat = _state_tensor_to_parameter_shape(value, old_parameter)
+
+    displacement = shaped.detach().float() - old_parameter.detach().float()
+    mapped = _project_full_state_tensor(
+        displacement,
+        old_parameter,
+        new_parameter,
+        projection,
+        role,
+        VECTOR,
+    )
+    mapped_shaped = mapped.reshape(new_parameter.shape).float()
+    position = new_parameter.detach().float() + mapped_shaped
+    position = position.flatten() if was_flat else position
+    return position.to(device=new_parameter.device, dtype=value.dtype)
+
+
+class OptimizerStateTransferAdapter:
+    display_name = "optimizer"
+    scalar_keys = {"step"}
+    state_rules: Dict[str, str] = {}
+    warm_restart_reason: Optional[str] = None
+
+    def __init__(self, optimizer: torch.optim.Optimizer):
+        self.optimizer = optimizer
+        self.qualified_name = _qualified_name(optimizer)
+
+    def _unexpected_state_keys(self) -> List[str]:
+        accepted = set(self.scalar_keys) | set(self.state_rules)
+        return sorted({key for state in self.optimizer.state.values() for key in state if key not in accepted})
+
+    def preflight(self):
+        unexpected = self._unexpected_state_keys()
+        if unexpected:
+            raise ValueError(
+                f"LoRA-Squeeze global optimizer mode does not know how {self.qualified_name} uses state "
+                f"{unexpected}. Use --lora_squeeze_optimizer_mode=per_squeeze."
+            )
+
+    def project_parameter_state(
+        self,
+        old_parameter: torch.nn.Parameter,
+        new_parameter: torch.nn.Parameter,
+        projection: torch.Tensor,
+        role: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        state = self.optimizer.state.get(old_parameter, {})
+        if not state:
+            return {}, "empty"
+        if self.warm_restart_reason is not None:
+            return {}, "warm_restart:" + self.warm_restart_reason
+
+        projected: Dict[str, Any] = {}
+        for key, value in state.items():
+            if key in self.scalar_keys:
+                if isinstance(value, torch.Tensor) and value.numel() != 1:
+                    raise ValueError(f"{self.qualified_name} state {key!r} was expected to be scalar")
+                projected[key] = _clone_value(value)
+                continue
+            if not isinstance(value, torch.Tensor) or not torch.is_floating_point(value):
+                raise ValueError(f"{self.qualified_name} state {key!r} is not a floating-point tensor")
+            kind = self.state_rules[key]
+            if kind == POSITION:
+                projected[key] = _project_position_state(
+                    value, old_parameter, new_parameter, projection, role
+                )
+            else:
+                projected[key] = _project_full_state_tensor(
+                    value, old_parameter, new_parameter, projection, role, kind
+                )
+        return projected, "projected"
+
+    def copy_group_state(
+        self,
+        new_optimizer: torch.optim.Optimizer,
+        transfers: List[Tuple[torch.nn.Parameter, Dict[str, Any]]],
+    ):
+        _validate_group_layout(self.optimizer, new_optimizer)
+
+
+class RuleBasedAdapter(OptimizerStateTransferAdapter):
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        display_name: str,
+        state_rules: Dict[str, str],
+        scalar_keys=None,
+    ):
+        super().__init__(optimizer)
+        self.display_name = display_name
+        self.state_rules = state_rules
+        if scalar_keys is not None:
+            self.scalar_keys = set(scalar_keys)
+
+
+def _validate_group_layout(old_optimizer: torch.optim.Optimizer, new_optimizer: torch.optim.Optimizer):
+    if _qualified_name(old_optimizer) != _qualified_name(new_optimizer):
+        raise ValueError(
+            "LoRA-Squeeze global optimizer mode rebuilt a different optimizer class: "
+            f"{_qualified_name(old_optimizer)} -> {_qualified_name(new_optimizer)}"
+        )
+    if len(old_optimizer.param_groups) != len(new_optimizer.param_groups):
+        raise ValueError("LoRA-Squeeze global optimizer mode changed the optimizer parameter-group count")
+
+
+def _copy_group_keys(old_optimizer, new_optimizer, keys: Iterable[str]):
+    _validate_group_layout(old_optimizer, new_optimizer)
+    for old_group, new_group in zip(old_optimizer.param_groups, new_optimizer.param_groups):
+        for key in keys:
+            if key in old_group:
+                new_group[key] = _clone_value(old_group[key])
+
+
+def _all_states(optimizer: torch.optim.Optimizer) -> Iterable[Dict[str, Any]]:
+    return optimizer.state.values()
+
+
+def _state_abs_sum(states: Iterable[Dict[str, Any]], key: str) -> float:
+    return sum(float(state[key].detach().float().abs().sum()) for state in states if key in state)
+
+
+def _state_l2_norm(states: Iterable[Dict[str, Any]], key: str) -> float:
+    squared = sum(float(state[key].detach().float().square().sum()) for state in states if key in state)
+    return math.sqrt(max(0.0, squared))
+
+
+def _transferred_states(transfers) -> Iterable[Dict[str, Any]]:
+    return (state for _, state in transfers)
+
+
+def _scaled_history(value: Any, old_norm: float, new_norm: float) -> Any:
+    if old_norm <= 0 or new_norm <= 0:
+        return type(value)(0) if not isinstance(value, torch.Tensor) else torch.zeros_like(value)
+    ratio = new_norm / old_norm
+    return value * ratio
+
+
+class ProdigyAdapter(RuleBasedAdapter):
+    def __init__(self, optimizer):
+        super().__init__(
+            optimizer,
+            "Prodigy",
+            {"s": GRADIENT, "p0": POSITION, "exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED},
+        )
+
+    def preflight(self):
+        unexpected = self._unexpected_state_keys()
+        slice_values = {group.get("slice_p", 1) for group in self.optimizer.param_groups}
+        if slice_values != {1}:
+            self.warm_restart_reason = "Prodigy slice_p state cannot be unsliced after a rank change"
+        elif unexpected:
+            self.warm_restart_reason = "unsupported Prodigy state: " + ",".join(unexpected)
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _validate_group_layout(self.optimizer, new_optimizer)
+        if self.warm_restart_reason is not None:
+            _copy_group_keys(self.optimizer, new_optimizer, ("d", "d_max"))
+            return
+
+        old_norm = _state_abs_sum(_all_states(self.optimizer), "s")
+        new_norm = _state_abs_sum(_transferred_states(transfers), "s")
+        for old_group, new_group in zip(self.optimizer.param_groups, new_optimizer.param_groups):
+            for key in ("d", "d_max", "k"):
+                if key in old_group:
+                    new_group[key] = _clone_value(old_group[key])
+            numerator = _scaled_history(old_group.get("d_numerator", 0.0), old_norm, new_norm)
+            new_group["d_numerator"] = numerator
+            new_group["d_denom"] = new_norm
+            d_coef = new_group.get("d_coef", 1.0)
+            new_group["d_hat"] = new_group.get("d", 0.0) if new_norm == 0 else d_coef * numerator / new_norm
+
+
+class ProdigyPlusWarmRestartAdapter(OptimizerStateTransferAdapter):
+    """Preserve the learned LR while restarting inseparable sliced/SF state.
+
+    ProdigyPlusScheduleFree 1.9.x stores its Prodigy anchor/accumulator at a
+    fixed 1-in-11 slice and combines them with schedule-free points and optional
+    factored/experimental moments. Rank mixing makes that slice non-invertible.
+    Restarting every per-parameter buffer together is safer than constructing a
+    hybrid, while retaining ``d`` avoids relearning the main LR estimate.
+    """
+
+    def __init__(self, optimizer):
+        super().__init__(optimizer)
+        self.warm_restart_reason = "ProdigyPlus sliced and schedule-free state is not jointly invertible"
+
+    def preflight(self):
+        pass
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _copy_group_keys(self.optimizer, new_optimizer, ("d", "d_prev", "shared_d"))
+
+
+class DAdaptRatioAdapter(RuleBasedAdapter):
+    def __init__(self, optimizer, display_name, rules, history_key, norm="l1"):
+        super().__init__(optimizer, display_name, rules)
+        self.history_key = history_key
+        self.norm = norm
+
+    def preflight(self):
+        unexpected = self._unexpected_state_keys()
+        if unexpected:
+            self.warm_restart_reason = "unsupported D-Adaptation state: " + ",".join(unexpected)
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _validate_group_layout(self.optimizer, new_optimizer)
+        if self.warm_restart_reason is not None:
+            _copy_group_keys(self.optimizer, new_optimizer, ("d",))
+            return
+        norm_fn = _state_l2_norm if self.norm == "l2" else _state_abs_sum
+        old_norm = norm_fn(_all_states(self.optimizer), "s")
+        new_norm = norm_fn(_transferred_states(transfers), "s")
+        for old_group, new_group in zip(self.optimizer.param_groups, new_optimizer.param_groups):
+            for key in ("d", "k"):
+                if key in old_group:
+                    new_group[key] = _clone_value(old_group[key])
+            value = _scaled_history(old_group.get(self.history_key, 0.0), old_norm, new_norm)
+            new_group[self.history_key] = value
+
+
+def _adan_metrics(states: Iterable[Dict[str, Any]], eps: float) -> Tuple[float, float]:
+    weighted_sq = 0.0
+    l1 = 0.0
+    for state in states:
+        if "s" not in state or "exp_avg_sq" not in state:
+            continue
+        s = state["s"].detach().float()
+        denom = state["exp_avg_sq"].detach().float().clamp_min(0).sqrt().add(eps)
+        weighted_sq += float((s.square() / denom).sum())
+        l1 += float(s.abs().sum())
+    return weighted_sq, l1
+
+
+class DAdaptAdanAdapter(RuleBasedAdapter):
+    def __init__(self, optimizer, display_name):
+        super().__init__(
+            optimizer,
+            display_name,
+            {
+                "s": GRADIENT,
+                "exp_avg": GRADIENT,
+                "exp_avg_diff": GRADIENT,
+                "exp_avg_sq": GRADIENT_SQUARED,
+                "pre_grad": GRADIENT,
+            },
+        )
+
+    def preflight(self):
+        unexpected = self._unexpected_state_keys()
+        if unexpected:
+            self.warm_restart_reason = "unsupported D-Adaptation Adan state: " + ",".join(unexpected)
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _validate_group_layout(self.optimizer, new_optimizer)
+        if self.warm_restart_reason is not None:
+            _copy_group_keys(self.optimizer, new_optimizer, ("d",))
+            return
+        old_group = self.optimizer.param_groups[0]
+        eps = float(old_group.get("eps", 1e-8))
+        beta = float(old_group.get("betas", (0.98, 0.92, 0.99))[-1])
+        old_sq, old_l1 = _adan_metrics(_all_states(self.optimizer), eps)
+        new_sq, new_l1 = _adan_metrics(_transferred_states(transfers), eps)
+        old_history = float(old_group.get("gsq_weighted", 0.0))
+        old_d_hat = 0.0 if old_l1 == 0 else (old_sq / (1 - beta) - old_history) / old_l1
+        new_history = max(0.0, new_sq / (1 - beta) - old_d_hat * new_l1)
+        for source, target in zip(self.optimizer.param_groups, new_optimizer.param_groups):
+            target["d"] = _clone_value(source.get("d", target.get("d")))
+            target["k"] = _clone_value(source.get("k", target.get("k", 0)))
+            target["gsq_weighted"] = new_history
+
+
+class DAdaptSGDAdapter(RuleBasedAdapter):
+    def __init__(self, optimizer):
+        super().__init__(optimizer, "DAdaptSGD", {"s": VECTOR, "x0": POSITION, "z": POSITION})
+
+    def project_parameter_state(self, old_parameter, new_parameter, projection, role):
+        projected, status = super().project_parameter_state(old_parameter, new_parameter, projection, role)
+        if projected and "x0" in projected and "s" in projected:
+            projected["z"] = projected["x0"] - projected["s"]
+        return projected, status
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _validate_group_layout(self.optimizer, new_optimizer)
+        old_norm = _state_l2_norm(_all_states(self.optimizer), "s")
+        new_norm = _state_l2_norm(_transferred_states(transfers), "s")
+        for old_group, new_group in zip(self.optimizer.param_groups, new_optimizer.param_groups):
+            new_group["d"] = _clone_value(old_group.get("d", new_group.get("d")))
+            new_group["numerator_weighted"] = _scaled_history(
+                old_group.get("numerator_weighted", 0.0), old_norm, new_norm
+            )
+            # Re-measure the initial gradient norm in the new coordinates.
+            new_group["k"] = 0
+            new_group.pop("g0_norm", None)
+
+
+class DAdaptAdaGradAdapter(RuleBasedAdapter):
+    def __init__(self, optimizer):
+        super().__init__(optimizer, "DAdaptAdaGrad", {"alphak": GRADIENT_SQUARED, "sk": GRADIENT, "x0": POSITION})
+
+    @staticmethod
+    def _metrics(states, eps):
+        weighted_sq = 0.0
+        l1 = 0.0
+        for state in states:
+            if "sk" not in state or "alphak" not in state:
+                continue
+            sk = state["sk"].detach().float()
+            denom = state["alphak"].detach().float().clamp_min(0).sqrt().add(eps)
+            weighted_sq += float((sk.square() / denom).sum())
+            l1 += float(sk.abs().sum())
+        return weighted_sq, l1
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _validate_group_layout(self.optimizer, new_optimizer)
+        group = self.optimizer.param_groups[0]
+        eps = float(group.get("eps", 1e-6))
+        old_sq, old_l1 = self._metrics(_all_states(self.optimizer), eps)
+        new_sq, new_l1 = self._metrics(_transferred_states(transfers), eps)
+        old_gsq = float(group.get("gsq_weighted", 0.0))
+        old_d_hat = 0.0 if old_l1 == 0 else (old_sq - old_gsq) / old_l1
+        new_gsq = max(0.0, new_sq - old_d_hat * new_l1)
+        for source, target in zip(self.optimizer.param_groups, new_optimizer.param_groups):
+            for key in ("d", "k"):
+                target[key] = _clone_value(source.get(key, target.get(key)))
+            target["sksq_weighted"] = new_sq
+            target["skl1"] = new_l1
+            target["gsq_weighted"] = new_gsq
+
+
+class AdafactorAdapter(OptimizerStateTransferAdapter):
+    scalar_keys = {"step", "RMS"}
+    state_rules = {"exp_avg": VECTOR, "exp_avg_sq": GRADIENT_SQUARED}
+
+    def preflight(self):
+        accepted = self.scalar_keys | set(self.state_rules) | {"exp_avg_sq_row", "exp_avg_sq_col"}
+        unexpected = sorted({key for state in self.optimizer.state.values() for key in state if key not in accepted})
+        if unexpected:
+            raise ValueError(f"unsupported Adafactor state for LoRA-Squeeze global mode: {unexpected}")
+
+    def project_parameter_state(self, old_parameter, new_parameter, projection, role):
+        state = self.optimizer.state.get(old_parameter, {})
+        if not state:
+            return {}, "empty"
+        projected = {key: _clone_value(value) for key, value in state.items() if key in self.scalar_keys}
+        if "exp_avg" in state:
+            projected["exp_avg"] = _project_full_state_tensor(
+                # Adafactor accumulates its already-preconditioned, LR-scaled
+                # update here (not the raw gradient), so this is a parameter
+                # vector rather than a gradient covector.
+                state["exp_avg"], old_parameter, new_parameter, projection, role, VECTOR
+            )
+        if "exp_avg_sq" in state:
+            projected["exp_avg_sq"] = _project_full_state_tensor(
+                state["exp_avg_sq"], old_parameter, new_parameter, projection, role, GRADIENT_SQUARED
+            )
+        elif "exp_avg_sq_row" in state and "exp_avg_sq_col" in state:
+            row = state["exp_avg_sq_row"].detach().float()
+            col = state["exp_avg_sq_col"].detach().float()
+            full = (row / row.mean(dim=-1, keepdim=True).clamp_min(1e-30)).unsqueeze(-1) * col.unsqueeze(-2)
+            full = full.to(device=old_parameter.device)
+            mapped = _project_full_state_tensor(
+                full, old_parameter, new_parameter, projection, role, GRADIENT_SQUARED
+            ).reshape(new_parameter.shape).float()
+            projected["exp_avg_sq_row"] = mapped.mean(dim=-1).to(
+                device=new_parameter.device, dtype=state["exp_avg_sq_row"].dtype
+            )
+            projected["exp_avg_sq_col"] = mapped.mean(dim=-2).to(
+                device=new_parameter.device, dtype=state["exp_avg_sq_col"].dtype
+            )
+        return projected, "projected"
+
+
+class ScheduleFreeAdapter(RuleBasedAdapter):
+    def __init__(self, optimizer, rules):
+        super().__init__(optimizer, type(optimizer).__name__, rules)
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _copy_group_keys(
+            self.optimizer,
+            new_optimizer,
+            ("k", "train_mode", "weight_sum", "lr_max", "scheduled_lr"),
+        )
+
+
+class BitsAndBytesAdapter(OptimizerStateTransferAdapter):
+    scalar_keys = {"step", "unorm_vec", "gnorm_vec"}
+
+    def __init__(self, optimizer, state1_kind, has_state2):
+        super().__init__(optimizer)
+        self.state1_kind = state1_kind
+        self.has_state2 = has_state2
+
+    def preflight(self):
+        args = getattr(self.optimizer, "args", None)
+        if (
+            args is not None
+            and getattr(args, "optim_bits", None) == 8
+            and not getattr(args, "block_wise", True)
+        ):
+            raise ValueError(
+                "LoRA-Squeeze global mode supports block-wise but not tensor-wise bitsandbytes 8-bit state"
+            )
+        accepted = self.scalar_keys | {"state1", "qmap1", "absmax1"}
+        if self.has_state2:
+            accepted |= {"state2", "qmap2", "absmax2"}
+        unexpected = sorted({key for state in self.optimizer.state.values() for key in state if key not in accepted})
+        if unexpected:
+            raise ValueError(
+                f"LoRA-Squeeze global mode supports only block-wise bitsandbytes state; found {unexpected}"
+            )
+
+    @staticmethod
+    def _project_bnb_buffer(state, prefix, kind, old_parameter, new_parameter, projection, role):
+        value = state[prefix]
+        if value.dtype != torch.uint8:
+            return _project_full_state_tensor(value, old_parameter, new_parameter, projection, role, kind), {}
+        try:
+            import bitsandbytes.functional as F
+        except ImportError as error:
+            raise ValueError("bitsandbytes is required to transfer quantized optimizer state") from error
+        suffix = prefix[-1]
+        qmap_key = f"qmap{suffix}"
+        absmax_key = f"absmax{suffix}"
+        # Paged bitsandbytes buffers use CUDA managed memory but present as
+        # CPU tensors. bitsandbytes' blockwise CUDA kernel consequently tries
+        # to obtain a CUDA stream for device index None when given the managed
+        # tensor directly. Materialize only the moment currently being
+        # projected as an ordinary tensor on the parameter device.
+        dequantize_value = value
+        if value.device != old_parameter.device or getattr(value, "is_paged", False):
+            dequantize_value = torch.empty(
+                value.shape,
+                dtype=value.dtype,
+                device=old_parameter.device,
+            )
+            dequantize_value.copy_(value)
+        absmax = state[absmax_key].to(device=old_parameter.device)
+        qmap = state[qmap_key].to(device=old_parameter.device)
+        dequantized = F.dequantize_blockwise(
+            dequantize_value,
+            absmax=absmax,
+            code=qmap,
+            blocksize=256,
+        ).reshape(old_parameter.shape)
+        projected = _project_full_state_tensor(
+            dequantized, old_parameter, new_parameter, projection, role, kind
+        ).reshape(new_parameter.shape).float()
+        quantized, quant_state = F.quantize_blockwise(
+            projected, code=qmap, blocksize=256
+        )
+        return quantized, {qmap_key: quant_state.code, absmax_key: quant_state.absmax}
+
+    def project_parameter_state(self, old_parameter, new_parameter, projection, role):
+        state = self.optimizer.state.get(old_parameter, {})
+        if not state:
+            return {}, "empty"
+        projected = {key: _clone_value(value) for key, value in state.items() if key in self.scalar_keys}
+        state1, metadata = self._project_bnb_buffer(
+            state, "state1", self.state1_kind, old_parameter, new_parameter, projection, role
+        )
+        projected["state1"] = state1
+        projected.update(metadata)
+        if self.has_state2:
+            state2, metadata = self._project_bnb_buffer(
+                state, "state2", GRADIENT_SQUARED, old_parameter, new_parameter, projection, role
+            )
+            projected["state2"] = state2
+            projected.update(metadata)
+        return projected, "projected"
+
+    def copy_group_state(self, new_optimizer, transfers):
+        _validate_group_layout(self.optimizer, new_optimizer)
+        get_state_buffer = getattr(new_optimizer, "get_state_buffer", None)
+        if get_state_buffer is None:
+            return
+        # Paged variants rely on their own managed-memory allocator. Re-home
+        # projected moment buffers through it instead of silently turning a
+        # paged optimizer into an ordinary CUDA-resident one after a squeeze.
+        for parameter, state in transfers:
+            for key in ("state1", "state2"):
+                if key not in state:
+                    continue
+                source = state[key]
+                target = get_state_buffer(parameter, dtype=source.dtype)
+                target.copy_(source)
+                state[key] = target
+
+
+def _torch_adapter(optimizer, class_name) -> Optional[OptimizerStateTransferAdapter]:
+    policies = {
+        "Adam": {"exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED, "max_exp_avg_sq": GRADIENT_SQUARED},
+        "AdamW": {"exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED, "max_exp_avg_sq": GRADIENT_SQUARED},
+        "RAdam": {"exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED},
+        "NAdam": {"exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED},
+        "SparseAdam": {"exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED},
+        "SGD": {"momentum_buffer": VECTOR},
+        "Adagrad": {"sum": GRADIENT_SQUARED},
+        "RMSprop": {"square_avg": GRADIENT_SQUARED, "grad_avg": GRADIENT, "momentum_buffer": VECTOR},
+        "Adamax": {"exp_avg": GRADIENT, "exp_inf": GRADIENT_ABS_MAX},
+        "Adadelta": {"square_avg": GRADIENT_SQUARED, "acc_delta": VECTOR_SQUARED},
+        "ASGD": {"ax": POSITION},
+    }
+    scalar_keys = {
+        "Adam": {"step"}, "AdamW": {"step"}, "RAdam": {"step"}, "NAdam": {"step", "mu_product"},
+        "SparseAdam": {"step"}, "SGD": {"step"}, "Adagrad": {"step"}, "RMSprop": {"step"},
+        "Adamax": {"step"}, "Adadelta": {"step"}, "ASGD": {"step", "eta", "mu"},
+    }
+    if class_name not in policies:
+        return None
+    return RuleBasedAdapter(optimizer, class_name, policies[class_name], scalar_keys[class_name])
+
+
+def prepare_optimizer_state_transfer(optimizer: torch.optim.Optimizer) -> OptimizerStateTransferAdapter:
+    module = type(optimizer).__module__
+    class_name = type(optimizer).__name__
+    adapter: Optional[OptimizerStateTransferAdapter] = None
+
+    if module.startswith("torch.optim"):
+        adapter = _torch_adapter(optimizer, class_name)
+    elif module.startswith("lion_pytorch") and class_name == "Lion":
+        adapter = RuleBasedAdapter(optimizer, "Lion", {"exp_avg": GRADIENT})
+    elif module.startswith("prodigyopt") and class_name == "Prodigy":
+        adapter = ProdigyAdapter(optimizer)
+    elif module.startswith("prodigyplus") and class_name == "ProdigyPlusScheduleFree":
+        adapter = ProdigyPlusWarmRestartAdapter(optimizer)
+    elif module.startswith("dadaptation"):
+        if class_name == "DAdaptAdam":
+            adapter = DAdaptRatioAdapter(
+                optimizer,
+                class_name,
+                {"s": GRADIENT, "exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED},
+                "numerator_weighted",
+            )
+        elif class_name == "DAdaptLion":
+            adapter = DAdaptRatioAdapter(
+                optimizer, class_name, {"s": VECTOR, "exp_avg": GRADIENT}, "numerator_weighted"
+            )
+        elif class_name == "DAdaptAdanIP":
+            adapter = DAdaptRatioAdapter(
+                optimizer,
+                class_name,
+                # dadaptation 3.2's experimental IP implementation assigns the
+                # squared-update accumulator to exp_avg_diff and the signed
+                # gradient-difference accumulator to exp_avg_sq (despite their
+                # names), so follow the implementation actually stepped.
+                {
+                    "s": GRADIENT,
+                    "exp_avg": GRADIENT,
+                    "exp_avg_diff": GRADIENT_SQUARED,
+                    "exp_avg_sq": GRADIENT,
+                    "pre_grad": GRADIENT,
+                },
+                "numerator_weighted",
+            )
+        elif class_name in ("DAdaptAdan", "DAdaptAdamPreprint"):
+            rules_name = class_name
+            adapter = DAdaptAdanAdapter(optimizer, rules_name)
+            if class_name == "DAdaptAdamPreprint":
+                adapter.state_rules = {"s": GRADIENT, "exp_avg": GRADIENT, "exp_avg_sq": GRADIENT_SQUARED}
+        elif class_name == "DAdaptSGD":
+            adapter = DAdaptSGDAdapter(optimizer)
+        elif class_name == "DAdaptAdaGrad":
+            adapter = DAdaptAdaGradAdapter(optimizer)
+    elif module.startswith("transformers") and class_name == "Adafactor":
+        adapter = AdafactorAdapter(optimizer)
+    elif module.startswith("schedulefree"):
+        if class_name in ("AdamWScheduleFree", "RAdamScheduleFree"):
+            adapter = ScheduleFreeAdapter(
+                optimizer, {"z": POSITION, "exp_avg_sq": GRADIENT_SQUARED, "exp_avg": GRADIENT}
+            )
+        elif class_name == "SGDScheduleFree":
+            adapter = ScheduleFreeAdapter(optimizer, {"z": POSITION})
+    elif module.startswith("bitsandbytes"):
+        if "Adam" in class_name and "AdEMAMix" not in class_name:
+            adapter = BitsAndBytesAdapter(optimizer, GRADIENT, has_state2=True)
+        elif "Lion" in class_name:
+            adapter = BitsAndBytesAdapter(optimizer, GRADIENT, has_state2=False)
+        elif "SGD" in class_name:
+            adapter = BitsAndBytesAdapter(optimizer, VECTOR, has_state2=False)
+
+    if adapter is None:
+        raise ValueError(
+            "LoRA-Squeeze global optimizer mode is not implemented for "
+            f"{_qualified_name(optimizer)}. Its state will not be guessed; use "
+            "--lora_squeeze_optimizer_mode=per_squeeze."
+        )
+    adapter.preflight()
+    return adapter
+
+
+def optimizer_owns_lr_schedule(optimizer: torch.optim.Optimizer) -> bool:
+    """Return whether LR/averaging progress is inseparable from optimizer state."""
+    optimizer = getattr(optimizer, "optimizer", optimizer)
+    module = type(optimizer).__module__
+    class_name = type(optimizer).__name__
+    if module.startswith("schedulefree") or (
+        module.startswith("prodigyplus") and class_name == "ProdigyPlusScheduleFree"
+    ):
+        return True
+    if module.startswith("transformers") and class_name == "Adafactor":
+        return any(bool(group.get("relative_step", False)) for group in optimizer.param_groups)
+    return False
+
+
+def validate_optimizer_scheduler_modes(
+    optimizer: torch.optim.Optimizer,
+    optimizer_mode: str,
+    scheduler_mode: str,
+):
+    if optimizer_owns_lr_schedule(optimizer) and optimizer_mode != scheduler_mode:
+        raw_optimizer = getattr(optimizer, "optimizer", optimizer)
+        raise ValueError(
+            "LoRA-Squeeze cannot independently restart optimizer and scheduler state for "
+            f"{_qualified_name(raw_optimizer)}. Its learning-rate/averaging schedule is owned by the optimizer; "
+            "set --lora_squeeze_optimizer_mode and --lora_squeeze_scheduler_mode to the same value."
+        )
+
+
+def copy_optimizer_param_group_state(
+    old_optimizer: torch.optim.Optimizer,
+    new_optimizer: torch.optim.Optimizer,
+    transfers: Optional[List[Tuple[torch.nn.Parameter, Dict[str, Any]]]] = None,
+):
+    adapter = prepare_optimizer_state_transfer(old_optimizer)
+    adapter.copy_group_state(new_optimizer, transfers or [])

--- a/library/lora_squeeze_schedule.py
+++ b/library/lora_squeeze_schedule.py
@@ -1,0 +1,457 @@
+"""LoRA-Squeeze scheduling, resume state, and configuration validation."""
+
+import argparse
+import json
+import math
+import os
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+
+TRAIN_STATE_LORA_SQUEEZE_KEY = "lora_squeeze"
+UNSUPPORTED_NETWORK_ARG_KEYS = {
+    "block_alphas",
+    "block_dims",
+    "conv_block_alphas",
+    "conv_block_dims",
+    "network_reg_dims",
+}
+
+
+def get_remaining_training_steps(max_train_steps: int, completed_steps: int) -> int:
+    return max(0, max_train_steps - completed_steps)
+
+
+def is_training_budget_exhausted(max_train_steps: int, completed_steps: int) -> bool:
+    return completed_steps >= max_train_steps
+
+
+def get_resume_epoch_and_batch_offset(
+    completed_steps: int,
+    num_batches_per_epoch: int,
+    gradient_accumulation_steps: int,
+) -> Tuple[int, int]:
+    if completed_steps < 0:
+        raise ValueError("completed_steps must not be negative")
+    if num_batches_per_epoch <= 0 or gradient_accumulation_steps <= 0:
+        raise ValueError("batch and gradient-accumulation counts must be positive")
+    updates_per_epoch = math.ceil(num_batches_per_epoch / gradient_accumulation_steps)
+    completed_epochs, updates_in_epoch = divmod(completed_steps, updates_per_epoch)
+    return completed_epochs, min(updates_in_epoch * gradient_accumulation_steps, num_batches_per_epoch)
+
+
+class LoRASqueezeSchedule:
+    RANK_SCHEDULE_CHOICES = ("linear", "geometric")
+    STEP_SCHEDULE_CHOICES = (
+        "equal",
+        "rank_proportional",
+        "sqrt_rank_proportional",
+        "inverse_rank_proportional",
+        "inverse_sqrt_rank_proportional",
+    )
+    STATE_MODE_CHOICES = ("per_squeeze", "global")
+    ALPHA_SCHEDULE_CHOICES = ("proportional", "sqrt")
+
+    def __init__(self, args: argparse.Namespace):
+        self.start_dim = getattr(args, "lora_squeeze_start_dim", None)
+        self.target_dim = args.network_dim
+        self.target_alpha = args.network_alpha
+        self.num_squeezes = getattr(args, "lora_squeeze_num_squeezes", 0)
+        if self.num_squeezes < 0:
+            raise ValueError("--lora_squeeze_num_squeezes must not be negative")
+        self.enabled = self.start_dim is not None or self.num_squeezes > 0
+        self.train_after_final_squeeze = getattr(args, "lora_squeeze_train_after_final_squeeze", True)
+        self.rank_schedule = getattr(args, "lora_squeeze_rank_schedule", "geometric")
+        self.step_schedule = getattr(args, "lora_squeeze_step_schedule", "equal")
+        self.optimizer_mode = getattr(args, "lora_squeeze_optimizer_mode", "per_squeeze")
+        self.scheduler_mode = getattr(args, "lora_squeeze_scheduler_mode", "global")
+        self.alpha_schedule = getattr(args, "lora_squeeze_alpha_schedule", "proportional")
+        self.first_segment_ratio = getattr(args, "lora_squeeze_first_segment_ratio", 1.0)
+        self.final_segment_ratio = getattr(args, "lora_squeeze_final_segment_ratio", 1.0)
+        if self.train_after_final_squeeze is None:
+            self.train_after_final_squeeze = True
+        if self.rank_schedule is None:
+            self.rank_schedule = "geometric"
+        if self.step_schedule is None:
+            self.step_schedule = "equal"
+        if self.optimizer_mode is None:
+            self.optimizer_mode = "per_squeeze"
+        if self.scheduler_mode is None:
+            self.scheduler_mode = "global"
+        if self.alpha_schedule is None:
+            self.alpha_schedule = "proportional"
+        if self.first_segment_ratio is None:
+            self.first_segment_ratio = 1.0
+        if self.final_segment_ratio is None:
+            self.final_segment_ratio = 1.0
+
+        self.ranks: List[int] = []
+        self.squeeze_steps: List[int] = []
+        self.segment_steps: List[int] = []
+        self.segment_weights: List[float] = []
+        self._resume_squeeze_steps: Optional[List[int]] = None
+        self._resume_segment_steps: Optional[List[int]] = None
+        self._resume_segment_weights: Optional[List[float]] = None
+        self.next_squeeze_index = 0
+        self.current_dim = self.target_dim
+        self.current_alpha = self.target_alpha
+        if not self.enabled:
+            return
+
+        if self.start_dim is None:
+            raise ValueError("--lora_squeeze_start_dim is required when LoRA-Squeeze is enabled")
+        if self.target_dim is None:
+            raise ValueError("--network_dim is required when LoRA-Squeeze is enabled")
+        if self.target_alpha is None:
+            raise ValueError("--network_alpha is required when LoRA-Squeeze is enabled")
+        if self.start_dim <= self.target_dim:
+            raise ValueError("--lora_squeeze_start_dim must be greater than --network_dim")
+        if self.num_squeezes <= 0:
+            raise ValueError("--lora_squeeze_num_squeezes must be greater than 0")
+        if self.target_dim <= 0:
+            raise ValueError("--network_dim must be greater than 0 when LoRA-Squeeze is enabled")
+        if not math.isfinite(self.target_alpha):
+            raise ValueError("--network_alpha must be finite when LoRA-Squeeze is enabled")
+        if self.target_alpha <= 0:
+            raise ValueError("--network_alpha must be greater than 0 when LoRA-Squeeze is enabled")
+        self._validate_choice("--lora_squeeze_rank_schedule", self.rank_schedule, self.RANK_SCHEDULE_CHOICES)
+        self._validate_choice("--lora_squeeze_step_schedule", self.step_schedule, self.STEP_SCHEDULE_CHOICES)
+        self._validate_choice("--lora_squeeze_optimizer_mode", self.optimizer_mode, self.STATE_MODE_CHOICES)
+        self._validate_choice("--lora_squeeze_scheduler_mode", self.scheduler_mode, self.STATE_MODE_CHOICES)
+        self._validate_choice("--lora_squeeze_alpha_schedule", self.alpha_schedule, self.ALPHA_SCHEDULE_CHOICES)
+        if not math.isfinite(self.first_segment_ratio):
+            raise ValueError("--lora_squeeze_first_segment_ratio must be finite")
+        if self.first_segment_ratio <= 0:
+            raise ValueError("--lora_squeeze_first_segment_ratio must be greater than 0")
+        if not math.isfinite(self.final_segment_ratio):
+            raise ValueError("--lora_squeeze_final_segment_ratio must be finite")
+        if self.final_segment_ratio <= 0:
+            raise ValueError("--lora_squeeze_final_segment_ratio must be greater than 0")
+
+        self.ranks = self._build_rank_schedule()
+        self.current_dim = self.start_dim
+        self.current_alpha = self.alpha_for_rank(self.current_dim)
+
+    @staticmethod
+    def _validate_choice(name: str, value: str, choices: Tuple[str, ...]):
+        if value not in choices:
+            raise ValueError(f"{name} must be one of: " + ", ".join(choices))
+
+    def _build_rank_schedule(self) -> List[int]:
+        ranks = [int(self.start_dim)]
+        rank_delta = self.start_dim - self.target_dim
+        for index in range(1, self.num_squeezes + 1):
+            if index == self.num_squeezes:
+                rank = self.target_dim
+            elif self.rank_schedule == "geometric":
+                progress = index / self.num_squeezes
+                ideal_rank = self.start_dim * math.pow(self.target_dim / self.start_dim, progress)
+                rank = math.floor(ideal_rank + 0.5)
+                minimum_rank = self.target_dim + self.num_squeezes - index
+                rank = min(max(rank, minimum_rank), ranks[-1] - 1)
+            else:
+                rank = math.floor(self.start_dim - rank_delta * index / self.num_squeezes)
+            if rank >= ranks[-1]:
+                raise ValueError(
+                    "LoRA-Squeeze rank schedule is not strictly decreasing. "
+                    "Use fewer squeezes or a larger start_dim-target_dim gap."
+                )
+            if rank < self.target_dim:
+                raise ValueError("LoRA-Squeeze rank schedule went below --network_dim")
+            ranks.append(int(rank))
+        return ranks
+
+    def alpha_for_rank(self, rank: int) -> float:
+        if self.alpha_schedule == "proportional":
+            alpha = float(self.target_alpha * rank / self.target_dim)
+        else:
+            alpha = float(self.target_alpha / math.sqrt(self.target_dim) * math.sqrt(rank))
+        if not math.isfinite(alpha):
+            raise ValueError(f"LoRA-Squeeze alpha schedule produced a non-finite alpha for rank {rank}")
+        return alpha
+
+    def _weight_for_rank(self, rank: int) -> float:
+        if self.step_schedule == "equal":
+            return 1.0
+        if self.step_schedule == "rank_proportional":
+            return float(rank)
+        if self.step_schedule == "sqrt_rank_proportional":
+            return math.sqrt(rank)
+        if self.step_schedule == "inverse_rank_proportional":
+            return 1.0 / float(rank)
+        if self.step_schedule == "inverse_sqrt_rank_proportional":
+            return 1.0 / math.sqrt(rank)
+        self._validate_choice("--lora_squeeze_step_schedule", self.step_schedule, self.STEP_SCHEDULE_CHOICES)
+        raise AssertionError("unreachable")
+
+    def _build_segment_weights(self) -> List[float]:
+        segment_ranks = self.ranks if self.train_after_final_squeeze else self.ranks[:-1]
+        weights = [self._weight_for_rank(rank) for rank in segment_ranks]
+        weights[0] *= self.first_segment_ratio
+        if self.train_after_final_squeeze:
+            weights[-1] *= self.final_segment_ratio
+        if any(not math.isfinite(weight) for weight in weights):
+            raise ValueError("LoRA-Squeeze step schedule produced a non-finite segment weight")
+        return weights
+
+    def set_total_steps(self, max_train_steps: int):
+        if not self.enabled:
+            return
+        self.segment_weights = self._build_segment_weights()
+        if max_train_steps < len(self.segment_weights):
+            raise ValueError(
+                f"max_train_steps={max_train_steps} is too small for "
+                f"{len(self.segment_weights)} LoRA-Squeeze training segments"
+            )
+        total_weight = sum(self.segment_weights)
+        if not math.isfinite(total_weight):
+            raise ValueError("LoRA-Squeeze step schedule produced a non-finite total segment weight")
+        cumulative_weight = 0.0
+        steps = []
+        weighted_boundary_count = self.num_squeezes if self.train_after_final_squeeze else self.num_squeezes - 1
+        for index in range(weighted_boundary_count):
+            cumulative_weight += self.segment_weights[index]
+            steps.append(math.floor(max_train_steps * cumulative_weight / total_weight))
+        if not self.train_after_final_squeeze:
+            # The terminal squeeze is the end of the training budget by definition.
+            # Do not let two numerically different floating-point summations move it
+            # one step earlier.
+            steps.append(max_train_steps)
+        previous_step = 0
+        for step in steps:
+            if step <= previous_step:
+                raise ValueError(
+                    "LoRA-Squeeze step schedule is not strictly increasing. "
+                    "Use fewer squeezes or more max_train_steps."
+                )
+            previous_step = step
+        if self.train_after_final_squeeze and steps[-1] >= max_train_steps:
+            raise ValueError(
+                "LoRA-Squeeze final segment has zero steps. "
+                "Increase max_train_steps or adjust the first/final segment ratios."
+            )
+        self.squeeze_steps = steps
+        boundaries = [0, *steps]
+        self.segment_steps = [boundaries[index + 1] - boundaries[index] for index in range(len(steps))]
+        if self.train_after_final_squeeze:
+            self.segment_steps.append(max_train_steps - steps[-1])
+        if sum(self.segment_steps) != max_train_steps:
+            raise AssertionError("LoRA-Squeeze segment steps do not cover the complete training budget")
+        self._validate_resume_schedule()
+
+    def _validate_resume_schedule(self):
+        comparisons = (
+            ("step schedule", self._resume_squeeze_steps, self.squeeze_steps),
+            ("segment steps", self._resume_segment_steps, self.segment_steps),
+            ("segment weights", self._resume_segment_weights, self.segment_weights),
+        )
+        for label, restored, current in comparisons:
+            if restored is not None and restored != current:
+                raise ValueError(
+                    f"LoRA-Squeeze resume state {label} does not match the current training configuration: "
+                    f"{restored} != {current}"
+                )
+
+    @property
+    def completed_squeezes(self) -> int:
+        return self.next_squeeze_index
+
+    @property
+    def current_segment_steps(self) -> Optional[int]:
+        if not self.enabled or not self.segment_steps or self.next_squeeze_index >= len(self.segment_steps):
+            return None
+        return self.segment_steps[self.next_squeeze_index]
+
+    @property
+    def next_segment_steps_after_squeeze(self) -> Optional[int]:
+        index = self.next_squeeze_index + 1
+        if not self.enabled or not self.segment_steps or index >= len(self.segment_steps):
+            return None
+        return self.segment_steps[index]
+
+    @property
+    def total_segments(self) -> int:
+        return len(self.segment_steps)
+
+    def next_due(self, global_step: int) -> Optional[Dict[str, Union[int, float]]]:
+        if not self.enabled or self.next_squeeze_index >= self.num_squeezes:
+            return None
+        if global_step < self.squeeze_steps[self.next_squeeze_index]:
+            return None
+        next_dim = self.ranks[self.next_squeeze_index + 1]
+        return {
+            "step": self.squeeze_steps[self.next_squeeze_index],
+            "dim": next_dim,
+            "alpha": self.alpha_for_rank(next_dim),
+        }
+
+    def mark_squeezed(self, dim: int, alpha: float):
+        self.current_dim = dim
+        self.current_alpha = alpha
+        self.next_squeeze_index += 1
+
+    def state_dict(self) -> Dict[str, Any]:
+        if not self.enabled:
+            return {}
+        return {
+            "version": 1,
+            "start_dim": self.start_dim,
+            "target_dim": self.target_dim,
+            "target_alpha": self.target_alpha,
+            "num_squeezes": self.num_squeezes,
+            "train_after_final_squeeze": bool(self.train_after_final_squeeze),
+            "optimizer_mode": self.optimizer_mode,
+            "scheduler_mode": self.scheduler_mode,
+            "rank_schedule": self.rank_schedule,
+            "step_schedule": self.step_schedule,
+            "alpha_schedule": self.alpha_schedule,
+            "first_segment_ratio": self.first_segment_ratio,
+            "final_segment_ratio": self.final_segment_ratio,
+            "ranks": list(self.ranks),
+            "squeeze_steps": list(self.squeeze_steps),
+            "segment_steps": list(self.segment_steps),
+            "segment_weights": list(self.segment_weights),
+            "next_squeeze_index": self.next_squeeze_index,
+            "current_dim": self.current_dim,
+            "current_alpha": self.current_alpha,
+        }
+
+    def load_state_dict(self, state: Dict[str, Any]):
+        if not self.enabled:
+            raise ValueError("cannot restore LoRA-Squeeze state when LoRA-Squeeze is not enabled")
+        if not state:
+            raise ValueError("LoRA-Squeeze resume state is missing")
+        expected_values = {
+            "version": 1,
+            "start_dim": self.start_dim,
+            "target_dim": self.target_dim,
+            "target_alpha": self.target_alpha,
+            "num_squeezes": self.num_squeezes,
+            "train_after_final_squeeze": bool(self.train_after_final_squeeze),
+            "optimizer_mode": self.optimizer_mode,
+            "scheduler_mode": self.scheduler_mode,
+            "rank_schedule": self.rank_schedule,
+            "step_schedule": self.step_schedule,
+            "alpha_schedule": self.alpha_schedule,
+            "first_segment_ratio": self.first_segment_ratio,
+            "final_segment_ratio": self.final_segment_ratio,
+            "ranks": self.ranks,
+        }
+        for key, expected in expected_values.items():
+            if key not in state:
+                raise ValueError(f"LoRA-Squeeze resume state is missing {key}")
+            actual = state[key]
+            if key in ("target_alpha", "first_segment_ratio", "final_segment_ratio"):
+                actual = float(actual)
+                if not math.isfinite(actual):
+                    raise ValueError(f"LoRA-Squeeze resume state {key} must be finite")
+                equal = math.isclose(actual, float(expected), rel_tol=1e-6, abs_tol=1e-8)
+            else:
+                equal = actual == expected
+            if not equal:
+                raise ValueError(
+                    f"LoRA-Squeeze resume state does not match current configuration for {key}: "
+                    f"{actual} != {expected}"
+                )
+        progress_keys = (
+            "next_squeeze_index",
+            "current_dim",
+            "current_alpha",
+            "squeeze_steps",
+            "segment_steps",
+            "segment_weights",
+        )
+        for key in progress_keys:
+            if key not in state:
+                raise ValueError(f"LoRA-Squeeze resume state is missing {key}")
+        index = int(state["next_squeeze_index"])
+        if index < 0 or index > self.num_squeezes:
+            raise ValueError(f"LoRA-Squeeze resume state has invalid next_squeeze_index: {index}")
+        expected_dim = self.ranks[index]
+        expected_alpha = self.alpha_for_rank(expected_dim)
+        current_dim = int(state["current_dim"])
+        current_alpha = float(state["current_alpha"])
+        if current_dim != expected_dim:
+            raise ValueError(
+                f"LoRA-Squeeze resume state current_dim does not match completed squeezes: "
+                f"{current_dim} != {expected_dim}"
+            )
+        if not math.isfinite(current_alpha):
+            raise ValueError("LoRA-Squeeze resume state current_alpha must be finite")
+        if not math.isclose(current_alpha, expected_alpha, rel_tol=1e-6, abs_tol=1e-8):
+            raise ValueError(
+                f"LoRA-Squeeze resume state current_alpha does not match completed squeezes: "
+                f"{current_alpha} != {expected_alpha}"
+            )
+        squeeze_steps = [int(step) for step in state["squeeze_steps"]]
+        segment_steps = [int(step) for step in state["segment_steps"]]
+        segment_weights = [float(weight) for weight in state["segment_weights"]]
+        if any(not math.isfinite(weight) for weight in segment_weights):
+            raise ValueError("LoRA-Squeeze resume state segment_weights must be finite")
+        self.next_squeeze_index = index
+        self.current_dim = current_dim
+        self.current_alpha = current_alpha
+        self.squeeze_steps = squeeze_steps
+        self.segment_steps = segment_steps
+        self.segment_weights = segment_weights
+        self._resume_squeeze_steps = list(self.squeeze_steps) if self.squeeze_steps else None
+        self._resume_segment_steps = list(self.segment_steps) if self.segment_steps else None
+        self._resume_segment_weights = list(self.segment_weights) if self.segment_weights else None
+
+    def rank_schedule_text(self) -> str:
+        return " -> ".join(str(rank) for rank in self.ranks)
+
+    def step_schedule_text(self) -> str:
+        return ", ".join(
+            f"step {step}: {self.ranks[index]}->{self.ranks[index + 1]}"
+            for index, step in enumerate(self.squeeze_steps)
+        )
+
+    def step_distribution_text(self) -> str:
+        text = self.step_schedule
+        if self.first_segment_ratio != 1.0:
+            text += f", first_segment_ratio={self.first_segment_ratio:g}"
+        if self.train_after_final_squeeze and self.final_segment_ratio != 1.0:
+            text += f", final_segment_ratio={self.final_segment_ratio:g}"
+        if self.segment_steps:
+            text += "; segment steps: " + " / ".join(str(step) for step in self.segment_steps)
+        return text
+
+
+def load_train_state_json(state_dir: str) -> Dict[str, Any]:
+    train_state_file = os.path.join(state_dir, "train_state.json")
+    if not os.path.exists(train_state_file):
+        raise ValueError(f"LoRA-Squeeze resume requires train_state.json in state directory: {state_dir}")
+    with open(train_state_file, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def restore_lora_squeeze_state_from_train_state(schedule: LoRASqueezeSchedule, train_state: Dict[str, Any]):
+    state = train_state.get(TRAIN_STATE_LORA_SQUEEZE_KEY)
+    if state is None:
+        raise ValueError(
+            "LoRA-Squeeze resume requires a state saved with LoRA-Squeeze metadata. "
+            "The selected train_state.json does not contain lora_squeeze."
+        )
+    schedule.load_state_dict(state)
+
+
+def restore_lora_squeeze_state_from_resume_dir(schedule: LoRASqueezeSchedule, state_dir: str) -> Dict[str, Any]:
+    train_state = load_train_state_json(state_dir)
+    restore_lora_squeeze_state_from_train_state(schedule, train_state)
+    return train_state
+
+
+def validate_lora_squeeze_training_args(args: argparse.Namespace):
+    if getattr(args, "torch_compile", False) or getattr(args, "compile", False):
+        raise ValueError(
+            "LoRA-Squeeze does not support torch.compile options because it replaces LoRA layers during training"
+        )
+
+
+def validate_lora_squeeze_network_args(net_kwargs: Dict[str, Any]):
+    unsupported = sorted(key for key in UNSUPPORTED_NETWORK_ARG_KEYS if key in net_kwargs)
+    if unsupported:
+        raise ValueError(
+            "LoRA-Squeeze does not support network_args that create separate per-module rank or alpha semantics: "
+            + ", ".join(unsupported)
+        )

--- a/library/lora_squeeze_training.py
+++ b/library/lora_squeeze_training.py
@@ -1,0 +1,738 @@
+"""LoRA-Squeeze optimizer, scheduler, and Accelerate lifecycle management."""
+
+import argparse
+import copy
+import json
+import math
+from dataclasses import dataclass
+from multiprocessing import Value
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+
+from library.accelerator_utils import (
+    find_replaceable_optimizer,
+    find_replaceable_scheduler,
+    make_replaceable_optimizer_scheduler,
+)
+from library.lora_squeeze_schedule import (
+    LoRASqueezeSchedule,
+    TRAIN_STATE_LORA_SQUEEZE_KEY,
+    get_remaining_training_steps,
+    get_resume_epoch_and_batch_offset,
+    is_training_budget_exhausted,
+    restore_lora_squeeze_state_from_resume_dir,
+    restore_lora_squeeze_state_from_train_state,
+    validate_lora_squeeze_network_args,
+    validate_lora_squeeze_training_args,
+)
+from library.lora_squeeze_compression import (
+    get_lora_squeeze_optimizer_parameter_layout,
+    restore_lora_module_layers,
+    preserve_lora_squeeze_alpha_precision,
+    snapshot_lora_module_layers,
+    squeeze_lora_network,
+    validate_lora_squeeze_network,
+    validate_lora_squeeze_optimizer_parameters,
+)
+from library.lora_squeeze_network import validate_lora_squeeze_network_module
+from library.lora_squeeze_optimizer import (
+    OptimizerStateCPUStagingError,
+    copy_optimizer_param_group_state,
+    move_optimizer_state_to_parameter_devices,
+    offload_optimizer_state_to_cpu,
+    prepare_optimizer_state_transfer,
+    restore_offloaded_optimizer_state,
+    validate_optimizer_scheduler_modes,
+)
+
+
+@dataclass
+class LoRASqueezeStepContext:
+    train_dim: int
+    train_alpha: float
+    learning_rates: List[float]
+    optimizer_param_groups: List[Dict[str, float]]
+    transition_stats: Optional[Dict[str, float]] = None
+
+
+class LoRASqueezeRuntime:
+    """Small integration surface between NetworkTrainer and LoRA-Squeeze."""
+
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.schedule = LoRASqueezeSchedule(args)
+        self.absolute_update_step = None
+        self.uses_conv_lora = False
+        if not self.enabled:
+            return
+        self.absolute_update_step = Value("i", 0)
+        validate_lora_squeeze_training_args(args)
+        if args.dim_from_weights:
+            raise ValueError(
+                "LoRA-Squeeze does not support --dim_from_weights because --network_dim is the target rank"
+            )
+        if args.deepspeed:
+            raise ValueError("LoRA-Squeeze does not support DeepSpeed yet")
+        if args.initial_step is not None or args.initial_epoch is not None:
+            raise ValueError("LoRA-Squeeze does not support --initial_step or --initial_epoch yet")
+
+    @property
+    def enabled(self) -> bool:
+        return self.schedule.enabled
+
+    @property
+    def current_dim(self) -> int:
+        return self.schedule.current_dim
+
+    @property
+    def current_alpha(self) -> float:
+        return self.schedule.current_alpha
+
+    def restore_from_resume_dir(self, state_dir: str):
+        restore_lora_squeeze_state_from_resume_dir(self.schedule, state_dir)
+
+    def restore_from_train_state(self, train_state: Dict[str, Any]):
+        if self.enabled:
+            restore_lora_squeeze_state_from_train_state(self.schedule, train_state)
+
+    def validate_process_count(self, num_processes: int):
+        if self.enabled and num_processes != 1:
+            raise ValueError("LoRA-Squeeze currently supports only single-process training")
+
+    def validate_network_module(self, network_module: Any, network_args: Dict[str, Any]):
+        if not self.enabled:
+            return
+        validate_lora_squeeze_network_args(network_args)
+        validate_lora_squeeze_network_module(network_module, network_args)
+
+    def prepare_network_args(self, network_args: Dict[str, Any]) -> Dict[str, Any]:
+        """Translate homogeneous C3Lier target settings to the current squeeze stage."""
+
+        if not self.enabled:
+            return network_args
+        if "conv_alpha" in network_args and "conv_dim" not in network_args:
+            raise ValueError("LoRA-Squeeze requires conv_dim when conv_alpha is specified")
+        if "conv_dim" not in network_args:
+            return network_args
+
+        try:
+            target_conv_dim = int(network_args["conv_dim"])
+            target_conv_alpha = float(network_args.get("conv_alpha", 1.0))
+        except (TypeError, ValueError) as error:
+            raise ValueError("LoRA-Squeeze requires numeric conv_dim and conv_alpha values") from error
+        if target_conv_dim != self.schedule.target_dim:
+            raise ValueError(
+                "LoRA-Squeeze requires homogeneous target ranks: "
+                f"conv_dim={target_conv_dim} must equal --network_dim={self.schedule.target_dim}"
+            )
+        if not math.isfinite(target_conv_alpha) or not math.isclose(
+            target_conv_alpha, self.schedule.target_alpha, rel_tol=1e-5, abs_tol=1e-8
+        ):
+            raise ValueError(
+                "LoRA-Squeeze requires homogeneous target alphas: "
+                f"conv_alpha={target_conv_alpha:.8g} must equal --network_alpha={self.schedule.target_alpha:.8g}"
+            )
+
+        self.uses_conv_lora = True
+        network_args["conv_dim"] = str(self.current_dim)
+        network_args["conv_alpha"] = str(self.current_alpha)
+        return network_args
+
+    def prepare_optimizer_scheduler_for_accelerator(self, optimizer: Any, lr_scheduler: Any) -> Tuple[Any, Any]:
+        if not self.enabled:
+            return optimizer, lr_scheduler
+        return make_replaceable_optimizer_scheduler(optimizer, lr_scheduler)
+
+    def validate_network(self, network: torch.nn.Module) -> Dict[str, float]:
+        return validate_lora_squeeze_network(network, self.schedule)
+
+    def preserve_alpha_precision(self, network: torch.nn.Module) -> int:
+        if not self.enabled:
+            return 0
+        return preserve_lora_squeeze_alpha_precision(network)
+
+    def initial_network_rank_alpha(self, network_dim: int, network_alpha: float) -> Tuple[int, float]:
+        if not self.enabled:
+            return network_dim, network_alpha
+        return self.current_dim, self.current_alpha
+
+    def set_total_steps(self, max_train_steps: int):
+        self.schedule.set_total_steps(max_train_steps)
+
+    def scheduler_training_steps(self) -> Optional[int]:
+        if self.enabled and self.schedule.scheduler_mode == "per_squeeze":
+            return self.schedule.current_segment_steps
+        return None
+
+    def preflight_optimizer(self, optimizer: torch.optim.Optimizer, network: torch.nn.Module):
+        if not self.enabled:
+            return None
+        validate_optimizer_scheduler_modes(
+            optimizer,
+            self.schedule.optimizer_mode,
+            self.schedule.scheduler_mode,
+        )
+        if self.schedule.optimizer_mode != "global":
+            return None
+        validate_lora_squeeze_optimizer_parameters(network, optimizer)
+        return prepare_optimizer_state_transfer(optimizer)
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.schedule.state_dict()
+
+    def add_to_train_state(self, train_state: Dict[str, Any]):
+        if self.enabled:
+            train_state[TRAIN_STATE_LORA_SQUEEZE_KEY] = self.state_dict()
+
+    def set_initial_step(self, initial_step: int):
+        if self.enabled:
+            self.absolute_update_step.value = initial_step
+
+    def progress_step(self) -> Optional[int]:
+        return self.absolute_update_step.value if self.enabled else None
+
+    def _validate_absolute_step(self, global_step: int):
+        if self.enabled and global_step != self.absolute_update_step.value:
+            raise RuntimeError(
+                "LoRA-Squeeze absolute update step diverged from NetworkTrainer global_step: "
+                f"{self.absolute_update_step.value} != {global_step}"
+            )
+
+    def remaining_steps(self, max_train_steps: int, global_step: int) -> int:
+        self._validate_absolute_step(global_step)
+        return get_remaining_training_steps(max_train_steps, global_step)
+
+    def budget_exhausted(self, max_train_steps: int, global_step: int) -> bool:
+        self._validate_absolute_step(global_step)
+        return is_training_budget_exhausted(max_train_steps, global_step)
+
+    def resume_epoch_and_batch_offset(
+        self,
+        completed_steps: int,
+        num_batches_per_epoch: int,
+        gradient_accumulation_steps: int,
+    ) -> Tuple[int, int]:
+        return get_resume_epoch_and_batch_offset(
+            completed_steps,
+            num_batches_per_epoch,
+            gradient_accumulation_steps,
+        )
+
+    def capture_step_context(self, optimizer: Any) -> Optional[LoRASqueezeStepContext]:
+        if not self.enabled:
+            return None
+        raw_optimizer = getattr(optimizer, "optimizer", optimizer)
+        optimizer_param_groups = []
+        for group in raw_optimizer.param_groups:
+            snapshot = {}
+            for key in ("lr", "d", "effective_lr"):
+                if key not in group:
+                    continue
+                try:
+                    snapshot[key] = float(group[key])
+                except (TypeError, ValueError):
+                    continue
+            optimizer_param_groups.append(snapshot)
+        return LoRASqueezeStepContext(
+            train_dim=self.current_dim,
+            train_alpha=self.current_alpha,
+            learning_rates=[group["lr"] for group in optimizer_param_groups],
+            optimizer_param_groups=optimizer_param_groups,
+        )
+
+    def run_after_optimizer_step(
+        self,
+        controller: "LoRASqueezeTrainingController",
+        context: Optional[LoRASqueezeStepContext],
+        global_step: int,
+    ) -> bool:
+        if not self.enabled:
+            return False
+        expected_step = self.absolute_update_step.value + 1
+        if global_step != expected_step:
+            raise RuntimeError(
+                f"LoRA-Squeeze expected absolute update step {expected_step}, received {global_step}"
+            )
+        self.absolute_update_step.value = global_step
+        squeezed = controller.run_if_due(global_step)
+        if context is not None and squeezed:
+            context.transition_stats = dict(controller.last_squeeze_stats or {})
+        return squeezed
+
+    def append_step_logs(self, logs: Dict[str, Any], context: Optional[LoRASqueezeStepContext]):
+        if not self.enabled or context is None:
+            return
+        logs["lora_squeeze/train_dim"] = context.train_dim
+        logs["lora_squeeze/train_alpha"] = context.train_alpha
+        logs["lora_squeeze/current_dim"] = self.current_dim
+        logs["lora_squeeze/current_alpha"] = self.current_alpha
+        logs["lora_squeeze/completed_squeezes"] = self.schedule.completed_squeezes
+        logs["lora_squeeze/transition"] = int(context.transition_stats is not None)
+        if context.transition_stats:
+            for key in (
+                "modules",
+                "source_rank",
+                "target_rank",
+                "retained_energy_min",
+                "retained_energy_mean",
+                "numerical_rank_min",
+                "numerical_rank_mean",
+                "rank_deficient_modules",
+                "revived_rank_channels",
+                "optimizer_state_projected",
+                "optimizer_state_reset",
+                "optimizer_state_empty",
+                "optimizer_state_warm_restarted",
+            ):
+                if key in context.transition_stats:
+                    logs[f"lora_squeeze/{key}"] = context.transition_stats[key]
+
+    def metadata_values(self) -> Dict[str, Any]:
+        schedule = self.schedule
+        if not self.enabled:
+            return {}
+        return {
+            "ss_network_dim": schedule.current_dim,
+            "ss_network_alpha": schedule.current_alpha,
+            "ss_lora_squeeze_enabled": True,
+            "ss_lora_squeeze_start_dim": schedule.start_dim,
+            "ss_lora_squeeze_target_dim": schedule.target_dim,
+            "ss_lora_squeeze_target_alpha": schedule.target_alpha,
+            "ss_lora_squeeze_num_squeezes": schedule.num_squeezes,
+            "ss_lora_squeeze_train_after_final_squeeze": bool(schedule.train_after_final_squeeze),
+            "ss_lora_squeeze_optimizer_mode": schedule.optimizer_mode,
+            "ss_lora_squeeze_scheduler_mode": schedule.scheduler_mode,
+            "ss_lora_squeeze_rank_distribution": schedule.rank_schedule,
+            "ss_lora_squeeze_step_distribution": schedule.step_schedule,
+            "ss_lora_squeeze_alpha_schedule": schedule.alpha_schedule,
+            "ss_lora_squeeze_first_segment_ratio": schedule.first_segment_ratio,
+            "ss_lora_squeeze_final_segment_ratio": schedule.final_segment_ratio,
+            "ss_lora_squeeze_rank_schedule": json.dumps(schedule.ranks),
+            "ss_lora_squeeze_step_schedule": json.dumps(schedule.squeeze_steps),
+            "ss_lora_squeeze_segment_steps": json.dumps(schedule.segment_steps),
+            "ss_lora_squeeze_segment_weights": json.dumps(schedule.segment_weights),
+            "ss_lora_squeeze_current_segment_steps": schedule.current_segment_steps,
+            "ss_lora_squeeze_current_dim": schedule.current_dim,
+            "ss_lora_squeeze_current_alpha": schedule.current_alpha,
+            "ss_lora_squeeze_completed_squeezes": schedule.completed_squeezes,
+        }
+
+    def update_metadata(self, metadata: Dict[str, Any], minimum_metadata: Dict[str, Any]):
+        for key, value in self.metadata_values().items():
+            value = str(value)
+            metadata[key] = value
+            if key in minimum_metadata:
+                minimum_metadata[key] = value
+        if self.uses_conv_lora:
+            for target in (metadata, minimum_metadata):
+                serialized_args = target.get("ss_network_args")
+                if serialized_args is None:
+                    continue
+                network_args = json.loads(serialized_args)
+                network_args["conv_dim"] = str(self.current_dim)
+                network_args["conv_alpha"] = str(self.current_alpha)
+                target["ss_network_args"] = json.dumps(network_args)
+
+    def resume_status_message(self, is_resuming: bool) -> Optional[str]:
+        if not self.enabled or not is_resuming:
+            return None
+        schedule = self.schedule
+        return (
+            "LoRA-Squeeze resume state restored: "
+            f"completed_squeezes={schedule.completed_squeezes}, "
+            f"current_rank={schedule.current_dim}, current_alpha={schedule.current_alpha:.8g}"
+        )
+
+    def network_creation_status_message(self, network_dim: int, network_alpha: float) -> Optional[str]:
+        if not self.enabled:
+            return None
+        schedule = self.schedule
+        return (
+            f"LoRA-Squeeze enabled. rank schedule: {schedule.rank_schedule_text()}; "
+            f"alpha schedule: {schedule.alpha_schedule}; "
+            f"current rank: {network_dim}; current alpha: {network_alpha:.8g}"
+        )
+
+    def preflight_status_message(self, stats: Dict[str, float]) -> Optional[str]:
+        if not self.enabled:
+            return None
+        return (
+            "LoRA-Squeeze preflight: "
+            f"modules={int(stats['modules'])}, current_rank={int(stats['source_rank'])}"
+        )
+
+    def step_schedule_status_messages(self) -> List[str]:
+        if not self.enabled:
+            return []
+        return [
+            f"LoRA-Squeeze step distribution: {self.schedule.step_distribution_text()}",
+            f"LoRA-Squeeze step schedule: {self.schedule.step_schedule_text()}",
+        ]
+
+    def optimizer_preflight_status_messages(self, optimizer_state_adapter: Optional[Any]) -> List[str]:
+        if (
+            not self.enabled
+            or optimizer_state_adapter is None
+            or optimizer_state_adapter.warm_restart_reason is None
+        ):
+            return []
+        return [
+            "LoRA-Squeeze global optimizer policy will preserve learned global scale and warm-restart "
+            f"coupled state: {optimizer_state_adapter.warm_restart_reason}"
+        ]
+
+    def optimizer_scheduler_status_messages(self, scheduler_training_steps: Optional[int]) -> List[str]:
+        if not self.enabled:
+            return []
+        schedule = self.schedule
+        messages = []
+        if schedule.optimizer_mode == "global":
+            messages.append("LoRA-Squeeze optimizer mode: global; optimizer-specific state transfer is enabled")
+        else:
+            messages.append("LoRA-Squeeze optimizer mode: per_squeeze; state will reset after each squeeze")
+        if schedule.scheduler_mode == "per_squeeze":
+            messages.append(
+                "LoRA-Squeeze scheduler mode: per_squeeze; "
+                f"segment {schedule.completed_squeezes + 1}/{schedule.total_segments}, "
+                f"steps={scheduler_training_steps}"
+            )
+        else:
+            messages.append("LoRA-Squeeze scheduler mode: global; continuing one global training curve")
+        return messages
+
+    def network_weights_load_error(self, error: RuntimeError) -> RuntimeError:
+        schedule = self.schedule
+        return RuntimeError(
+            "Failed to load --network_weights while LoRA-Squeeze is enabled. "
+            "A rank mismatch is a possible cause: the weight file must match "
+            f"the current LoRA-Squeeze rank {schedule.current_dim}; alpha values must also match "
+            f"the current LoRA-Squeeze alpha {schedule.current_alpha:.8g}. "
+            f"Original error: {error}"
+        )
+
+
+class LoRASqueezeTrainingController:
+    def __init__(
+        self,
+        *,
+        args: argparse.Namespace,
+        accelerator: Any,
+        schedule: LoRASqueezeSchedule,
+        network: torch.nn.Module,
+        optimizer_util: Any,
+        optimizer_name: str,
+        optimizer_args: str,
+        optimizer: torch.optim.Optimizer,
+        optimizer_train_fn: Callable[[], None],
+        optimizer_eval_fn: Callable[[], None],
+        lr_scheduler: Any,
+        lr_descriptions: Any,
+        prepare_optimizer_params_fn: Callable[[], Tuple[Any, Any]],
+        prepare_grad_fn: Callable[[], None],
+        update_metadata_fn: Callable[[], None],
+        clean_memory_fn: Callable[[], None],
+        logger: Optional[Any] = None,
+        optimizer_factory_args: Optional[argparse.Namespace] = None,
+    ):
+        self.args = args
+        self.accelerator = accelerator
+        self.schedule = schedule
+        self.network = network
+        self.optimizer_util = optimizer_util
+        self.optimizer_name = optimizer_name
+        self.optimizer_args = optimizer_args
+        self.optimizer = optimizer
+        self.optimizer_train_fn = optimizer_train_fn
+        self.optimizer_eval_fn = optimizer_eval_fn
+        self.lr_scheduler = lr_scheduler
+        self.lr_descriptions = lr_descriptions
+        self.prepare_optimizer_params_fn = prepare_optimizer_params_fn
+        self.prepare_grad_fn = prepare_grad_fn
+        self.update_metadata_fn = update_metadata_fn
+        self.clean_memory_fn = clean_memory_fn
+        self.logger = logger
+        self.optimizer_factory_args = optimizer_factory_args if optimizer_factory_args is not None else args
+        self.last_squeeze_stats: Optional[Dict[str, float]] = None
+        self.replaceable_optimizer = find_replaceable_optimizer(optimizer)
+        self.replaceable_scheduler = find_replaceable_scheduler(lr_scheduler)
+
+    def export_training_state(self) -> Tuple[str, str, Any, Callable[[], None], Callable[[], None], Any, Any]:
+        return (
+            self.optimizer_name,
+            self.optimizer_args,
+            self.optimizer,
+            self.optimizer_train_fn,
+            self.optimizer_eval_fn,
+            self.lr_scheduler,
+            self.lr_descriptions,
+        )
+
+    def _terminal_state_save_requested(self) -> bool:
+        return bool(getattr(self.args, "save_state", False) or getattr(self.args, "save_state_on_train_end", False))
+
+    def _release_terminal_optimizer_parameters(self):
+        raw_optimizer = (
+            self.replaceable_optimizer.optimizer
+            if self.replaceable_optimizer is not None
+            else getattr(self.optimizer, "optimizer", self.optimizer)
+        )
+        if hasattr(raw_optimizer, "state"):
+            raw_optimizer.state.clear()
+        for group in getattr(raw_optimizer, "param_groups", []):
+            group["params"] = []
+
+    def rebuild_optimizer(
+        self,
+        optimizer_state_transfers: List[Tuple[torch.nn.Parameter, Dict[str, Any]]],
+        squeeze_stats: Dict[str, float],
+        segment_steps: Optional[int],
+        expected_parameter_layout: Optional[Tuple[Tuple[str, ...], ...]],
+        offload_optimizer_state: bool = True,
+    ):
+        terminal_squeeze = segment_steps is None
+        old_optimizer = self.optimizer
+        old_lr_scheduler = self.lr_scheduler
+        raw_old_optimizer = (
+            self.replaceable_optimizer.optimizer
+            if self.replaceable_optimizer is not None
+            else getattr(old_optimizer, "optimizer", old_optimizer)
+        )
+        global_optimizer_mode = self.schedule.optimizer_mode == "global"
+        global_scheduler_mode = self.schedule.scheduler_mode == "global"
+        old_scheduler_state = (
+            old_lr_scheduler.state_dict()
+            if global_scheduler_mode and hasattr(old_lr_scheduler, "state_dict")
+            else None
+        )
+        old_group_lrs = [group["lr"] for group in raw_old_optimizer.param_groups] if global_scheduler_mode else None
+
+        trainable_params, new_lr_descriptions = self.prepare_optimizer_params_fn()
+        optimizer_factory_args = copy.copy(self.optimizer_factory_args)
+        new_optimizer_name, new_optimizer_args, new_optimizer = self.optimizer_util.get_optimizer(
+            optimizer_factory_args, trainable_params
+        )
+        if global_optimizer_mode:
+            unwrapped_network = self.accelerator.unwrap_model(self.network)
+            new_parameter_layout = get_lora_squeeze_optimizer_parameter_layout(unwrapped_network, new_optimizer)
+            if new_parameter_layout != expected_parameter_layout:
+                raise ValueError(
+                    "LoRA-Squeeze global optimizer mode changed factor parameter-group membership or ordering: "
+                    f"{expected_parameter_layout} -> {new_parameter_layout}"
+                )
+
+        projected_state_count = 0
+        old_optimizer_offload_records = []
+        try:
+            if global_optimizer_mode:
+                if offload_optimizer_state:
+                    old_optimizer_offload_records = offload_optimizer_state_to_cpu(raw_old_optimizer)
+                copy_optimizer_param_group_state(raw_old_optimizer, new_optimizer, optimizer_state_transfers)
+                for parameter, state in optimizer_state_transfers:
+                    if state:
+                        new_optimizer.state[parameter] = state
+                        projected_state_count += 1
+                move_optimizer_state_to_parameter_devices(new_optimizer)
+
+            if global_scheduler_mode:
+                new_lr_scheduler = self.optimizer_util.get_scheduler_fix(
+                    self.args,
+                    new_optimizer,
+                    self.accelerator.num_processes,
+                )
+            else:
+                new_lr_scheduler = self.optimizer_util.get_scheduler_fix(
+                    self.args,
+                    new_optimizer,
+                    self.accelerator.num_processes,
+                    training_steps=1 if terminal_squeeze else segment_steps,
+                )
+            if global_scheduler_mode:
+                if old_scheduler_state is not None and hasattr(new_lr_scheduler, "load_state_dict"):
+                    new_lr_scheduler.load_state_dict(old_scheduler_state)
+                if len(new_optimizer.param_groups) != len(old_group_lrs):
+                    raise ValueError("LoRA-Squeeze global scheduler mode changed the optimizer parameter-group count")
+                for group, lr in zip(new_optimizer.param_groups, old_group_lrs):
+                    group["lr"] = lr
+
+            new_optimizer_train_fn, new_optimizer_eval_fn = self.optimizer_util.get_optimizer_train_eval_fn(
+                new_optimizer, self.args
+            )
+            new_optimizer_train_fn()
+        except Exception:
+            if hasattr(new_optimizer, "state"):
+                for state in new_optimizer.state.values():
+                    state.clear()
+                new_optimizer.state.clear()
+            restore_offloaded_optimizer_state(old_optimizer_offload_records)
+            raise
+
+        if self.replaceable_optimizer is not None:
+            self.replaceable_optimizer.replace(new_optimizer)
+            prepared_optimizer = old_optimizer
+        else:
+            prepared_optimizer = new_optimizer
+        if self.replaceable_scheduler is not None:
+            self.replaceable_scheduler.replace(new_lr_scheduler)
+            prepared_lr_scheduler = old_lr_scheduler
+        else:
+            prepared_lr_scheduler = new_lr_scheduler
+
+        if hasattr(raw_old_optimizer, "state"):
+            raw_old_optimizer.state.clear()
+
+        self.optimizer_name = new_optimizer_name
+        self.optimizer_args = new_optimizer_args
+        self.optimizer = prepared_optimizer
+        self.lr_scheduler = prepared_lr_scheduler
+        self.optimizer_train_fn, self.optimizer_eval_fn = self.optimizer_util.get_optimizer_train_eval_fn(
+            prepared_optimizer, self.args
+        )
+        self.lr_descriptions = new_lr_descriptions
+
+        target_rank = int(squeeze_stats.get("target_rank", self.schedule.current_dim))
+        if global_optimizer_mode:
+            reset_state_count = int(squeeze_stats.get("optimizer_state_reset", 0))
+            empty_state_count = int(squeeze_stats.get("optimizer_state_empty", 0))
+            warm_restart_count = int(squeeze_stats.get("optimizer_state_warm_restarted", 0))
+            self.accelerator.print(
+                "LoRA-Squeeze optimizer continued globally: "
+                f"rank={target_rank}, projected_states={projected_state_count}, "
+                f"warm_restarted_states={warm_restart_count}, reset_states={reset_state_count}, "
+                f"empty_states={empty_state_count}"
+            )
+            if warm_restart_count > 0:
+                self.accelerator.print(
+                    "LoRA-Squeeze optimizer used a coherent warm restart for unprojectable state; "
+                    "the optimizer's learned global scale was preserved"
+                )
+            if reset_state_count > 0:
+                self.accelerator.print(
+                    "LoRA-Squeeze warning: global optimizer mode continued optimizer param-group state, "
+                    "but reset unsupported per-parameter optimizer state for some squeezed parameters"
+                )
+        else:
+            self.accelerator.print(f"LoRA-Squeeze optimizer reset for rank={target_rank}")
+
+        if global_scheduler_mode:
+            self.accelerator.print(f"LoRA-Squeeze scheduler continued globally for rank={target_rank}")
+        elif terminal_squeeze:
+            self.accelerator.print(f"LoRA-Squeeze scheduler refreshed after terminal squeeze: rank={target_rank}")
+        else:
+            self.accelerator.print(
+                "LoRA-Squeeze scheduler restarted: "
+                f"segment {self.schedule.completed_squeezes + 2}/{self.schedule.total_segments}, "
+                f"rank={target_rank}, steps={segment_steps}"
+            )
+
+    def run_if_due(self, lora_squeeze_step: int) -> bool:
+        self.last_squeeze_stats = None
+        event = self.schedule.next_due(lora_squeeze_step)
+        if event is None:
+            return False
+
+        target_dim = int(event["dim"])
+        target_alpha = float(event["alpha"])
+        unwrapped_network = self.accelerator.unwrap_model(self.network)
+        self.accelerator.wait_for_everyone()
+        raw_optimizer = (
+            self.replaceable_optimizer.optimizer
+            if self.replaceable_optimizer is not None
+            else getattr(self.optimizer, "optimizer", self.optimizer)
+        )
+        next_segment_steps = self.schedule.next_segment_steps_after_squeeze
+        terminal_squeeze = next_segment_steps is None
+        skip_terminal_rebuild = terminal_squeeze and not self._terminal_state_save_requested()
+        optimizer_for_state_transfer = (
+            raw_optimizer if self.schedule.optimizer_mode == "global" and not skip_terminal_rebuild else None
+        )
+        optimizer_parameter_layout = (
+            get_lora_squeeze_optimizer_parameter_layout(unwrapped_network, raw_optimizer)
+            if optimizer_for_state_transfer is not None
+            else None
+        )
+        terminal_optimizer_in_eval_mode = False
+        if terminal_squeeze:
+            self.optimizer_eval_fn()
+            terminal_optimizer_in_eval_mode = True
+        layer_snapshots = snapshot_lora_module_layers(unwrapped_network)
+
+        def squeeze_and_rebuild(optimizer_state_staging_device, offload_optimizer_state):
+            stats, optimizer_state_transfers = squeeze_lora_network(
+                unwrapped_network,
+                target_dim,
+                target_alpha,
+                optimizer_for_state_transfer=optimizer_for_state_transfer,
+                optimizer_state_staging_device=optimizer_state_staging_device,
+            )
+            if not skip_terminal_rebuild:
+                self.prepare_grad_fn()
+                self.rebuild_optimizer(
+                    optimizer_state_transfers,
+                    stats,
+                    next_segment_steps,
+                    optimizer_parameter_layout,
+                    offload_optimizer_state=offload_optimizer_state,
+                )
+            return stats
+
+        try:
+            cpu_staging_error = None
+            try:
+                stats = squeeze_and_rebuild(
+                    "cpu" if optimizer_for_state_transfer is not None else None,
+                    True,
+                )
+            except OptimizerStateCPUStagingError as error:
+                cpu_staging_error = str(error)
+
+            if cpu_staging_error is not None:
+                restore_lora_module_layers(layer_snapshots)
+                self.prepare_grad_fn()
+                self.clean_memory_fn()
+                self.accelerator.print(
+                    "LoRA-Squeeze CPU optimizer-state staging failed; retrying on the parameter device "
+                    f"with higher peak VRAM usage. Error: {cpu_staging_error}"
+                )
+                stats = squeeze_and_rebuild(None, False)
+        except Exception:
+            restore_lora_module_layers(layer_snapshots)
+            try:
+                if terminal_optimizer_in_eval_mode:
+                    self.optimizer_train_fn()
+                self.prepare_grad_fn()
+            except Exception as restore_error:
+                if self.logger is not None:
+                    self.logger.warning(f"failed to refresh LoRA gradients after rollback: {restore_error}")
+            raise
+
+        layer_snapshots.clear()
+        self.schedule.mark_squeezed(target_dim, target_alpha)
+        self.last_squeeze_stats = dict(stats)
+        self.update_metadata_fn()
+        self.accelerator.print(
+            f"LoRA-Squeeze at step {lora_squeeze_step}: rank {int(stats['source_rank'])} -> {target_dim}, "
+            f"alpha={target_alpha:.8g}, retained_energy_min={stats['retained_energy_min']:.6f}, "
+            f"retained_energy_mean={stats['retained_energy_mean']:.6f}, "
+            f"numerical_rank_min={int(stats['numerical_rank_min'])}"
+        )
+        revived_channels = int(stats.get("revived_rank_channels", 0))
+        if revived_channels > 0:
+            self.accelerator.print(
+                "LoRA-Squeeze warning: revived "
+                f"{revived_channels} numerically zero rank channels across "
+                f"{int(stats['rank_deficient_modules'])} modules with zero-product, learnable initialization"
+            )
+        if skip_terminal_rebuild:
+            self._release_terminal_optimizer_parameters()
+            self.accelerator.print(
+                "LoRA-Squeeze terminal compression complete; skipped optimizer and scheduler rebuild "
+                "and compressed the optimizer evaluation point because no resumable state was requested"
+            )
+        elif terminal_squeeze:
+            self.accelerator.print(
+                "LoRA-Squeeze terminal compression complete; rebuilt resumable optimizer and scheduler state "
+                "from the optimizer evaluation point"
+            )
+        self.clean_memory_fn()
+        return True

--- a/library/optimizer.py
+++ b/library/optimizer.py
@@ -471,16 +471,22 @@ def get_dummy_scheduler(optimizer: Optimizer) -> Any:
 # Add some checking and features to the original function.
 
 
-def get_scheduler_fix(args, optimizer: Optimizer, num_processes: int):
+def get_scheduler_fix(args, optimizer: Optimizer, num_processes: int, training_steps: Optional[int] = None):
     """
     Unified API to get any scheduler from its name.
+
+    ``training_steps`` overrides ``args.max_train_steps`` for scheduler
+    construction. LoRA-Squeeze uses this for independent rank segments.
     """
     # if schedulefree optimizer, return dummy scheduler
     if is_schedulefree_optimizer(optimizer, args):
         return get_dummy_scheduler(optimizer)
 
     name = args.lr_scheduler
-    num_training_steps = args.max_train_steps * num_processes  # * args.gradient_accumulation_steps
+    if training_steps is not None and training_steps <= 0:
+        raise ValueError("training_steps must be greater than 0")
+    scheduler_training_steps = args.max_train_steps if training_steps is None else training_steps
+    num_training_steps = scheduler_training_steps * num_processes  # * args.gradient_accumulation_steps
     num_warmup_steps: Optional[int] = (
         int(args.lr_warmup_steps * num_training_steps) if isinstance(args.lr_warmup_steps, float) else args.lr_warmup_steps
     )

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -127,6 +127,7 @@ from library.model_io import (  # noqa: F401, E402
 from library.args import (  # noqa: F401, E402
     add_sd_models_arguments,
     add_optimizer_arguments,
+    add_lora_squeeze_arguments,
     add_training_arguments,
     add_masked_loss_arguments,
     add_dit_training_arguments,

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -13,6 +13,7 @@ import torch
 import re
 from library.utils import setup_logging
 from library.sdxl_original_unet import SdxlUNet2DConditionModel
+from library.lora_squeeze_network import StandardLoRASqueezeModuleMixin
 
 setup_logging()
 import logging
@@ -22,7 +23,11 @@ logger = logging.getLogger(__name__)
 RE_UPDOWN = re.compile(r"(up|down)_blocks_(\d+)_(resnets|upsamplers|downsamplers|attentions)_(\d+)_")
 
 
-class LoRAModule(torch.nn.Module):
+def validate_lora_squeeze_support(_network_args: Dict[str, str]):
+    """Declare early compatibility; instantiated factors are validated separately."""
+
+
+class LoRAModule(StandardLoRASqueezeModuleMixin, torch.nn.Module):
     """
     replaces forward method of the original Linear, instead of replacing the original Linear module.
     """
@@ -1063,6 +1068,10 @@ class LoRANetwork(torch.nn.Module):
         self.multiplier = multiplier
         for lora in self.text_encoder_loras + self.unet_loras:
             lora.multiplier = self.multiplier
+
+    def get_lora_squeeze_modules(self):
+        """Expose only factors whose replacement lifecycle this network owns."""
+        return tuple(self.text_encoder_loras + self.unet_loras)
 
     def set_enabled(self, is_enabled):
         for lora in self.text_encoder_loras + self.unet_loras:

--- a/networks/lora_anima.py
+++ b/networks/lora_anima.py
@@ -6,6 +6,7 @@ import re
 from typing import Dict, List, Optional, Tuple, Type, Union
 import torch
 from library.utils import setup_logging
+from library.lora_squeeze_network import StandardLoRASqueezeModuleMixin
 
 import logging
 
@@ -13,7 +14,11 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 
-class LoRAModule(torch.nn.Module):
+def validate_lora_squeeze_support(_network_args: Dict[str, str]):
+    """Declare early compatibility; instantiated factors are validated separately."""
+
+
+class LoRAModule(StandardLoRASqueezeModuleMixin, torch.nn.Module):
     """
     replaces forward method of the original Linear, instead of replacing the original Linear module.
     """
@@ -565,6 +570,10 @@ class LoRANetwork(torch.nn.Module):
         self.multiplier = multiplier
         for lora in self.text_encoder_loras + self.unet_loras:
             lora.multiplier = self.multiplier
+
+    def get_lora_squeeze_modules(self):
+        """Expose only factors whose replacement lifecycle this network owns."""
+        return tuple(self.text_encoder_loras + self.unet_loras)
 
     def set_enabled(self, is_enabled):
         for lora in self.text_encoder_loras + self.unet_loras:

--- a/tests/lora_squeeze_test_utils.py
+++ b/tests/lora_squeeze_test_utils.py
@@ -1,0 +1,178 @@
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from library.accelerator_utils import ReplaceableLRScheduler, ReplaceableOptimizer
+from library.lora_squeeze_compression import get_lora_factor_matrices
+from library.lora_squeeze_network import StandardLoRASqueezeModuleMixin
+from library.lora_squeeze_schedule import LoRASqueezeSchedule
+from library.lora_squeeze_training import LoRASqueezeTrainingController
+
+
+def make_schedule_args(**overrides):
+    args = {
+        "lora_squeeze_start_dim": 41,
+        "lora_squeeze_num_squeezes": 4,
+        "network_dim": 9,
+        "network_alpha": 3,
+        "lora_squeeze_train_after_final_squeeze": True,
+        "lora_squeeze_rank_schedule": "geometric",
+        "lora_squeeze_step_schedule": "equal",
+        "lora_squeeze_optimizer_mode": "global",
+        "lora_squeeze_scheduler_mode": "global",
+        "lora_squeeze_alpha_schedule": "sqrt",
+        "lora_squeeze_first_segment_ratio": 1.0,
+        "lora_squeeze_final_segment_ratio": 1.0,
+        "dim_from_weights": False,
+        "deepspeed": False,
+        "initial_step": None,
+        "initial_epoch": None,
+        "torch_compile": False,
+        "compile": False,
+    }
+    args.update(overrides)
+    return SimpleNamespace(**args)
+
+
+def make_schedule(**overrides):
+    return LoRASqueezeSchedule(make_schedule_args(**overrides))
+
+
+class FakeLoRAModule(StandardLoRASqueezeModuleMixin, nn.Module):
+    def __init__(self, in_dim, out_dim, rank, alpha, kernel_size=1):
+        super().__init__()
+        self.lora_name = "test_lora"
+        self.lora_dim = rank
+        self.scale = alpha / rank
+        self.register_buffer("alpha", torch.tensor(alpha))
+        if kernel_size == 1:
+            self.lora_down = nn.Linear(in_dim, rank, bias=False)
+            self.lora_up = nn.Linear(rank, out_dim, bias=False)
+        else:
+            self.lora_down = nn.Conv2d(in_dim, rank, kernel_size, padding=kernel_size // 2, bias=False)
+            self.lora_up = nn.Conv2d(rank, out_dim, 1, bias=False)
+
+
+class FakeFloatAlphaLoRAModule(StandardLoRASqueezeModuleMixin, nn.Module):
+    def __init__(self, in_dim, out_dim, rank, alpha):
+        super().__init__()
+        self.lora_name = "float_alpha_lora"
+        self.lora_dim = rank
+        self.scale = alpha / rank
+        self.alpha = alpha
+        self.lora_down = nn.Linear(in_dim, rank, bias=False)
+        self.lora_up = nn.Linear(rank, out_dim, bias=False)
+
+
+class FakeNetwork(nn.Module):
+    def __init__(self, module):
+        super().__init__()
+        self.adapter = module
+
+    def get_lora_squeeze_modules(self):
+        return (self.adapter,)
+
+
+class FakeMultiNetwork(nn.Module):
+    def __init__(self, *modules):
+        super().__init__()
+        self.adapters = nn.ModuleList(modules)
+
+    def get_lora_squeeze_modules(self):
+        return tuple(self.adapters)
+
+
+class FakeScheduler:
+    def __init__(self, optimizer):
+        self.optimizer = optimizer
+        self.loaded_state = None
+
+    def state_dict(self):
+        return {"step": 3}
+
+    def load_state_dict(self, state):
+        self.loaded_state = state
+
+    def step(self):
+        pass
+
+    def get_last_lr(self):
+        return [group["lr"] for group in self.optimizer.param_groups]
+
+
+class FakeAccelerator:
+    num_processes = 1
+    device = torch.device("cpu")
+
+    def __init__(self, optimizer, scheduler):
+        self._optimizers = [optimizer]
+        self._schedulers = [scheduler]
+        self.messages = []
+
+    def unwrap_model(self, network):
+        return network
+
+    def wait_for_everyone(self):
+        pass
+
+    def prepare(self, optimizer, scheduler):
+        self._optimizers.append(optimizer)
+        self._schedulers.append(scheduler)
+        return optimizer, scheduler
+
+    def print(self, message):
+        self.messages.append(message)
+
+
+class FakeOptimizerUtil:
+    def __init__(self, optimizer_class=torch.optim.SGD, lr=0.1):
+        self.optimizer_class = optimizer_class
+        self.lr = lr
+        self.training_steps = []
+
+    def get_optimizer(self, args, trainable_params):
+        optimizer = self.optimizer_class(trainable_params, lr=self.lr)
+        return f"{type(optimizer).__module__}.{type(optimizer).__name__}", "", optimizer
+
+    def get_scheduler_fix(self, args, optimizer, num_processes, training_steps=None):
+        self.training_steps.append(training_steps)
+        return FakeScheduler(optimizer)
+
+    def get_optimizer_train_eval_fn(self, optimizer, args):
+        return lambda: None, lambda: None
+
+
+def effective_delta(module):
+    up, down, _ = get_lora_factor_matrices(module)
+    return up @ down * module.scale
+
+
+def build_controller(schedule, network, optimizer_util=None, args=None):
+    args = args or SimpleNamespace()
+    raw_optimizer = torch.optim.SGD(network.parameters(), lr=0.1)
+    optimizer = ReplaceableOptimizer(raw_optimizer)
+    scheduler = ReplaceableLRScheduler(FakeScheduler(raw_optimizer))
+    accelerator = FakeAccelerator(optimizer, scheduler)
+    optimizer_util = optimizer_util or FakeOptimizerUtil()
+    grad_refreshes = []
+
+    controller = LoRASqueezeTrainingController(
+        args=args,
+        accelerator=accelerator,
+        schedule=schedule,
+        network=network,
+        optimizer_util=optimizer_util,
+        optimizer_name="torch.optim.SGD",
+        optimizer_args="",
+        optimizer=optimizer,
+        optimizer_train_fn=lambda: None,
+        optimizer_eval_fn=lambda: None,
+        lr_scheduler=scheduler,
+        lr_descriptions=None,
+        prepare_optimizer_params_fn=lambda: (list(network.parameters()), None),
+        prepare_grad_fn=lambda: grad_refreshes.append(True),
+        update_metadata_fn=lambda: None,
+        clean_memory_fn=lambda: None,
+    )
+    return controller, accelerator, optimizer_util, optimizer, scheduler, grad_refreshes

--- a/tests/test_lora_squeeze.py
+++ b/tests/test_lora_squeeze.py
@@ -1,0 +1,221 @@
+import argparse
+import json
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from library.args import add_lora_squeeze_arguments
+from library.lora_squeeze_schedule import (
+    get_remaining_training_steps,
+    get_resume_epoch_and_batch_offset,
+    is_training_budget_exhausted,
+    restore_lora_squeeze_state_from_resume_dir,
+    validate_lora_squeeze_network_args,
+    validate_lora_squeeze_training_args,
+)
+from library.lora_squeeze_training import LoRASqueezeRuntime
+from tests.lora_squeeze_test_utils import make_schedule, make_schedule_args
+
+
+def test_arguments_are_registered_with_safe_defaults():
+    parser = argparse.ArgumentParser()
+    add_lora_squeeze_arguments(parser)
+    args = parser.parse_args([])
+
+    assert args.lora_squeeze_start_dim is None
+    assert args.lora_squeeze_num_squeezes == 0
+    assert args.lora_squeeze_optimizer_mode == "per_squeeze"
+    assert args.lora_squeeze_scheduler_mode == "global"
+    assert args.lora_squeeze_alpha_schedule == "proportional"
+    assert args.lora_squeeze_first_segment_ratio == 1.0
+    assert args.lora_squeeze_final_segment_ratio == 1.0
+
+
+def test_legacy_namespace_keeps_lora_squeeze_disabled(monkeypatch):
+    args = SimpleNamespace(network_dim=4, network_alpha=1)
+
+    def fail_allocation(*args, **kwargs):
+        raise AssertionError("must not allocate")
+
+    monkeypatch.setattr("library.lora_squeeze_training.Value", fail_allocation)
+
+    runtime = LoRASqueezeRuntime(args)
+
+    assert not runtime.enabled
+    assert runtime.absolute_update_step is None
+
+
+@pytest.mark.parametrize(
+    ("rank_schedule", "expected"),
+    [
+        ("geometric", [41, 28, 19, 13, 9]),
+        ("linear", [41, 33, 25, 17, 9]),
+    ],
+)
+def test_rank_schedules(rank_schedule, expected):
+    schedule = make_schedule(lora_squeeze_rank_schedule=rank_schedule)
+    assert schedule.ranks == expected
+
+
+def test_geometric_schedule_remains_strict_in_a_tight_integer_range():
+    schedule = make_schedule(lora_squeeze_start_dim=13, network_dim=9)
+    assert schedule.ranks == [13, 12, 11, 10, 9]
+
+
+@pytest.mark.parametrize(
+    ("step_schedule", "expected_steps"),
+    [
+        ("equal", [750, 750, 750, 750]),
+        ("rank_proportional", [1600, 800, 400, 200]),
+    ],
+)
+def test_step_schedules_distribute_the_complete_budget(step_schedule, expected_steps):
+    schedule = make_schedule(
+        lora_squeeze_start_dim=16,
+        network_dim=2,
+        lora_squeeze_num_squeezes=3,
+        lora_squeeze_step_schedule=step_schedule,
+    )
+    schedule.set_total_steps(3000)
+
+    assert schedule.segment_steps == expected_steps
+    assert sum(schedule.segment_steps) == 3000
+
+
+def test_first_and_final_segment_ratios_can_be_combined():
+    schedule = make_schedule(
+        lora_squeeze_start_dim=16,
+        network_dim=2,
+        lora_squeeze_num_squeezes=3,
+        lora_squeeze_first_segment_ratio=2.0,
+        lora_squeeze_final_segment_ratio=3.0,
+    )
+    schedule.set_total_steps(700)
+
+    assert schedule.segment_weights == [2.0, 1.0, 1.0, 3.0]
+    assert schedule.segment_steps == [200, 100, 100, 300]
+
+
+def test_terminal_boundary_uses_the_exact_budget_with_fractional_weights():
+    schedule = make_schedule(
+        lora_squeeze_start_dim=5,
+        network_dim=1,
+        network_alpha=1,
+        lora_squeeze_num_squeezes=4,
+        lora_squeeze_rank_schedule="linear",
+        lora_squeeze_step_schedule="sqrt_rank_proportional",
+        lora_squeeze_train_after_final_squeeze=False,
+    )
+    schedule.set_total_steps(257)
+
+    assert schedule.squeeze_steps[-1] == 257
+    assert sum(schedule.segment_steps) == 257
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"lora_squeeze_rank_schedule": "quadratic"}, "rank_schedule must be one of"),
+        ({"lora_squeeze_alpha_schedule": "quadratic"}, "alpha_schedule must be one of"),
+        ({"network_alpha": math.inf}, "network_alpha must be finite"),
+        ({"lora_squeeze_first_segment_ratio": 0}, "first_segment_ratio must be greater than 0"),
+        ({"lora_squeeze_final_segment_ratio": math.nan}, "final_segment_ratio must be finite"),
+    ],
+)
+def test_invalid_schedule_configuration_is_rejected(override, message):
+    with pytest.raises(ValueError, match=message):
+        make_schedule(**override)
+
+
+@pytest.mark.parametrize("option", ["torch_compile", "compile"])
+def test_compile_modes_are_rejected(option):
+    args = SimpleNamespace(torch_compile=False, compile=False)
+    setattr(args, option, True)
+    with pytest.raises(ValueError, match="torch.compile"):
+        validate_lora_squeeze_training_args(args)
+
+
+def test_heterogeneous_network_args_are_rejected_but_c3lier_is_allowed():
+    validate_lora_squeeze_network_args({"conv_dim": "4", "conv_alpha": "1"})
+    with pytest.raises(ValueError, match="network_reg_dims"):
+        validate_lora_squeeze_network_args({"network_reg_dims": ".*=4"})
+
+
+def test_c3lier_args_and_metadata_follow_the_current_squeeze_stage():
+    runtime = LoRASqueezeRuntime(
+        make_schedule_args(
+            lora_squeeze_start_dim=8,
+            network_dim=4,
+            network_alpha=2,
+            lora_squeeze_num_squeezes=1,
+        )
+    )
+    network_args = runtime.prepare_network_args({"conv_dim": "4", "conv_alpha": "2"})
+    metadata = {"ss_network_args": json.dumps(network_args)}
+
+    assert network_args["conv_dim"] == "8"
+    assert float(network_args["conv_alpha"]) == pytest.approx(runtime.current_alpha)
+
+    runtime.schedule.mark_squeezed(4, 2.0)
+    runtime.update_metadata(metadata, {})
+    saved_args = json.loads(metadata["ss_network_args"])
+    assert saved_args["conv_dim"] == "4"
+    assert saved_args["conv_alpha"] == "2.0"
+
+
+def test_schedule_state_round_trip_restores_progress():
+    schedule = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    schedule.set_total_steps(120)
+    schedule.mark_squeezed(schedule.ranks[1], schedule.alpha_for_rank(schedule.ranks[1]))
+
+    restored = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    restored.load_state_dict(schedule.state_dict())
+
+    assert restored.completed_squeezes == 1
+    assert restored.current_dim == schedule.ranks[1]
+    assert restored.current_alpha == pytest.approx(schedule.alpha_for_rank(schedule.ranks[1]))
+    assert restored.squeeze_steps == schedule.squeeze_steps
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda state: state.pop("next_squeeze_index"), "missing next_squeeze_index"),
+        (lambda state: state.__setitem__("version", 2), "configuration for version"),
+        (lambda state: state.__setitem__("current_alpha", math.inf), "current_alpha must be finite"),
+    ],
+)
+def test_invalid_resume_state_is_rejected(mutation, message):
+    schedule = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    schedule.set_total_steps(120)
+    state = schedule.state_dict()
+    mutation(state)
+
+    restored = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    with pytest.raises(ValueError, match=message):
+        restored.load_state_dict(state)
+
+
+def test_resume_directory_restores_current_rank(tmp_path):
+    schedule = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    schedule.set_total_steps(120)
+    schedule.mark_squeezed(schedule.ranks[1], schedule.alpha_for_rank(schedule.ranks[1]))
+    (tmp_path / "train_state.json").write_text(
+        json.dumps({"current_epoch": 0, "current_step": 40, "lora_squeeze": schedule.state_dict()}),
+        encoding="utf-8",
+    )
+
+    restored = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    restore_lora_squeeze_state_from_resume_dir(restored, str(tmp_path))
+
+    assert restored.completed_squeezes == 1
+    assert restored.current_dim == schedule.ranks[1]
+
+
+def test_resume_budget_helpers_use_absolute_optimizer_steps():
+    assert get_remaining_training_steps(11, completed_steps=4) == 7
+    assert not is_training_budget_exhausted(11, completed_steps=10)
+    assert is_training_budget_exhausted(11, completed_steps=11)
+    assert get_resume_epoch_and_batch_offset(2, 5, 2) == (0, 4)
+    assert get_resume_epoch_and_batch_offset(3, 5, 2) == (1, 0)

--- a/tests/test_lora_squeeze_compression.py
+++ b/tests/test_lora_squeeze_compression.py
@@ -1,0 +1,233 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from library.lora_squeeze_compression import (
+    get_lora_squeeze_optimizer_parameter_layout,
+    preserve_lora_squeeze_alpha_precision,
+    restore_lora_module_layers,
+    snapshot_lora_module_layers,
+    squeeze_lora_network,
+    validate_lora_squeeze_network,
+    validate_lora_squeeze_optimizer_parameters,
+)
+from library.lora_squeeze_network import validate_lora_squeeze_network_module
+from tests.lora_squeeze_test_utils import (
+    FakeFloatAlphaLoRAModule,
+    FakeLoRAModule,
+    FakeMultiNetwork,
+    FakeNetwork,
+    effective_delta,
+    make_schedule,
+)
+
+
+@pytest.mark.parametrize("kernel_size", [1, 3], ids=["linear", "conv2d"])
+def test_compression_matches_direct_truncated_svd(kernel_size):
+    torch.manual_seed(123)
+    module = FakeLoRAModule(11, 13, 8, 5.5, kernel_size=kernel_size)
+    nn.init.normal_(module.lora_down.weight)
+    nn.init.normal_(module.lora_up.weight)
+    before = effective_delta(module)
+    u, s, vh = torch.linalg.svd(before, full_matrices=False)
+    expected = (u[:, :4] * s[:4]) @ vh[:4]
+
+    stats, transfers = squeeze_lora_network(FakeNetwork(module), 4, target_alpha=2.75)
+
+    assert torch.allclose(effective_delta(module), expected, rtol=2e-5, atol=2e-5)
+    assert stats["retained_energy_mean"] == pytest.approx(float((s[:4] ** 2).sum() / (s**2).sum()))
+    assert transfers == []
+    assert module.lora_dim == 4
+    assert module.alpha.dtype == torch.float32
+
+
+def test_repeated_squeeze_matches_direct_lower_rank_approximation():
+    torch.manual_seed(321)
+    module = FakeLoRAModule(11, 13, 8, 5.5)
+    nn.init.normal_(module.lora_down.weight)
+    nn.init.normal_(module.lora_up.weight)
+    before = effective_delta(module)
+    u, s, vh = torch.linalg.svd(before, full_matrices=False)
+    expected = (u[:, :2] * s[:2]) @ vh[:2]
+
+    squeeze_lora_network(FakeNetwork(module), 5, target_alpha=3.0)
+    squeeze_lora_network(FakeNetwork(module), 2, target_alpha=1.5)
+
+    assert torch.allclose(effective_delta(module), expected, rtol=2e-5, atol=2e-5)
+
+
+def test_float_alpha_and_low_precision_buffer_are_handled_without_false_mismatch():
+    float_alpha = FakeFloatAlphaLoRAModule(7, 5, 4, 2.0)
+    squeeze_lora_network(FakeNetwork(float_alpha), 2, target_alpha=1.25)
+    assert isinstance(float_alpha.alpha, float)
+    assert float_alpha.alpha == pytest.approx(1.25)
+
+    buffered = FakeLoRAModule(7, 5, 4, 1.234567)
+    buffered.alpha = buffered.alpha.to(torch.float16)
+    buffered.scale = float(buffered.alpha.float()) / buffered.lora_dim
+    assert preserve_lora_squeeze_alpha_precision(FakeNetwork(buffered)) == 1
+    assert buffered.alpha.dtype == torch.float32
+
+
+def test_squeeze_preserves_cpu_rng_state():
+    torch.manual_seed(2025)
+    module = FakeLoRAModule(7, 5, 4, 2.0)
+    nn.init.normal_(module.lora_down.weight)
+    nn.init.normal_(module.lora_up.weight)
+    state = torch.get_rng_state()
+
+    squeeze_lora_network(FakeNetwork(module), 2, target_alpha=1.0)
+
+    assert torch.equal(torch.get_rng_state(), state)
+
+
+def test_rank_deficient_squeeze_revives_a_trainable_zero_channel():
+    torch.manual_seed(2026)
+    module = FakeLoRAModule(7, 5, 4, 4.0)
+    with torch.no_grad():
+        module.lora_down.weight.normal_()
+        module.lora_up.weight.zero_()
+        module.lora_up.weight[:, 0].normal_()
+    before = effective_delta(module)
+
+    stats, _ = squeeze_lora_network(FakeNetwork(module), 2, target_alpha=2.0)
+
+    assert torch.allclose(effective_delta(module), before, rtol=2e-5, atol=2e-5)
+    assert stats["numerical_rank_min"] == 1
+    assert stats["rank_deficient_modules"] == 1
+    assert stats["revived_rank_channels"] == 1
+
+    revived_index = int(torch.argmin(module.lora_up.weight.detach().norm(dim=0)))
+    assert module.lora_up.weight[:, revived_index].count_nonzero() == 0
+    assert module.lora_down.weight[revived_index].norm() > 0
+
+    target = torch.randn_like(before)
+    delta = module.lora_up.weight @ module.lora_down.weight * module.scale
+    ((delta - target) ** 2).mean().backward()
+    assert module.lora_up.weight.grad[:, revived_index].abs().sum() > 0
+
+
+def test_snapshot_restores_replaced_factor_objects():
+    module = FakeLoRAModule(7, 5, 4, 2.0)
+    network = FakeNetwork(module)
+    original_down = module.lora_down
+    original_up = module.lora_up
+    snapshots = snapshot_lora_module_layers(network)
+
+    squeeze_lora_network(network, 2, target_alpha=1.0)
+    restore_lora_module_layers(snapshots)
+
+    assert module.lora_down is original_down
+    assert module.lora_up is original_up
+    assert module.lora_dim == 4
+    assert module.scale == pytest.approx(0.5)
+
+
+def test_optimizer_parameter_validation_rejects_non_factor_parameters():
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, 4.0))
+    optimizer = torch.optim.AdamW(network.parameters())
+    validate_lora_squeeze_optimizer_parameters(network, optimizer)
+    assert get_lora_squeeze_optimizer_parameter_layout(network, optimizer) == (
+        ("0:test_lora.lora_down.weight", "0:test_lora.lora_up.weight"),
+    )
+
+    network.extra_gate = nn.Parameter(torch.ones(1))
+    optimizer = torch.optim.AdamW(network.parameters())
+    with pytest.raises(ValueError, match="non-factor optimizer parameters: extra_gate"):
+        validate_lora_squeeze_optimizer_parameters(network, optimizer)
+
+
+def test_network_module_requires_an_explicit_support_contract():
+    unsupported = SimpleNamespace(__name__="networks.unsupported")
+    with pytest.raises(ValueError, match="does not implement validate_lora_squeeze_support"):
+        validate_lora_squeeze_network_module(unsupported, {})
+
+    received = []
+    supported = SimpleNamespace(
+        __name__="networks.supported",
+        validate_lora_squeeze_support=lambda network_args: received.append(network_args),
+    )
+    validate_lora_squeeze_network_module(supported, {"foo": "bar"})
+    assert received == [{"foo": "bar"}]
+
+
+def test_resumed_validation_checks_the_current_and_future_ranks():
+    schedule = make_schedule(lora_squeeze_start_dim=16, network_dim=4, lora_squeeze_num_squeezes=2)
+    schedule.set_total_steps(120)
+    resumed_rank = schedule.ranks[1]
+    schedule.mark_squeezed(resumed_rank, schedule.alpha_for_rank(resumed_rank))
+
+    stats = validate_lora_squeeze_network(
+        FakeNetwork(FakeLoRAModule(7, 5, resumed_rank, schedule.current_alpha)),
+        schedule,
+    )
+
+    assert stats["source_rank"] == resumed_rank
+    assert stats["modules"] == 1
+
+
+@pytest.mark.parametrize(
+    "mutate, message",
+    [
+        (lambda module: setattr(module, "lora_down", nn.Linear(7, 3, bias=False)), "input features do not match rank"),
+        (lambda module: setattr(module, "scale", module.scale * 2), "alpha/scale"),
+    ],
+)
+def test_network_validation_rejects_inconsistent_factor_metadata(mutate, message):
+    schedule = make_schedule(lora_squeeze_start_dim=4, network_dim=2, network_alpha=2, lora_squeeze_num_squeezes=1)
+    module = FakeLoRAModule(7, 5, 4, schedule.current_alpha)
+    mutate(module)
+
+    with pytest.raises(ValueError, match=message):
+        validate_lora_squeeze_network(FakeNetwork(module), schedule)
+
+
+def test_mixed_current_ranks_are_rejected_before_training():
+    schedule = make_schedule(lora_squeeze_start_dim=4, network_dim=2, network_alpha=2, lora_squeeze_num_squeezes=1)
+    network = FakeMultiNetwork(
+        FakeLoRAModule(7, 5, 4, schedule.current_alpha),
+        FakeLoRAModule(7, 5, 3, schedule.current_alpha),
+    )
+
+    with pytest.raises(ValueError, match="rank"):
+        validate_lora_squeeze_network(network, schedule)
+
+
+@pytest.mark.parametrize("module_name", ["networks.lora", "networks.lora_anima"])
+def test_builtin_lora_modules_validate_and_squeeze(module_name):
+    network_module = importlib.import_module(module_name)
+    schedule = make_schedule(lora_squeeze_start_dim=8, network_dim=4, lora_squeeze_num_squeezes=1)
+    validate_lora_squeeze_network_module(network_module, {})
+    module = network_module.LoRAModule(
+        "test",
+        nn.Linear(7, 5, bias=False),
+        lora_dim=8,
+        alpha=schedule.current_alpha,
+    )
+
+    validate_lora_squeeze_network(FakeNetwork(module), schedule)
+    squeeze_lora_network(FakeNetwork(module), 4, target_alpha=2.0)
+
+    assert module.lora_dim == 4
+
+
+def test_standard_protocol_rejects_unsafe_factor_semantics():
+    schedule = make_schedule(lora_squeeze_start_dim=4, network_dim=2, lora_squeeze_num_squeezes=1)
+
+    grouped = FakeLoRAModule(4, 5, 4, 4.0, kernel_size=3)
+    grouped.lora_down = nn.Conv2d(4, 4, 1, groups=2, bias=False)
+    with pytest.raises(ValueError, match="grouped LoRA convolutions"):
+        validate_lora_squeeze_network(FakeNetwork(grouped), schedule)
+
+    hooked = FakeLoRAModule(7, 5, 4, 4.0)
+    hooked.lora_down.register_forward_hook(lambda _module, _inputs, output: output)
+    with pytest.raises(ValueError, match="hooks attached"):
+        validate_lora_squeeze_network(FakeNetwork(hooked), schedule)
+
+    frozen = FakeLoRAModule(7, 5, 4, 4.0)
+    frozen.lora_up.weight.requires_grad_(False)
+    with pytest.raises(ValueError, match="frozen lora_up"):
+        validate_lora_squeeze_network(FakeNetwork(frozen), schedule)

--- a/tests/test_lora_squeeze_optimizer.py
+++ b/tests/test_lora_squeeze_optimizer.py
@@ -1,0 +1,299 @@
+import pytest
+import torch
+from torch import nn
+
+from library.lora_squeeze_compression import squeeze_lora_network
+from library.lora_squeeze_optimizer import (
+    OptimizerStateCPUStagingError,
+    copy_optimizer_param_group_state,
+    move_optimizer_state_to_parameter_devices,
+    offload_optimizer_state_to_cpu,
+    prepare_optimizer_state_transfer,
+    stage_optimizer_state,
+    validate_optimizer_scheduler_modes,
+)
+from tests.lora_squeeze_test_utils import FakeLoRAModule, FakeNetwork
+
+
+def install_transfers(old_optimizer, new_optimizer, transfers):
+    copy_optimizer_param_group_state(old_optimizer, new_optimizer, transfers)
+    for parameter, state in transfers:
+        if state:
+            new_optimizer.state[parameter] = state
+
+
+def test_cpu_staging_uses_a_distinct_error(monkeypatch):
+    def fail_move(value, device, move_scalar_tensors=True):
+        raise RuntimeError("move failed")
+
+    monkeypatch.setattr("library.lora_squeeze_optimizer._move_optimizer_state_value", fail_move)
+    with pytest.raises(OptimizerStateCPUStagingError, match="projected optimizer state"):
+        stage_optimizer_state({"buffer": torch.ones(2)}, "cpu")
+    with pytest.raises(RuntimeError, match="move failed"):
+        stage_optimizer_state({"buffer": torch.ones(2)}, "cuda")
+
+
+def test_partial_optimizer_offload_rolls_back(monkeypatch):
+    first = nn.Parameter(torch.zeros(2))
+    second = nn.Parameter(torch.zeros(2))
+    optimizer = torch.optim.SGD([first, second], lr=0.1)
+    optimizer.state[first]["buffer"] = torch.ones_like(first)
+    optimizer.state[second]["buffer"] = torch.ones_like(second)
+
+    from library import lora_squeeze_optimizer as optimizer_module
+
+    original_move = optimizer_module._move_optimizer_state_value_with_device_record
+    calls = 0
+
+    def fail_second_move(value, device):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("CPU transfer failed")
+        return original_move(value, device)
+
+    monkeypatch.setattr(optimizer_module, "_move_optimizer_state_value_with_device_record", fail_second_move)
+
+    with pytest.raises(OptimizerStateCPUStagingError, match="existing optimizer state"):
+        offload_optimizer_state_to_cpu(optimizer)
+
+    assert calls == 2
+    assert torch.equal(optimizer.state[first]["buffer"], torch.ones_like(first))
+    assert torch.equal(optimizer.state[second]["buffer"], torch.ones_like(second))
+
+
+def test_sgd_momentum_uses_parameter_displacement_projection():
+    old_parameter = nn.Parameter(torch.zeros(3, 4))
+    new_parameter = nn.Parameter(torch.zeros(3, 2))
+    optimizer = torch.optim.SGD([old_parameter], lr=0.1, momentum=0.9)
+    momentum = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    optimizer.state[old_parameter]["momentum_buffer"] = momentum.clone()
+    projection = torch.tensor([[2.0, 0.0], [0.0, 0.5], [0.0, 0.0], [0.0, 0.0]])
+
+    projected, status = prepare_optimizer_state_transfer(optimizer).project_parameter_state(
+        old_parameter, new_parameter, projection, "up"
+    )
+    expected = momentum @ torch.linalg.pinv(projection.T)
+
+    assert status == "projected"
+    assert torch.allclose(projected["momentum_buffer"], expected)
+    assert not torch.allclose(projected["momentum_buffer"], momentum @ projection)
+
+    next_optimizer = torch.optim.SGD([new_parameter], lr=0.1, momentum=0.9)
+    next_optimizer.state[new_parameter] = projected
+    new_parameter.grad = torch.zeros_like(new_parameter)
+    next_optimizer.step()
+    assert torch.allclose(new_parameter, -0.09 * expected)
+
+
+def test_ill_conditioned_projection_fails_closed():
+    old_parameter = nn.Parameter(torch.zeros(1, 2))
+    new_parameter = nn.Parameter(torch.zeros(1, 1))
+    optimizer = torch.optim.SGD([old_parameter], momentum=0.9)
+    optimizer.state[old_parameter]["momentum_buffer"] = torch.ones_like(old_parameter)
+
+    with pytest.raises(ValueError, match="ill-conditioned.*per_squeeze"):
+        prepare_optimizer_state_transfer(optimizer).project_parameter_state(
+            old_parameter,
+            new_parameter,
+            torch.tensor([[1e-8], [0.0]]),
+            "up",
+        )
+
+
+def test_convolutional_adam_state_can_take_another_step_after_squeeze():
+    torch.manual_seed(14)
+    module = FakeLoRAModule(7, 5, 4, 2.0, kernel_size=3)
+    nn.init.normal_(module.lora_up.weight)
+    optimizer = torch.optim.AdamW(module.parameters(), lr=1e-3, amsgrad=True)
+    for parameter in module.parameters():
+        parameter.grad = torch.randn_like(parameter)
+    optimizer.step()
+    optimizer.zero_grad()
+
+    stats, transfers = squeeze_lora_network(
+        FakeNetwork(module), 2, target_alpha=1.0, optimizer_for_state_transfer=optimizer
+    )
+    new_optimizer = torch.optim.AdamW(module.parameters(), lr=1e-3, amsgrad=True)
+    install_transfers(optimizer, new_optimizer, transfers)
+    for parameter in module.parameters():
+        parameter.grad = torch.randn_like(parameter)
+    new_optimizer.step()
+
+    assert stats["optimizer_state_projected"] == 2
+    assert all(torch.isfinite(parameter).all() for parameter in module.parameters())
+
+
+def test_unknown_optimizer_state_is_rejected_without_changing_layers():
+    module = FakeLoRAModule(7, 5, 4, 2.0)
+    optimizer = torch.optim.SGD(module.parameters(), lr=0.1)
+    for parameter in module.parameters():
+        optimizer.state[parameter]["p0"] = torch.randn(parameter.numel())
+
+    with pytest.raises(ValueError, match="state.*p0"):
+        squeeze_lora_network(FakeNetwork(module), 2, target_alpha=1.0, optimizer_for_state_transfer=optimizer)
+    assert module.lora_dim == 4
+
+
+def test_adafactor_preserves_relative_step_and_refactors_second_moment():
+    from transformers.optimization import Adafactor
+
+    torch.manual_seed(32)
+    module = FakeLoRAModule(7, 5, 4, 2.0)
+    nn.init.normal_(module.lora_up.weight)
+    kwargs = dict(lr=None, beta1=0.9, relative_step=True, scale_parameter=True, warmup_init=False)
+    optimizer = Adafactor(module.parameters(), **kwargs)
+    for _ in range(3):
+        for parameter in module.parameters():
+            parameter.grad = torch.randn_like(parameter)
+        optimizer.step()
+        optimizer.zero_grad()
+
+    stats, transfers = squeeze_lora_network(
+        FakeNetwork(module), 2, target_alpha=1.0, optimizer_for_state_transfer=optimizer
+    )
+    new_optimizer = Adafactor(module.parameters(), **kwargs)
+    install_transfers(optimizer, new_optimizer, transfers)
+
+    assert stats["optimizer_state_projected"] == 2
+    for parameter in module.parameters():
+        state = new_optimizer.state[parameter]
+        assert state["step"] == 3
+        assert state["exp_avg"].shape == parameter.shape
+        assert state["exp_avg_sq_row"].shape == parameter.shape[:-1]
+        assert state["exp_avg_sq_col"].shape == parameter.shape[:-2] + parameter.shape[-1:]
+
+
+def test_prodigy_preserves_learned_scale_and_complete_state():
+    prodigyopt = pytest.importorskip("prodigyopt")
+    torch.manual_seed(31)
+    module = FakeLoRAModule(7, 5, 4, 2.0)
+    nn.init.normal_(module.lora_up.weight)
+    optimizer = prodigyopt.Prodigy(module.parameters(), lr=1.0, use_bias_correction=True)
+    for _ in range(3):
+        for parameter in module.parameters():
+            parameter.grad = torch.randn_like(parameter)
+        optimizer.step()
+        optimizer.zero_grad()
+
+    old_d = optimizer.param_groups[0]["d"]
+    old_k = optimizer.param_groups[0]["k"]
+    stats, transfers = squeeze_lora_network(
+        FakeNetwork(module), 2, target_alpha=1.0, optimizer_for_state_transfer=optimizer
+    )
+    new_optimizer = prodigyopt.Prodigy(module.parameters(), lr=1.0, use_bias_correction=True)
+    install_transfers(optimizer, new_optimizer, transfers)
+
+    assert stats["optimizer_state_projected"] == 2
+    assert stats["optimizer_state_warm_restarted"] == 0
+    assert new_optimizer.param_groups[0]["d"] == old_d
+    assert new_optimizer.param_groups[0]["k"] == old_k
+    assert all(
+        set(new_optimizer.state[parameter]) == {"step", "s", "p0", "exp_avg", "exp_avg_sq"}
+        for parameter in module.parameters()
+    )
+
+
+def test_prodigy_plus_uses_a_coherent_warm_restart():
+    prodigyplus = pytest.importorskip("prodigyplus")
+    torch.manual_seed(35)
+    module = FakeLoRAModule(64, 64, 16, 8.0)
+    nn.init.normal_(module.lora_up.weight)
+    kwargs = {"lr": 1.0, "factored": True, "stochastic_rounding": False}
+    optimizer = prodigyplus.ProdigyPlusScheduleFree(module.parameters(), **kwargs)
+    for _ in range(2):
+        for parameter in module.parameters():
+            parameter.grad = torch.randn_like(parameter)
+        optimizer.step()
+        optimizer.zero_grad()
+    optimizer.param_groups[0]["d"] = 0.023
+
+    stats, transfers = squeeze_lora_network(
+        FakeNetwork(module), 8, target_alpha=4.0, optimizer_for_state_transfer=optimizer
+    )
+    new_optimizer = prodigyplus.ProdigyPlusScheduleFree(module.parameters(), **kwargs)
+    install_transfers(optimizer, new_optimizer, transfers)
+
+    assert stats["optimizer_state_warm_restarted"] == 2
+    assert [state for _, state in transfers] == [{}, {}]
+    assert new_optimizer.param_groups[0]["d"] == pytest.approx(0.023)
+
+
+def test_schedule_free_preserves_iteration_history():
+    schedulefree = pytest.importorskip("schedulefree")
+    torch.manual_seed(33)
+    module = FakeLoRAModule(7, 5, 4, 2.0)
+    nn.init.normal_(module.lora_up.weight)
+    optimizer = schedulefree.AdamWScheduleFree(module.parameters(), lr=0.01)
+    optimizer.train()
+    for _ in range(3):
+        for parameter in module.parameters():
+            parameter.grad = torch.randn_like(parameter)
+        optimizer.step()
+        optimizer.zero_grad()
+
+    old_k = optimizer.param_groups[0]["k"]
+    stats, transfers = squeeze_lora_network(
+        FakeNetwork(module), 2, target_alpha=1.0, optimizer_for_state_transfer=optimizer
+    )
+    new_optimizer = schedulefree.AdamWScheduleFree(module.parameters(), lr=0.01)
+    new_optimizer.train()
+    install_transfers(optimizer, new_optimizer, transfers)
+
+    assert stats["optimizer_state_projected"] == 2
+    assert new_optimizer.param_groups[0]["k"] == old_k
+    assert all(new_optimizer.state[p]["z"].shape == p.shape for p in module.parameters())
+
+
+@pytest.mark.parametrize(
+    ("optimizer_mode", "scheduler_mode"),
+    [("per_squeeze", "global"), ("global", "per_squeeze")],
+)
+def test_ordinary_optimizer_allows_independent_state_modes(optimizer_mode, scheduler_mode):
+    optimizer = torch.optim.AdamW([nn.Parameter(torch.ones(1))])
+    validate_optimizer_scheduler_modes(optimizer, optimizer_mode, scheduler_mode)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for paged bitsandbytes coverage")
+def test_paged_bitsandbytes_state_projects_and_remains_paged():
+    bnb = pytest.importorskip("bitsandbytes")
+    if not hasattr(bnb.optim, "PagedAdamW8bit"):
+        pytest.skip("PagedAdamW8bit is not available")
+
+    torch.manual_seed(36)
+    module = FakeLoRAModule(4096, 4096, 41, 41.0).cuda()
+    optimizer = bnb.optim.PagedAdamW8bit(module.parameters(), lr=1e-3, min_8bit_size=4096)
+    for parameter in module.parameters():
+        parameter.grad = torch.randn_like(parameter)
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+
+    old_buffers = [
+        value
+        for state in optimizer.state.values()
+        for key, value in state.items()
+        if key in ("state1", "state2")
+    ]
+    if not old_buffers or not all(getattr(value, "is_paged", False) for value in old_buffers):
+        pytest.skip("bitsandbytes did not allocate managed paged buffers")
+
+    stats, transfers = squeeze_lora_network(
+        FakeNetwork(module),
+        28,
+        target_alpha=28.0,
+        optimizer_for_state_transfer=optimizer,
+        optimizer_state_staging_device="cpu",
+    )
+    new_optimizer = bnb.optim.PagedAdamW8bit(module.parameters(), lr=1e-3, min_8bit_size=4096)
+    install_transfers(optimizer, new_optimizer, transfers)
+    move_optimizer_state_to_parameter_devices(new_optimizer)
+
+    new_buffers = [
+        value
+        for state in new_optimizer.state.values()
+        for key, value in state.items()
+        if key in ("state1", "state2")
+    ]
+    assert new_buffers
+    assert all(getattr(value, "is_paged", False) for value in new_buffers)
+    assert stats["optimizer_state_projected"] == 2

--- a/tests/test_lora_squeeze_training.py
+++ b/tests/test_lora_squeeze_training.py
@@ -1,0 +1,360 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from library.accelerator_utils import (
+    ReplaceableLRScheduler,
+    ReplaceableOptimizer,
+    find_replaceable_optimizer,
+    find_replaceable_scheduler,
+    make_replaceable_optimizer_scheduler,
+)
+from library.args import get_sanitized_config_or_none, resume_from_local_or_hf_if_specified
+from library.lora_squeeze_optimizer import OptimizerStateCPUStagingError, stage_optimizer_state
+from library.lora_squeeze_training import LoRASqueezeRuntime, LoRASqueezeTrainingController
+from tests.lora_squeeze_test_utils import (
+    FakeAccelerator,
+    FakeLoRAModule,
+    FakeNetwork,
+    FakeOptimizerUtil,
+    FakeScheduler,
+    build_controller,
+    effective_delta,
+    make_schedule,
+    make_schedule_args,
+)
+
+
+def test_ordinary_resume_does_not_mutate_args_or_tracker_config():
+    class ResumeAccelerator:
+        def __init__(self):
+            self.loaded_paths = []
+
+        def load_state(self, path):
+            self.loaded_paths.append(path)
+
+    args = SimpleNamespace(
+        resume="state-a",
+        resume_from_huggingface=False,
+        log_config=True,
+        lora_squeeze_start_dim=None,
+        lora_squeeze_num_squeezes=0,
+        lora_squeeze_optimizer_mode="per_squeeze",
+    )
+    accelerator = ResumeAccelerator()
+
+    resume_from_local_or_hf_if_specified(accelerator, args)
+    args.resume = "state-b"
+    resume_from_local_or_hf_if_specified(accelerator, args)
+
+    assert accelerator.loaded_paths == ["state-a", "state-b"]
+    assert not hasattr(args, "_resume_state_dir")
+    tracker_config = get_sanitized_config_or_none(args)
+    assert "_resume_state_dir" not in tracker_config
+    assert not any(key.startswith("lora_squeeze_") for key in tracker_config)
+
+
+def test_enabled_squeeze_arguments_remain_in_tracker_config():
+    args = SimpleNamespace(
+        log_config=True,
+        lora_squeeze_start_dim=16,
+        lora_squeeze_num_squeezes=2,
+        lora_squeeze_optimizer_mode="global",
+    )
+    tracker_config = get_sanitized_config_or_none(args)
+    assert tracker_config["lora_squeeze_start_dim"] == 16
+    assert tracker_config["lora_squeeze_num_squeezes"] == 2
+
+
+def test_replaceable_objects_keep_stable_public_identities():
+    parameter = nn.Parameter(torch.ones(1))
+    optimizer = torch.optim.SGD([parameter], lr=0.1)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+    replaceable_optimizer, replaceable_scheduler = make_replaceable_optimizer_scheduler(optimizer, scheduler)
+
+    new_parameter = nn.Parameter(torch.ones(1))
+    new_optimizer = torch.optim.AdamW([new_parameter], lr=0.2)
+    new_scheduler = torch.optim.lr_scheduler.StepLR(new_optimizer, step_size=2)
+    replaceable_optimizer.replace(new_optimizer)
+    replaceable_scheduler.replace(new_scheduler)
+
+    assert isinstance(replaceable_optimizer, ReplaceableOptimizer)
+    assert isinstance(replaceable_scheduler, ReplaceableLRScheduler)
+    assert find_replaceable_optimizer(replaceable_optimizer) is replaceable_optimizer
+    assert find_replaceable_scheduler(replaceable_scheduler) is replaceable_scheduler
+    assert replaceable_optimizer.optimizer is new_optimizer
+    assert replaceable_scheduler.scheduler is new_scheduler
+
+
+def test_replaceable_objects_survive_real_accelerate_save_load(tmp_path):
+    from accelerate import Accelerator
+
+    accelerator = Accelerator()
+    parameter = nn.Parameter(torch.ones(1, device=accelerator.device))
+    optimizer = torch.optim.SGD([parameter], lr=0.1)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.5)
+    replaceable_optimizer, replaceable_scheduler = make_replaceable_optimizer_scheduler(optimizer, scheduler)
+    prepared_optimizer, prepared_scheduler = accelerator.prepare(replaceable_optimizer, replaceable_scheduler)
+    optimizer_identity = id(prepared_optimizer)
+    scheduler_identity = id(prepared_scheduler)
+
+    new_parameter = nn.Parameter(torch.ones(1, device=accelerator.device))
+    new_optimizer = torch.optim.SGD([new_parameter], lr=0.2)
+    new_scheduler = torch.optim.lr_scheduler.StepLR(new_optimizer, step_size=1, gamma=0.5)
+    find_replaceable_optimizer(prepared_optimizer).replace(new_optimizer)
+    find_replaceable_scheduler(prepared_scheduler).replace(new_scheduler)
+
+    new_parameter.grad = torch.ones_like(new_parameter)
+    prepared_optimizer.step()
+    prepared_scheduler.step()
+
+    assert id(prepared_optimizer) == optimizer_identity
+    assert id(prepared_scheduler) == scheduler_identity
+    assert torch.allclose(new_parameter, torch.tensor([0.8], device=accelerator.device))
+
+    accelerator.save_state(str(tmp_path))
+    new_optimizer.param_groups[0]["lr"] = 0.9
+    accelerator.load_state(str(tmp_path))
+    assert new_optimizer.param_groups[0]["lr"] == pytest.approx(0.1)
+
+
+def test_runtime_reports_current_rank_in_weight_errors():
+    runtime = LoRASqueezeRuntime(
+        make_schedule_args(
+            lora_squeeze_start_dim=4,
+            network_dim=2,
+            network_alpha=2,
+            lora_squeeze_num_squeezes=1,
+        )
+    )
+
+    error = runtime.network_weights_load_error(RuntimeError("unexpected tensor key"))
+    assert "current LoRA-Squeeze rank 4" in str(error)
+    assert "Original error: unexpected tensor key" in str(error)
+
+    runtime.schedule.mark_squeezed(2, 2.0)
+    assert "current LoRA-Squeeze rank 2" in str(runtime.network_weights_load_error(RuntimeError("mismatch")))
+
+
+def test_boundary_metrics_distinguish_trained_and_new_ranks():
+    runtime = LoRASqueezeRuntime(
+        make_schedule_args(
+            lora_squeeze_start_dim=4,
+            network_dim=2,
+            network_alpha=2,
+            lora_squeeze_num_squeezes=1,
+        )
+    )
+    runtime.set_total_steps(10)
+    optimizer = torch.optim.SGD([nn.Parameter(torch.zeros(1))], lr=0.25)
+    context = runtime.capture_step_context(optimizer)
+
+    class BoundaryController:
+        last_squeeze_stats = {"source_rank": 4.0, "target_rank": 2.0}
+
+        def run_if_due(self, global_step):
+            runtime.schedule.mark_squeezed(2, runtime.schedule.alpha_for_rank(2))
+            return True
+
+    boundary = runtime.schedule.squeeze_steps[0]
+    runtime.set_initial_step(boundary - 1)
+    assert runtime.run_after_optimizer_step(BoundaryController(), context, boundary)
+    logs = {}
+    runtime.append_step_logs(logs, context)
+
+    assert logs["lora_squeeze/train_dim"] == 4
+    assert logs["lora_squeeze/current_dim"] == 2
+    assert logs["lora_squeeze/transition"] == 1
+
+
+def test_controller_rebuild_does_not_reprepare_or_replace_registrations(monkeypatch):
+    schedule = make_schedule(
+        lora_squeeze_start_dim=4,
+        network_dim=2,
+        network_alpha=2,
+        lora_squeeze_num_squeezes=1,
+        lora_squeeze_optimizer_mode="global",
+        lora_squeeze_scheduler_mode="global",
+    )
+    schedule.set_total_steps(10)
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, schedule.current_alpha))
+    controller, accelerator, _, optimizer, scheduler, grad_refreshes = build_controller(schedule, network)
+    original_optimizer_registry = tuple(accelerator._optimizers)
+    original_scheduler_registry = tuple(accelerator._schedulers)
+
+    def fail_prepare(*args):
+        raise AssertionError("must not reprepare")
+
+    monkeypatch.setattr(accelerator, "prepare", fail_prepare)
+    assert controller.run_if_due(schedule.squeeze_steps[0])
+
+    assert tuple(map(id, accelerator._optimizers)) == tuple(map(id, original_optimizer_registry))
+    assert tuple(map(id, accelerator._schedulers)) == tuple(map(id, original_scheduler_registry))
+    assert controller.optimizer is optimizer
+    assert controller.lr_scheduler is scheduler
+    assert network.adapter.lora_dim == 2
+    assert schedule.completed_squeezes == 1
+    assert len(grad_refreshes) == 1
+
+
+def test_controller_rolls_back_on_factor_group_reordering():
+    schedule = make_schedule(
+        lora_squeeze_start_dim=4,
+        network_dim=2,
+        network_alpha=2,
+        lora_squeeze_num_squeezes=1,
+        lora_squeeze_optimizer_mode="global",
+        lora_squeeze_scheduler_mode="global",
+    )
+    schedule.set_total_steps(10)
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, schedule.current_alpha))
+    controller, _, _, _, _, grad_refreshes = build_controller(schedule, network)
+    controller.prepare_optimizer_params_fn = lambda: (list(reversed(list(network.parameters()))), None)
+
+    with pytest.raises(ValueError, match="membership or ordering"):
+        controller.run_if_due(schedule.squeeze_steps[0])
+
+    assert network.adapter.lora_dim == 4
+    assert schedule.completed_squeezes == 0
+    assert len(grad_refreshes) == 2
+
+
+def test_cpu_staging_failure_retries_on_parameter_device(monkeypatch):
+    schedule = make_schedule(
+        lora_squeeze_start_dim=4,
+        network_dim=2,
+        network_alpha=2,
+        lora_squeeze_num_squeezes=1,
+        lora_squeeze_optimizer_mode="global",
+        lora_squeeze_scheduler_mode="global",
+    )
+    schedule.set_total_steps(10)
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, schedule.current_alpha))
+    controller, accelerator, _, optimizer, _, grad_refreshes = build_controller(schedule, network)
+    for parameter in optimizer.param_groups[0]["params"]:
+        optimizer.state[parameter]["momentum_buffer"] = torch.ones_like(parameter)
+
+    staging_devices = []
+
+    def fail_cpu_staging(state, device):
+        staging_devices.append(device)
+        if device is not None and torch.device(device).type == "cpu":
+            raise OptimizerStateCPUStagingError("simulated CPU staging failure")
+        return stage_optimizer_state(state, device)
+
+    monkeypatch.setattr("library.lora_squeeze_compression.stage_optimizer_state", fail_cpu_staging)
+    assert controller.run_if_due(schedule.squeeze_steps[0])
+
+    assert staging_devices == ["cpu", None, None]
+    assert network.adapter.lora_dim == 2
+    assert len(controller.optimizer.state) == 2
+    assert len(grad_refreshes) == 2
+    assert any("retrying on the parameter device" in message for message in accelerator.messages)
+
+
+def test_terminal_squeeze_skips_rebuild_without_resumable_state():
+    schedule = make_schedule(
+        lora_squeeze_start_dim=4,
+        network_dim=2,
+        network_alpha=2,
+        lora_squeeze_num_squeezes=1,
+        lora_squeeze_train_after_final_squeeze=False,
+        lora_squeeze_optimizer_mode="global",
+        lora_squeeze_scheduler_mode="global",
+    )
+    schedule.set_total_steps(10)
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, schedule.current_alpha))
+    controller, accelerator, optimizer_util, optimizer, scheduler, grad_refreshes = build_controller(schedule, network)
+    for parameter in optimizer.param_groups[0]["params"]:
+        optimizer.state[parameter]["momentum_buffer"] = torch.ones_like(parameter)
+
+    assert controller.run_if_due(schedule.squeeze_steps[0])
+
+    assert optimizer_util.training_steps == []
+    assert accelerator._optimizers == [optimizer]
+    assert accelerator._schedulers == [scheduler]
+    assert controller.optimizer.param_groups[0]["params"] == []
+    assert len(controller.optimizer.state) == 0
+    assert grad_refreshes == []
+
+
+def test_terminal_squeeze_rebuilds_when_end_state_will_be_saved():
+    schedule = make_schedule(
+        lora_squeeze_start_dim=4,
+        network_dim=2,
+        network_alpha=2,
+        lora_squeeze_num_squeezes=1,
+        lora_squeeze_train_after_final_squeeze=False,
+        lora_squeeze_optimizer_mode="per_squeeze",
+        lora_squeeze_scheduler_mode="per_squeeze",
+    )
+    schedule.set_total_steps(10)
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, schedule.current_alpha))
+    controller, _, optimizer_util, optimizer, scheduler, grad_refreshes = build_controller(
+        schedule, network, args=SimpleNamespace(save_state_on_train_end=True)
+    )
+
+    assert controller.run_if_due(schedule.squeeze_steps[0])
+
+    assert optimizer_util.training_steps[-1] == 1
+    assert controller.optimizer is optimizer
+    assert controller.lr_scheduler is scheduler
+    assert [tuple(parameter.shape) for parameter in controller.optimizer.param_groups[0]["params"]] == [
+        (2, 7),
+        (5, 2),
+    ]
+    assert len(grad_refreshes) == 1
+
+
+def test_real_accelerate_controller_rebuild_keeps_prepared_objects():
+    from accelerate import Accelerator
+
+    schedule = make_schedule(
+        lora_squeeze_start_dim=4,
+        network_dim=2,
+        network_alpha=2,
+        lora_squeeze_num_squeezes=1,
+        lora_squeeze_optimizer_mode="global",
+        lora_squeeze_scheduler_mode="global",
+    )
+    schedule.set_total_steps(10)
+    accelerator = Accelerator()
+    network = FakeNetwork(FakeLoRAModule(7, 5, 4, schedule.current_alpha)).to(accelerator.device)
+    raw_optimizer = torch.optim.AdamW(network.parameters(), lr=0.01)
+    loss = (network.adapter.lora_up.weight @ network.adapter.lora_down.weight).square().mean()
+    loss.backward()
+    raw_optimizer.step()
+    raw_optimizer.zero_grad(set_to_none=True)
+    raw_scheduler = torch.optim.lr_scheduler.StepLR(raw_optimizer, step_size=2)
+    optimizer, scheduler = make_replaceable_optimizer_scheduler(raw_optimizer, raw_scheduler)
+    prepared_optimizer, prepared_scheduler = accelerator.prepare(optimizer, scheduler)
+    optimizer_identity = id(prepared_optimizer)
+    scheduler_identity = id(prepared_scheduler)
+
+    controller = LoRASqueezeTrainingController(
+        args=SimpleNamespace(),
+        accelerator=accelerator,
+        schedule=schedule,
+        network=network,
+        optimizer_util=FakeOptimizerUtil(torch.optim.AdamW, lr=0.01),
+        optimizer_name="torch.optim.AdamW",
+        optimizer_args="",
+        optimizer=prepared_optimizer,
+        optimizer_train_fn=lambda: None,
+        optimizer_eval_fn=lambda: None,
+        lr_scheduler=prepared_scheduler,
+        lr_descriptions=None,
+        prepare_optimizer_params_fn=lambda: (list(network.parameters()), None),
+        prepare_grad_fn=lambda: None,
+        update_metadata_fn=lambda: None,
+        clean_memory_fn=lambda: None,
+    )
+
+    assert controller.run_if_due(schedule.squeeze_steps[0])
+    assert id(controller.optimizer) == optimizer_identity
+    assert id(controller.lr_scheduler) == scheduler_identity
+    assert network.adapter.lora_dim == 2
+    assert len(controller.optimizer.state) == 2
+    assert find_replaceable_optimizer(controller.optimizer).optimizer is not raw_optimizer

--- a/train_network.py
+++ b/train_network.py
@@ -4,7 +4,7 @@ import argparse
 import math
 import os
 import typing
-from typing import Any, List, Literal, Union, Optional
+from typing import Any, Dict, List, Literal, Union, Optional
 import sys
 import random
 import time
@@ -39,6 +39,7 @@ import library.logging_util as logging_util
 import library.loss as loss_util
 import library.checkpoint_io as checkpoint_io
 import library.sampling as sampling
+import library.lora_squeeze_training as lora_squeeze_training
 import library.config_util as config_util
 from library.config_util import (
     ConfigSanitizer,
@@ -82,6 +83,8 @@ class NetworkTrainer:
         maximum_norm=None,
         mean_grad_norm=None,
         mean_combined_norm=None,
+        learning_rates=None,
+        lr_param_groups=None,
     ):
         logs = {"loss/current": current_loss, "loss/average": avr_loss}
 
@@ -95,7 +98,7 @@ class NetworkTrainer:
         if mean_combined_norm is not None:
             logs["norm/avg_combined_norm"] = mean_combined_norm
 
-        lrs = lr_scheduler.get_last_lr()
+        lrs = learning_rates if learning_rates is not None else lr_scheduler.get_last_lr()
         for i, lr in enumerate(lrs):
             if lr_descriptions is not None:
                 lr_desc = lr_descriptions[i]
@@ -112,11 +115,15 @@ class NetworkTrainer:
             logs[f"lr/{lr_desc}"] = lr
 
             if args.optimizer_type.lower().startswith("DAdapt".lower()) or args.optimizer_type.lower().startswith("Prodigy".lower()):
-                opt = lr_scheduler.optimizers[-1] if hasattr(lr_scheduler, "optimizers") else optimizer
-                if opt is not None:
-                    logs[f"lr/d*lr/{lr_desc}"] = opt.param_groups[i]["d"] * opt.param_groups[i]["lr"]
-                    if "effective_lr" in opt.param_groups[i]:
-                        logs[f"lr/d*eff_lr/{lr_desc}"] = opt.param_groups[i]["d"] * opt.param_groups[i]["effective_lr"]
+                if lr_param_groups is not None:
+                    group = lr_param_groups[i]
+                else:
+                    opt = lr_scheduler.optimizers[-1] if hasattr(lr_scheduler, "optimizers") else optimizer
+                    group = opt.param_groups[i] if opt is not None else None
+                if group is not None:
+                    logs[f"lr/d*lr/{lr_desc}"] = group["d"] * group["lr"]
+                    if "effective_lr" in group:
+                        logs[f"lr/d*eff_lr/{lr_desc}"] = group["d"] * group["effective_lr"]
 
         return logs
 
@@ -903,6 +910,24 @@ class NetworkTrainer:
         deepspeed_utils.prepare_deepspeed_args(args)
         setup_logging(args, reset=True)
 
+        # Validate LoRA-Squeeze compatibility before loading datasets, models, or caches.
+        lora_squeeze = lora_squeeze_training.LoRASqueezeRuntime(args)
+        resume_state_dir = None
+        net_kwargs = {}
+        if args.network_args is not None:
+            for net_arg in args.network_args:
+                key, value = net_arg.split("=", 1)
+                net_kwargs[key] = value
+        network_module = None
+        if lora_squeeze.enabled:
+            sys.path.append(os.path.dirname(__file__))
+            network_module = importlib.import_module(args.network_module)
+            lora_squeeze.validate_network_module(network_module, net_kwargs)
+            if args.resume:
+                resume_state_dir = args_util.get_resume_state_dir(args)
+                lora_squeeze.restore_from_resume_dir(resume_state_dir)
+            net_kwargs = lora_squeeze.prepare_network_args(net_kwargs)
+
         cache_latents = args.cache_latents
         use_dreambooth_method = args.in_json is None
         use_user_config = args.dataset_config is not None
@@ -1000,6 +1025,10 @@ class NetworkTrainer:
         logger.info("preparing accelerator")
         accelerator = accelerator_setup.prepare_accelerator(args)
         is_main_process = accelerator.is_main_process
+        lora_squeeze.validate_process_count(accelerator.num_processes)
+        lora_squeeze_resume_message = lora_squeeze.resume_status_message(bool(args.resume))
+        if lora_squeeze_resume_message is not None:
+            accelerator.print(lora_squeeze_resume_message)
 
         # mixed precisionに対応した型を用意しておき適宜castする
         weight_dtype, save_dtype = accelerator_setup.prepare_dtype(args)
@@ -1048,8 +1077,8 @@ class NetworkTrainer:
         # 差分追加学習のためにモデルを読み込む
         sys.path.append(os.path.dirname(__file__))
         accelerator.print("import network module:", args.network_module)
-        network_module = importlib.import_module(args.network_module)
-
+        if network_module is None:
+            network_module = importlib.import_module(args.network_module)
         if args.base_weights is not None:
             # base_weights が指定されている場合は、指定された重みを読み込みマージする
             for i, weight_path in enumerate(args.base_weights):
@@ -1068,12 +1097,6 @@ class NetworkTrainer:
             accelerator.print(f"all weights merged: {', '.join(args.base_weights)}")
 
         # prepare network
-        net_kwargs = {}
-        if args.network_args is not None:
-            for net_arg in args.network_args:
-                key, value = net_arg.split("=", 1)
-                net_kwargs[key] = value
-
         # if a new network is added in future, add if ~ then blocks for each network (;'∀')
         if args.dim_from_weights:
             network, _ = network_module.create_network_from_weights(1, args.network_weights, vae, text_encoder, unet, **net_kwargs)
@@ -1082,10 +1105,19 @@ class NetworkTrainer:
                 # workaround for LyCORIS (;^ω^)
                 net_kwargs["dropout"] = args.network_dropout
 
+            initial_network_dim, initial_network_alpha = lora_squeeze.initial_network_rank_alpha(
+                args.network_dim, args.network_alpha
+            )
+            lora_squeeze_creation_message = lora_squeeze.network_creation_status_message(
+                initial_network_dim, initial_network_alpha
+            )
+            if lora_squeeze_creation_message is not None:
+                accelerator.print(lora_squeeze_creation_message)
+
             network = network_module.create_network(
                 1.0,
-                args.network_dim,
-                args.network_alpha,
+                initial_network_dim,
+                initial_network_alpha,
                 vae,
                 text_encoder,
                 unet,
@@ -1117,8 +1149,19 @@ class NetworkTrainer:
 
         if args.network_weights is not None:
             # FIXME consider alpha of weights: this assumes that the alpha is not changed
-            info = network.load_weights(args.network_weights)
+            try:
+                info = network.load_weights(args.network_weights)
+            except RuntimeError as e:
+                if lora_squeeze.enabled:
+                    raise lora_squeeze.network_weights_load_error(e) from e
+                raise
             accelerator.print(f"load network weights from {args.network_weights}: {info}")
+
+        if lora_squeeze.enabled:
+            preflight_stats = lora_squeeze.validate_network(network)
+            preflight_message = lora_squeeze.preflight_status_message(preflight_stats)
+            if preflight_message is not None:
+                accelerator.print(preflight_message)
 
         if args.gradient_checkpointing:
             if args.cpu_offload_checkpointing:
@@ -1146,6 +1189,13 @@ class NetworkTrainer:
                 text_encoder_lr = args.text_encoder_lr
             else:
                 text_encoder_lr = None if len(args.text_encoder_lr) == 0 else args.text_encoder_lr[0]
+
+        # Some optimizer factories normalize args in place. LoRA-Squeeze rebuilds the optimizer after rank changes,
+        # so retain the original factory inputs and effective learning rates for those later rebuilds.
+        lora_squeeze_optimizer_factory_args = argparse.Namespace(**vars(args)) if lora_squeeze.enabled else None
+        lora_squeeze_text_encoder_lr = text_encoder_lr
+        lora_squeeze_unet_lr = args.unet_lr
+        lora_squeeze_default_lr = args.learning_rate
         try:
             if support_multiple_lrs:
                 results = network.prepare_optimizer_params_with_multiple_te_lrs(text_encoder_lr, args.unet_lr, args.learning_rate)
@@ -1173,6 +1223,9 @@ class NetworkTrainer:
 
         optimizer_name, optimizer_args, optimizer = optimizer_util.get_optimizer(args, trainable_params)
         optimizer_train_fn, optimizer_eval_fn = optimizer_util.get_optimizer_train_eval_fn(optimizer, args)
+        optimizer_state_adapter = lora_squeeze.preflight_optimizer(optimizer, network)
+        for message in lora_squeeze.optimizer_preflight_status_messages(optimizer_state_adapter):
+            accelerator.print(message)
 
         # prepare dataloader
         # strategies are set here because they cannot be referenced in another process. Copy them with the dataset
@@ -1213,9 +1266,21 @@ class NetworkTrainer:
 
         # データセット側にも学習ステップを送信
         train_dataset_group.set_max_train_steps(args.max_train_steps)
+        lora_squeeze.set_total_steps(args.max_train_steps)
+        for message in lora_squeeze.step_schedule_status_messages():
+            accelerator.print(message)
 
         # lr schedulerを用意する
-        lr_scheduler = optimizer_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
+        scheduler_training_steps = lora_squeeze.scheduler_training_steps()
+        if scheduler_training_steps is None:
+            lr_scheduler = optimizer_util.get_scheduler_fix(args, optimizer, accelerator.num_processes)
+        else:
+            lr_scheduler = optimizer_util.get_scheduler_fix(
+                args, optimizer, accelerator.num_processes, training_steps=scheduler_training_steps
+            )
+        for message in lora_squeeze.optimizer_scheduler_status_messages(scheduler_training_steps):
+            accelerator.print(message)
+        optimizer, lr_scheduler = lora_squeeze.prepare_optimizer_scheduler_for_accelerator(optimizer, lr_scheduler)
 
         # 実験的機能：勾配も含めたfp16/bf16学習を行う　モデル全体をfp16/bf16にする
         if args.full_fp16:
@@ -1230,6 +1295,7 @@ class NetworkTrainer:
             ), "full_bf16 requires mixed precision='bf16' / full_bf16を使う場合はmixed_precision='bf16'を指定してください。"
             accelerator.print("enable full bf16 training.")
             network.to(weight_dtype)
+        lora_squeeze.preserve_alpha_precision(network)
 
         unet_weight_dtype = te_weight_dtype = weight_dtype
         # Experimental Feature: Put base model into fp8 to save vram
@@ -1350,9 +1416,14 @@ class NetworkTrainer:
             # save current ecpoch and step
             train_state_file = os.path.join(output_dir, "train_state.json")
             # +1 is needed because the state is saved before current_step is set from global_step
-            logger.info(f"save train state to {train_state_file} at epoch {current_epoch.value} step {current_step.value+1}")
+            state_step = current_step.value + 1
+            if lora_squeeze.enabled:
+                state_step = lora_squeeze.progress_step()
+            logger.info(f"save train state to {train_state_file} at epoch {current_epoch.value} step {state_step}")
+            train_state = {"current_epoch": current_epoch.value, "current_step": state_step}
+            lora_squeeze.add_to_train_state(train_state)
             with open(train_state_file, "w", encoding="utf-8") as f:
-                json.dump({"current_epoch": current_epoch.value, "current_step": current_step.value + 1}, f)
+                json.dump(train_state, f)
 
         steps_from_state = None
 
@@ -1373,13 +1444,19 @@ class NetworkTrainer:
                 with open(train_state_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
                 steps_from_state = data["current_step"]
+                lora_squeeze.restore_from_train_state(data)
                 logger.info(f"load train state from {train_state_file}: {data}")
 
         accelerator.register_save_state_pre_hook(save_model_hook)
         accelerator.register_load_state_pre_hook(load_model_hook)
 
         # resumeする
-        args_util.resume_from_local_or_hf_if_specified(accelerator, args)
+        if resume_state_dir is None:
+            args_util.resume_from_local_or_hf_if_specified(accelerator, args)
+        else:
+            args_util.resume_from_local_or_hf_if_specified(accelerator, args, resume_state_dir)
+        if lora_squeeze.enabled and args.resume:
+            lora_squeeze.validate_network(accelerator.unwrap_model(network))
 
         # epoch数を計算する
         num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
@@ -1424,6 +1501,11 @@ class NetworkTrainer:
             use_dreambooth_method=use_dreambooth_method,
         )
 
+        def update_lora_squeeze_metadata():
+            lora_squeeze.update_metadata(self._metadata, self._minimum_metadata)
+
+        update_lora_squeeze_metadata()
+
         # calculate steps to skip when resuming or starting from a specific step
         initial_step = 0
         if args.initial_epoch is not None or args.initial_step is not None:
@@ -1446,11 +1528,22 @@ class NetworkTrainer:
                 steps_from_state = None
 
         if initial_step > 0:
-            assert (
-                args.max_train_steps > initial_step
-            ), f"max_train_steps should be greater than initial step / max_train_stepsは初期ステップより大きい必要があります: {args.max_train_steps} vs {initial_step}"
+            valid_step_budget = (
+                args.max_train_steps >= initial_step
+                if lora_squeeze.enabled
+                else args.max_train_steps > initial_step
+            )
+            assert valid_step_budget, (
+                "max_train_steps should be greater than initial step "
+                "(or equal for a completed LoRA-Squeeze resume) / "
+                f"max_train_steps: {args.max_train_steps} vs initial_step: {initial_step}"
+            )
+
+        lora_squeeze.set_initial_step(initial_step)
+        absolute_initial_step = initial_step
 
         epoch_to_start = 0
+        resume_batch_offset = 0
         if initial_step > 0:
             if args.skip_until_initial_step:
                 # if skip_until_initial_step is specified, load data and discard it to ensure the same data is used
@@ -1459,16 +1552,25 @@ class NetworkTrainer:
                         f"initial_step is specified but not resuming. lr scheduler will be started from the beginning / initial_stepが指定されていますがresumeしていないため、lr schedulerは最初から始まります"
                     )
                 logger.info(f"skipping {initial_step} steps / {initial_step}ステップをスキップします")
-                initial_step *= args.gradient_accumulation_steps
+                if lora_squeeze.enabled:
+                    epoch_to_start, resume_batch_offset = lora_squeeze.resume_epoch_and_batch_offset(
+                        initial_step,
+                        len(train_dataloader),
+                        args.gradient_accumulation_steps,
+                    )
+                else:
+                    initial_step *= args.gradient_accumulation_steps
 
-                # set epoch to start to make initial_step less than len(train_dataloader)
-                epoch_to_start = initial_step // math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+                    # set epoch to start to make initial_step less than len(train_dataloader)
+                    epoch_to_start = initial_step // math.ceil(
+                        len(train_dataloader) / args.gradient_accumulation_steps
+                    )
             else:
                 # if not, only epoch no is skipped for informative purpose
                 epoch_to_start = initial_step // math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
                 initial_step = 0  # do not skip
 
-        global_step = 0
+        global_step = absolute_initial_step if lora_squeeze.enabled else 0
 
         noise_scheduler = self.get_noise_scheduler(args, accelerator.device)
 
@@ -1488,6 +1590,51 @@ class NetworkTrainer:
         else:
             on_step_start_for_network = lambda *args, **kwargs: None
 
+        def prepare_lora_squeeze_optimizer_params():
+            unwrapped_network = accelerator.unwrap_model(network)
+            try:
+                if support_multiple_lrs:
+                    results = unwrapped_network.prepare_optimizer_params_with_multiple_te_lrs(
+                        lora_squeeze_text_encoder_lr, lora_squeeze_unet_lr, lora_squeeze_default_lr
+                    )
+                else:
+                    results = unwrapped_network.prepare_optimizer_params(
+                        lora_squeeze_text_encoder_lr, lora_squeeze_unet_lr, lora_squeeze_default_lr
+                    )
+            except TypeError:
+                results = unwrapped_network.prepare_optimizer_params(
+                    lora_squeeze_text_encoder_lr, lora_squeeze_unet_lr
+                )
+            if type(results) is tuple:
+                return results[0], results[1]
+            return results, None
+
+        def refresh_lora_squeeze_grad():
+            accelerator.unwrap_model(network).prepare_grad_etc(text_encoder, unet)
+
+        lora_squeeze_controller = None
+        if lora_squeeze.enabled:
+            lora_squeeze_controller = lora_squeeze_training.LoRASqueezeTrainingController(
+                args=args,
+                accelerator=accelerator,
+                schedule=lora_squeeze.schedule,
+                network=network,
+                optimizer_util=optimizer_util,
+                optimizer_name=optimizer_name,
+                optimizer_args=optimizer_args,
+                optimizer=optimizer,
+                optimizer_train_fn=optimizer_train_fn,
+                optimizer_eval_fn=optimizer_eval_fn,
+                lr_scheduler=lr_scheduler,
+                lr_descriptions=lr_descriptions,
+                prepare_optimizer_params_fn=prepare_lora_squeeze_optimizer_params,
+                prepare_grad_fn=refresh_lora_squeeze_grad,
+                update_metadata_fn=update_lora_squeeze_metadata,
+                clean_memory_fn=lambda: clean_memory_on_device(accelerator.device),
+                logger=logger,
+                optimizer_factory_args=lora_squeeze_optimizer_factory_args,
+            )
+
         # if text_encoder is not needed for training, delete it to save memory.
         # TODO this can be automated after SDXL sample prompt cache is implemented
         if self.is_text_encoder_not_needed_for_training(args):
@@ -1506,10 +1653,12 @@ class NetworkTrainer:
         is_tracking = len(accelerator.trackers) > 0
         if is_tracking:
             # log empty object to commit the sample images to wandb
-            accelerator.log({}, step=0)
+            accelerator.log({}, step=global_step)
 
         # training loop
-        if initial_step > 0:  # only if skip_until_initial_step is specified
+        if lora_squeeze.enabled:
+            initial_step = resume_batch_offset
+        elif initial_step > 0:  # only if skip_until_initial_step is specified
             for skip_epoch in range(epoch_to_start):  # skip epochs
                 logger.info(f"skipping epoch {skip_epoch+1} because initial_step (multiplied) is {initial_step}")
                 initial_step -= len(train_dataloader)
@@ -1527,7 +1676,12 @@ class NetworkTrainer:
         clean_memory_on_device(accelerator.device)
 
         progress_bar = tqdm(
-            range(args.max_train_steps - initial_step), smoothing=0, disable=not accelerator.is_local_main_process, desc="steps"
+            range(
+                lora_squeeze.remaining_steps(args.max_train_steps, global_step)
+            ),
+            smoothing=0,
+            disable=not accelerator.is_local_main_process,
+            desc="steps",
         )
 
         validation_steps = (
@@ -1571,6 +1725,8 @@ class NetworkTrainer:
             random.setstate(python_rng_state)
 
         for epoch in range(epoch_to_start, num_train_epochs):
+            if lora_squeeze.budget_exhausted(args.max_train_steps, global_step):
+                break
             accelerator.print(f"\nepoch {epoch+1}/{num_train_epochs}\n")
             current_epoch.value = epoch + 1
 
@@ -1590,6 +1746,7 @@ class NetworkTrainer:
                     initial_step -= 1
                     continue
 
+                lora_squeeze_step_context = None
                 with accelerator.accumulate(training_model):
                     on_step_start_for_network(text_encoder, unet)
 
@@ -1629,6 +1786,7 @@ class NetworkTrainer:
                     optimizer.step()
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
+                    lora_squeeze_step_context = lora_squeeze.capture_step_context(optimizer)
 
                 if args.scale_weight_norms:
                     keys_scaled, mean_norm, maximum_norm = accelerator.unwrap_model(network).apply_max_norm_regularization(
@@ -1658,6 +1816,19 @@ class NetworkTrainer:
                 if accelerator.sync_gradients:
                     progress_bar.update(1)
                     global_step += 1
+
+                    if lora_squeeze.run_after_optimizer_step(
+                        lora_squeeze_controller, lora_squeeze_step_context, global_step
+                    ):
+                        (
+                            optimizer_name,
+                            optimizer_args,
+                            optimizer,
+                            optimizer_train_fn,
+                            optimizer_eval_fn,
+                            lr_scheduler,
+                            lr_descriptions,
+                        ) = lora_squeeze_controller.export_training_state()
 
                     optimizer_eval_fn()
                     self.sample_images(
@@ -1693,6 +1864,8 @@ class NetworkTrainer:
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss: float = loss_recorder.moving_average
                 logs = {"avr_loss": avr_loss}  # , "lr": lr_scheduler.get_last_lr()[0]}
+                if lora_squeeze_step_context is not None:
+                    logs["lora_squeeze_dim"] = lora_squeeze_step_context.train_dim
                 progress_bar.set_postfix(**{**max_mean_logs, **logs})
 
                 if is_tracking:
@@ -1708,7 +1881,18 @@ class NetworkTrainer:
                         maximum_norm,
                         mean_grad_norm,
                         mean_combined_norm,
+                        learning_rates=(
+                            lora_squeeze_step_context.learning_rates
+                            if lora_squeeze_step_context is not None
+                            else None
+                        ),
+                        lr_param_groups=(
+                            lora_squeeze_step_context.optimizer_param_groups
+                            if lora_squeeze_step_context is not None
+                            else None
+                        ),
                     )
+                    lora_squeeze.append_step_logs(logs, lora_squeeze_step_context)
                     self.step_logging(accelerator, logs, global_step, epoch + 1)
 
                 # VALIDATION PER STEP: global_step is already incremented
@@ -1752,7 +1936,7 @@ class NetworkTrainer:
                     accelerator.unwrap_model(network).train()
                     progress_bar.unpause()
 
-                if global_step >= args.max_train_steps:
+                if lora_squeeze.budget_exhausted(args.max_train_steps, global_step):
                     break
 
             # EPOCH VALIDATION
@@ -1876,6 +2060,7 @@ def setup_parser() -> argparse.ArgumentParser:
     args_util.add_optimizer_arguments(parser)
     config_util.add_config_arguments(parser)
     custom_train_functions.add_custom_train_arguments(parser)
+    args_util.add_lora_squeeze_arguments(parser)
 
     parser.add_argument(
         "--cpu_offload_checkpointing",


### PR DESCRIPTION
## Summary

This PR adds opt-in [LoRA-Squeeze](https://arxiv.org/abs/2602.10993) support to `train_network.py`.

LoRA-Squeeze starts LoRA training at a higher rank and compresses it to the configured deployment rank during the same training run. The completed output is a standard LoRA at `network_dim`; no special inference support is required.

Three main training patterns are supported:

- **In-Squeeze:** progressively reduce rank several times during training.
- **Post-Squeeze:** train entirely at a high rank, then compress once at the end.
- **Cont-Squeeze:** compress once before the end and continue training at the target rank.

The feature is disabled unless `lora_squeeze_start_dim` or `lora_squeeze_num_squeezes` is configured.

## Basic In-Squeeze example

```toml
network_dim = 8
network_alpha = 4
max_train_steps = 4000
lora_squeeze_start_dim = 64
lora_squeeze_num_squeezes = 3
```

With the defaults, this creates:

```text
64 -> 32 -> 16 -> 8
```

The 4000 configured training steps are divided equally:

```text
steps    0-1000: rank 64
steps 1000-2000: rank 32
steps 2000-3000: rank 16
steps 3000-4000: rank 8
```

`max_train_steps` remains the total training budget. LoRA-Squeeze redistributes those steps between ranks; it does not add extra training steps.

The default configuration is equivalent to:

```toml
lora_squeeze_rank_schedule = "geometric"
lora_squeeze_step_schedule = "equal"
lora_squeeze_alpha_schedule = "proportional"
lora_squeeze_train_after_final_squeeze = true
lora_squeeze_optimizer_mode = "per_squeeze"
lora_squeeze_scheduler_mode = "global"
lora_squeeze_first_segment_ratio = 1.0
lora_squeeze_final_segment_ratio = 1.0
```

## Post-Squeeze example

Post-Squeeze trains at the higher rank for the complete training budget and compresses once at the end:

```toml
network_dim = 8
network_alpha = 4
max_train_steps = 4000
lora_squeeze_start_dim = 64
lora_squeeze_num_squeezes = 1
lora_squeeze_train_after_final_squeeze = false
```

This produces:

```text
steps 0-4000: train at rank 64
end of run:   compress 64 -> 8
saved LoRA:   rank 8
```

There are no optimizer updates at rank 8 in this configuration.

## Cont-Squeeze example

Cont-Squeeze performs one rank reduction and then continues training at the deployment rank:

```toml
network_dim = 8
network_alpha = 4
max_train_steps = 4000
lora_squeeze_start_dim = 64
lora_squeeze_num_squeezes = 1
lora_squeeze_train_after_final_squeeze = true
```

With equal step distribution:

```text
steps    0-2000: rank 64
steps 2000-4000: rank 8
```

This allows the compressed LoRA to adapt further at its final rank.

## Configuration options

| Option | Default | Purpose |
|---|---:|---|
| `lora_squeeze_start_dim` | unset | Initial training rank. Must be greater than `network_dim`. |
| `lora_squeeze_num_squeezes` | `0` | Number of rank-reduction events. |
| `lora_squeeze_train_after_final_squeeze` | `true` | Whether to train at the final target rank. |
| `lora_squeeze_rank_schedule` | `geometric` | Controls how intermediate ranks are selected. |
| `lora_squeeze_step_schedule` | `equal` | Controls how training steps are divided between ranks. |
| `lora_squeeze_alpha_schedule` | `proportional` | Controls alpha at intermediate ranks. |
| `lora_squeeze_first_segment_ratio` | `1.0` | Adjusts the relative length of the first segment. |
| `lora_squeeze_final_segment_ratio` | `1.0` | Adjusts the relative length of the final segment. |
| `lora_squeeze_optimizer_mode` | `per_squeeze` | Controls optimizer-state continuity across rank changes. |
| `lora_squeeze_scheduler_mode` | `global` | Controls LR-scheduler continuity across rank changes. |

## Rank schedules

`lora_squeeze_rank_schedule` controls the intermediate ranks.

### Geometric

```toml
lora_squeeze_rank_schedule = "geometric"
```

Geometric scheduling aims for approximately equal compression ratios:

```text
rank(i) ≈ start_dim × (network_dim / start_dim)^(i / num_squeezes)
```

For a starting rank of 64, target rank of 8, and three squeezes:

```text
64 -> 32 -> 16 -> 8
```

### Linear

```toml
lora_squeeze_rank_schedule = "linear"
```

Linear scheduling aims for approximately equal rank differences:

```text
rank(i) ≈ start_dim - (start_dim - network_dim) × i / num_squeezes
```

Using the same configuration:

```text
64 -> 45 -> 26 -> 8
```

Intermediate values are converted to integer ranks while ensuring that every transition strictly decreases the rank.

## Step distribution

`lora_squeeze_step_schedule` controls how `max_train_steps` is divided between the training ranks.

Each rank receives a weight:

| Schedule | Weight for rank `r` |
|---|---:|
| `equal` | `1` |
| `rank_proportional` | `r` |
| `sqrt_rank_proportional` | `sqrt(r)` |
| `inverse_rank_proportional` | `1 / r` |
| `inverse_sqrt_rank_proportional` | `1 / sqrt(r)` |

Steps are allocated proportionally:

```text
steps(r) ≈ max_train_steps × weight(r) / sum(all segment weights)
```

Integer boundaries are calculated cumulatively so the segments always cover exactly `max_train_steps`.

For a `64 -> 32 -> 16 -> 8` schedule with 400 training steps:

### Equal

```toml
lora_squeeze_step_schedule = "equal"
```

```text
rank 64: 100 steps
rank 32: 100 steps
rank 16: 100 steps
rank  8: 100 steps
```

### Rank-proportional

```toml
lora_squeeze_step_schedule = "rank_proportional"
```

```text
rank 64: 213 steps
rank 32: 107 steps
rank 16:  53 steps
rank  8:  27 steps
```

This allocates more training to the more expressive high-rank stages.

The inverse schedules allocate more steps after the LoRA has been compressed. The square-root variants provide a milder version of either preference.

## Adjusting the first and final segments

The first and final segments can be emphasized independently:

```toml
lora_squeeze_first_segment_ratio = 2.0
lora_squeeze_final_segment_ratio = 3.0
```

These values multiply the corresponding segment weights before the steps are distributed.

For an equal `64 -> 32 -> 16 -> 8` schedule with 600 total steps:

```text
rank 64: 171 steps
rank 32:  86 steps
rank 16:  85 steps
rank  8: 258 steps
```

This can reserve additional time for both the initial high-rank solution and refinement at the final deployment rank.

## Alpha schedules

`network_alpha` remains the final deployment alpha.

Intermediate alpha values are calculated using `lora_squeeze_alpha_schedule`.

For:

```toml
network_dim = 8
network_alpha = 4
```

### Proportional

```toml
lora_squeeze_alpha_schedule = "proportional"
```

For rank `r`:

```text
alpha(r) = network_alpha × r / network_dim
```

This keeps `alpha / rank` constant:

```text
rank 64: alpha 32
rank 32: alpha 16
rank 16: alpha  8
rank  8: alpha  4
```

### Square-root

```toml
lora_squeeze_alpha_schedule = "sqrt"
```

For rank `r`:

```text
alpha(r) = network_alpha × sqrt(r / network_dim)
```

With `network_dim = 8` and `network_alpha = 4`:

```text
rank 64: alpha 11.314
rank 32: alpha  8.000
rank 16: alpha  5.657
rank  8: alpha  4.000
```

## Optimizer and scheduler modes

Optimizer and scheduler continuity can be configured independently.

### Default: reset optimizer, continue scheduler

```toml
lora_squeeze_optimizer_mode = "per_squeeze"
lora_squeeze_scheduler_mode = "global"
```

Each rank starts with fresh optimizer state, while the LR scheduler continues across the complete training run.

### Restart both for each rank

```toml
lora_squeeze_optimizer_mode = "per_squeeze"
lora_squeeze_scheduler_mode = "per_squeeze"
```

Each rank segment receives a fresh optimizer and a new scheduler curve based on that segment’s length. Scheduler warmup is therefore repeated for every segment.

### Continue both globally

```toml
lora_squeeze_optimizer_mode = "global"
lora_squeeze_scheduler_mode = "global"
```

Compatible optimizer state is transformed into the new LoRA factor coordinates, and the LR curve continues without restarting.

Global optimizer mode supports the major optimizer families used by sd-scripts, including PyTorch Adam-family optimizers, SGD, Adafactor, Lion, supported bitsandbytes variants, schedule-free optimizers, Prodigy, and D-Adaptation variants.

Unknown or incompatible optimizer state is rejected before training begins. `per_squeeze` mode can be used with any optimizer.

Optimizers that manage their own learning-rate or averaging schedule require optimizer and scheduler modes to match.

## Supported networks

Initial support is provided for:

- `networks.lora`
- `networks.lora_anima`

Supported factors include:

- Standard Linear LoRA factors.
- Conv2d LoRA factors with a 1×1 `lora_up`.
- LoRA-C3Lier when `conv_dim` and `conv_alpha` match the final `network_dim` and `network_alpha`.

All participating LoRA modules must use the same current rank and alpha.

The following are not currently supported:

- Block-specific or regex-specific ranks and alphas.
- Split-QKV or `ModuleList` LoRA factors.
- LoRA-FA.
- Multi-process or DeepSpeed training.
- `torch.compile`.
- `dim_from_weights`.
- `initial_step` and `initial_epoch`.

When `network_weights` is used, the loaded weights must match the current scheduled rank and alpha. For a new run this is the starting rank; for a resumed run it is the rank recorded in the saved LoRA-Squeeze state.

## Resume and observability

LoRA-Squeeze state is saved in `train_state.json`, including the generated rank schedule, step boundaries, current rank and alpha, and completed squeeze count.

Resumed runs continue from the saved absolute optimizer step and preserve the original squeeze boundaries and total `max_train_steps` budget.

The current schedule and progress are also written to model metadata and training logs. Transition logs include:

- Rank and alpha used for the completed training step.
- Newly installed rank and alpha.
- Retained spectral energy.
- Numerical rank.
- Optimizer-state transfer statistics.

## Implementation

Compression uses reduced QR decompositions and SVD of a rank-sized interaction core. It therefore avoids constructing the full model-sized LoRA weight update.

The feature is separated into schedule, network protocol, compression, optimizer-state, and training-lifecycle modules. Network modules explicitly declare support and expose the LoRA factors they allow to be replaced.

## Documentation and tests

A bilingual English/Japanese guide documents the available configurations, supported networks, optimizer behavior, resume semantics, and limitations.

Test coverage includes schedule generation, Linear and Conv2d compression, repeated squeezes, optimizer and scheduler modes, resume state, metadata, Accelerate integration, and supported network protocols.