### PR TITLE
Fix typos and exclude vendored ipex directory from typos check

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -35,4 +35,4 @@ tak="tak"
 temperal="temperal"
 
 [files]
-extend-exclude = ["_typos.toml", "venv", "configs"]
+extend-exclude = ["_typos.toml", "venv", "configs", "library/ipex", "library/hunyuan_image_text_encoder.py"]

--- a/flux_minimal_inference.py
+++ b/flux_minimal_inference.py
@@ -576,12 +576,12 @@ if __name__ == "__main__":
                     elif opt.startswith("g"):
                         guidance = float(opt[1:].strip())
                     elif opt.startswith("m"):
-                        mutipliers = opt[1:].strip().split(",")
-                        if len(mutipliers) != len(lora_models):
+                        multipliers = opt[1:].strip().split(",")
+                        if len(multipliers) != len(lora_models):
                             logger.error(f"Invalid number of multipliers, expected {len(lora_models)}")
                             continue
                         for i, lora_model in enumerate(lora_models):
-                            lora_model.set_multiplier(float(mutipliers[i]))
+                            lora_model.set_multiplier(float(multipliers[i]))
                     elif opt.startswith("n"):
                         negative_prompt = opt[1:].strip()
                         if negative_prompt == "-":

--- a/library/anima_utils.py
+++ b/library/anima_utils.py
@@ -316,5 +316,5 @@ def save_anima_model(
         metadata = {}
     metadata["format"] = "pt"  # For compatibility with the official .safetensors file
 
-    save_file(prefixed_sd, save_path, metadata=metadata)  # safetensors.save_file cosumes a lot of memory, but Anima is small enough
+    save_file(prefixed_sd, save_path, metadata=metadata)  # safetensors.save_file consumes a lot of memory, but Anima is small enough
     logger.info(f"Saved Anima model to {save_path}")

--- a/library/strategy_base.py
+++ b/library/strategy_base.py
@@ -376,7 +376,7 @@ class TextEncoderOutputsCachingStrategy:
 
 
 class LatentsCachingStrategy:
-    # TODO commonize utillity functions to this class, such as npz handling etc.
+    # TODO commonize utility functions to this class, such as npz handling etc.
 
     _strategy = None  # strategy instance: actual strategy class
 

--- a/sd3_minimal_inference.py
+++ b/sd3_minimal_inference.py
@@ -373,12 +373,12 @@ if __name__ == "__main__":
                     elif opt.startswith("d"):
                         seed = int(opt[1:].strip())
                     elif opt.startswith("m"):
-                        mutipliers = opt[1:].strip().split(",")
-                        if len(mutipliers) != len(lora_models):
+                        multipliers = opt[1:].strip().split(",")
+                        if len(multipliers) != len(lora_models):
                             logger.error(f"Invalid number of multipliers, expected {len(lora_models)}")
                             continue
                         for i, lora_model in enumerate(lora_models):
-                            lora_model.set_multiplier(float(mutipliers[i]))
+                            lora_model.set_multiplier(float(multipliers[i]))
                     elif opt.startswith("n"):
                         negative_prompt = opt[1:].strip()
                         if negative_prompt == "-":

--- a/sdxl_train_control_net_lllite.py
+++ b/sdxl_train_control_net_lllite.py
@@ -228,7 +228,7 @@ def train(args):
         info = unet_lllite.load_lllite_weights(args.network_weights, unet_sd)
         accelerator.print(f"load ControlNet-LLLite weights from {args.network_weights}: {info}")
     else:
-        # cosumes large memory, so send to GPU before creating the LLLite model
+        # consumes large memory, so send to GPU before creating the LLLite model
         accelerator.print("sending U-Net to GPU")
         unet.to(accelerator.device, dtype=weight_dtype)
         unet_sd = unet.state_dict()


### PR DESCRIPTION
## 概要
typo チェック (`typos`) 関連の対応です。

## 変更内容

### 1. `_typos.toml`: ipex ディレクトリを丸ごと除外
上流 (IPEX) 由来の vendored コードである `library/ipex/` を、個別ファイル指定ではなくディレクトリ単位で `extend-exclude` に追加。上流更新で別ファイルに同種パターンが増えても追随不要になります。

除外対象の検出はいずれも誤検出または上流の変数名で、こちらで修正すべきものではありません:
- `library/ipex/hijacks.py`: `arange` (`torch.arange` API 名を underscore identifier で拾ったもの)
- `library/ipex/attention.py`: `dyanmic` (上流 IPEX の変数名 `sdpa_pre_dyanmic_atten`)
- `library/hunyuan_image_text_encoder.py`: `Canva` (Canva フォント名データテーブル、既存除外を維持)

### 2. 自コード内の本物の typo を修正
| ファイル | 修正 |
|---|---|
| `sd3_minimal_inference.py` | `mutipliers` → `multipliers` (局所変数) |
| `flux_minimal_inference.py` | `mutipliers` → `multipliers` (同型のコピペコード) |
| `sdxl_train_control_net_lllite.py` | コメント `cosumes` → `consumes` |
| `library/anima_utils.py` | コメント `cosumes` → `consumes` |
| `library/strategy_base.py` | コメント `utillity` → `utility` |

## 確認
`typos` 全体実行で exit=0 (クリーン) を確認済み。