### PR TITLE
Anima ControlNet-LLLite v2.1: latent conditioning input

### DIFF
--- a/anima_minimal_inference_control_net_lllite.py
+++ b/anima_minimal_inference_control_net_lllite.py
@@ -43,7 +43,13 @@ from PIL import Image
 from safetensors import safe_open
 
 import anima_minimal_inference as ami
-from networks.control_net_lllite_anima import ControlNetLLLiteDiT, load_lllite_weights
+from library import anima_train_utils
+from networks.control_net_lllite_anima import (
+    COND_INPUT_SPACES,
+    ControlNetLLLiteDiT,
+    build_cond_tensors,
+    load_lllite_weights,
+)
 from library.utils import setup_logging
 
 setup_logging()
@@ -89,19 +95,20 @@ def _load_mask_image(
     return t.to(device=device, dtype=dtype)
 
 
-def _build_inpaint_cond_image(
-    rgb: torch.Tensor, mask: torch.Tensor, masked_input: bool
-) -> torch.Tensor:
-    """rgb: (B, 3, H, W) in [-1, 1], mask: (B, 1, H, W) in {0, 1}. Return (B, 4, H, W).
+# VAE used to encode the control image in latent cond mode. Loaded lazily and kept on CPU
+# between prompts (mirrors how anima_minimal_inference handles the decode VAE).
+_cond_vae = None
 
-    The mask channel is normalized to [-1, 1] (= (mask - 0.5) * 2) to match the RGB range.
-    """
-    if masked_input:
-        keep = (mask < 0.5).to(rgb.dtype)
-        rgb = rgb * keep
-    # mask channel: {0, 1} -> {-1, 1}. matches transforms.Normalize([0.5], [0.5])
-    mask_pm1 = mask.to(rgb.dtype) * 2.0 - 1.0
-    return torch.cat([rgb, mask_pm1], dim=1)
+
+def _get_cond_vae(args):
+    global _cond_vae
+    if _cond_vae is None:
+        logger.info("Loading VAE for LLLite cond encoding (latent cond input space)...")
+        _cond_vae = anima_train_utils.load_qwen_image_vae(args, device="cpu", disable_mmap=True)
+        _cond_vae.to(torch.bfloat16)
+        _cond_vae.eval()
+        _cond_vae.requires_grad_(False)
+    return _cond_vae
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +213,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--lllite_inpaint_masked_input", type=str, default=None, choices=["true", "false"],
         help="override inpaint_masked_input from weights metadata (true/false)",
+    )
+    parser.add_argument(
+        "--lllite_cond_input", type=str, default=None, choices=list(COND_INPUT_SPACES),
+        help="override cond_input_space from weights metadata (pixel/latent)",
     )
 
     args = parser.parse_args()
@@ -333,6 +344,12 @@ def load_dit_model(args, device, dit_weight_dtype=None):
         inpaint_masked_input = (
             meta.get("lllite.inpaint_masked_input", "false").lower() == "true"
         )
+    # cond 入力空間 (v2.1). メタデータ欠落時は pixel (旧重み互換)
+    cond_input_space = (
+        args.lllite_cond_input
+        if args.lllite_cond_input is not None
+        else meta.get("lllite.cond_input_space", "pixel")
+    )
     version = meta.get("lllite.version", "?")
     inpaint_log = (
         f", inpaint=on(masked_input={inpaint_masked_input})" if cond_in_channels == 4 else ""
@@ -341,6 +358,7 @@ def load_dit_model(args, device, dit_weight_dtype=None):
         f"LLLite config (v{version}): cond_emb_dim={cond_emb_dim}, mlp_dim={mlp_dim}, "
         f"target_layers={target_layers}, cond_dim={cond_dim}, cond_resblocks={cond_resblocks}, "
         f"use_aspp={use_aspp}{(' dilations=' + str(list(aspp_dilations))) if use_aspp else ''}, "
+        f"cond_input={cond_input_space}, "
         f"cond_in_channels={cond_in_channels}{inpaint_log}, multiplier={args.lllite_multiplier}"
     )
 
@@ -356,6 +374,7 @@ def load_dit_model(args, device, dit_weight_dtype=None):
         aspp_dilations=aspp_dilations,
         cond_in_channels=cond_in_channels,
         inpaint_masked_input=inpaint_masked_input,
+        cond_input_space=cond_input_space,
     )
     load_lllite_weights(lllite, args.lllite_weights, strict=False)
     lllite.apply_to()
@@ -390,13 +409,14 @@ def generate_body(
             "control_image is not set. Specify --control_image globally, "
             "or --cn per prompt in --from_file mode."
         )
-    cond_image = _load_control_image(ci_path, height, width, device, torch.bfloat16)
-    logger.info(f"Loaded control image: {ci_path} -> {tuple(cond_image.shape)}")
+    rgb = _load_control_image(ci_path, height, width, device, torch.bfloat16)
+    logger.info(f"Loaded control image: {ci_path} -> {tuple(rgb.shape)}")
 
     if not hasattr(anima, "lllite"):
         raise RuntimeError("DiT has no .lllite attribute; load_dit_model patch was not applied")
 
-    # inpainting (4ch): require a mask image; concat to cond_image as 4th channel
+    # inpainting (4ch): require a mask image
+    mask = None
     if anima.lllite.cond_in_channels == 4:
         mk_path = getattr(args, "mask_image", None)
         if mk_path is None:
@@ -405,17 +425,35 @@ def generate_body(
                 "Specify --mask_image globally, or --mk per prompt in --from_file mode."
             )
         mask = _load_mask_image(mk_path, height, width, device, torch.bfloat16)
-        cond_image = _build_inpaint_cond_image(
-            cond_image, mask, anima.lllite.inpaint_masked_input
-        )
         logger.info(
-            f"Loaded mask image: {mk_path} -> 4ch cond_image {tuple(cond_image.shape)}"
-            f" (masked_input={anima.lllite.inpaint_masked_input})"
+            f"Loaded mask image: {mk_path} (masked_input={anima.lllite.inpaint_masked_input})"
         )
+
+    # latent cond mode: VAE-encode the control image (kept on CPU between prompts)
+    is_latent = anima.lllite.cond_input_space == "latent"
+    cond_vae = _get_cond_vae(args) if is_latent else None
+    if cond_vae is not None:
+        cond_vae.to(device)
+    try:
+        cond_image, cond_mask = build_cond_tensors(
+            rgb,
+            mask,
+            cond_input_space=anima.lllite.cond_input_space,
+            cond_in_channels=anima.lllite.cond_in_channels,
+            inpaint_masked_input=anima.lllite.inpaint_masked_input,
+            vae=cond_vae,
+        )
+    finally:
+        if cond_vae is not None:
+            cond_vae.to("cpu")
+    logger.info(
+        f"LLLite cond ({anima.lllite.cond_input_space}): cond_image={tuple(cond_image.shape)}"
+        + (f", cond_mask={tuple(cond_mask.shape)}" if cond_mask is not None else "")
+    )
 
     # honor per-prompt override of multiplier
     anima.lllite.set_multiplier(args.lllite_multiplier)
-    anima.lllite.set_cond_image(cond_image)
+    anima.lllite.set_cond_image(cond_image, cond_mask)
 
     try:
         return _original_generate_body(args, anima, context, context_null, device, seed)

--- a/anima_train_control_net_lllite.py
+++ b/anima_train_control_net_lllite.py
@@ -56,7 +56,9 @@ from networks.control_net_lllite_anima import (
     AnimaControlNetLLLiteWrapper,
     save_lllite_model,
     load_lllite_weights,
+    build_cond_tensors,
     LLLITE_ARCH_VERSION,
+    COND_INPUT_SPACES as LLLITE_COND_INPUT_SPACES,
     PRESETS as LLLITE_PRESETS,
     ATOMIC_SPECIFIERS as LLLITE_ATOMIC_SPECIFIERS,
 )
@@ -87,24 +89,6 @@ def _load_mask_image(path: str, width: int, height: int, device, dtype) -> torch
     return tensor.to(device=device, dtype=dtype)
 
 
-def _build_inpaint_cond_image(
-    rgb: torch.Tensor,
-    masks: torch.Tensor,
-    masked_input: bool,
-) -> torch.Tensor:
-    """rgb: (B, 3, H, W) in [-1, 1], masks: (B, 1, H, W) in {0, 1} (1=inpaint).
-    Returns (B, 4, H, W) with the mask channel normalized to [-1, 1] to match the RGB range.
-
-    masked_input=True のとき、RGB を mask 域で 0 に潰してから concat する。
-    """
-    if masked_input:
-        keep = (masks < 0.5).to(rgb.dtype)  # (B, 1, H, W)
-        rgb = rgb * keep
-    # mask channel: {0, 1} -> {-1, 1} (= (mask - 0.5) * 2). matches transforms.Normalize([0.5], [0.5])
-    mask_pm1 = masks.to(rgb.dtype) * 2.0 - 1.0
-    return torch.cat([rgb, mask_pm1], dim=1)
-
-
 def _generate_random_masks_for_batch(
     batch_size: int, height: int, width: int, device, dtype
 ) -> torch.Tensor:
@@ -119,7 +103,7 @@ def _generate_random_masks_for_batch(
     return torch.from_numpy(masks_np).to(device=device, dtype=dtype)
 
 
-def _make_lllite_sample_hooks(args, lllite, dit_dtype):
+def _make_lllite_sample_hooks(args, lllite, dit_dtype, vae=None):
     """Build (on_prompt_start, on_prompt_end) callbacks that wire control image / multiplier
     into the LLLite module before each sample prompt is rendered. The pre-sample multiplier is
     saved and restored so that, e.g., `--am 0` for inspection does not leak into training (which
@@ -129,9 +113,14 @@ def _make_lllite_sample_hooks(args, lllite, dit_dtype):
     In inpainting mode (cond_in_channels=4) the prompt line additionally accepts `--mk <path>`
     for the mask image. If the mask is missing/not found the prompt is rendered without LLLite cond
     (warning logged), so users can intentionally inspect the base DiT.
+
+    `vae` is required when the LLLite runs in latent cond input space (the control image is VAE
+    encoded before being fed to conditioning1).
     """
 
     is_inpaint = lllite.cond_in_channels == 4
+    is_latent = lllite.cond_input_space == "latent"
+    assert not is_latent or vae is not None, "vae is required for latent cond input space"
 
     saved = {"multiplier": None}
 
@@ -183,11 +172,18 @@ def _make_lllite_sample_hooks(args, lllite, dit_dtype):
                 lllite.clear_cond_image()
                 return
             mask = _load_mask_image(mk_path, w, h, accelerator.device, dit_dtype)
-            cond_image = _build_inpaint_cond_image(rgb, mask, args.lllite_inpaint_masked_input)
         else:
-            cond_image = rgb
+            mask = None
 
-        lllite.set_cond_image(cond_image)
+        cond_image, cond_mask = build_cond_tensors(
+            rgb,
+            mask,
+            cond_input_space=lllite.cond_input_space,
+            cond_in_channels=lllite.cond_in_channels,
+            inpaint_masked_input=args.lllite_inpaint_masked_input,
+            vae=vae,
+        )
+        lllite.set_cond_image(cond_image, cond_mask)
 
     def on_prompt_end(prompt_dict: dict):
         lllite.clear_cond_image()
@@ -268,6 +264,18 @@ def add_anima_lllite_arguments(parser: argparse.ArgumentParser):
         ),
     )
     parser.add_argument(
+        "--lllite_cond_input",
+        type=str,
+        default="pixel",
+        choices=list(LLLITE_COND_INPUT_SPACES),
+        help=(
+            "input space for the control image: 'pixel' feeds the image directly to conditioning1 (default, v2), "
+            "'latent' VAE-encodes it first and feeds the 16ch latent (v2.1). "
+            "/ 制御画像の入力空間。pixel は画像をそのまま conditioning1 に入力 (既定)、"
+            "latent は VAE で encode した 16ch latent を入力する"
+        ),
+    )
+    parser.add_argument(
         "--lllite_inpaint_masked_input",
         action="store_true",
         help=(
@@ -321,6 +329,9 @@ def train(args):
         )
 
     cache_latents = args.cache_latents
+
+    # cond 入力空間 (v2.1). latent モードでは cond 画像を毎ステップ VAE encode するため VAE を常駐させる
+    is_latent_cond = args.lllite_cond_input == "latent"
 
     if args.seed is not None:
         set_seed(args.seed)
@@ -467,7 +478,11 @@ def train(args):
         vae.requires_grad_(False)
         vae.eval()
         train_dataset_group.new_cache_latents(vae, accelerator)
-        vae.to("cpu")
+        if is_latent_cond:
+            # latent cond モードでは学習ループ・サンプル生成で毎回 cond 画像を encode するため GPU に残す
+            logger.info("keeping VAE on GPU for latent cond encoding (--lllite_cond_input latent)")
+        else:
+            vae.to("cpu")
         clean_memory_on_device(accelerator.device)
         accelerator.wait_for_everyone()
 
@@ -488,6 +503,11 @@ def train(args):
     # inpainting (4ch) フラグの早期検証
     if args.lllite_cond_in_channels < 1:
         raise ValueError(f"--lllite_cond_in_channels must be >= 1, got {args.lllite_cond_in_channels}")
+    if is_latent_cond and args.lllite_cond_in_channels not in (3, 4):
+        raise ValueError(
+            "--lllite_cond_input latent supports --lllite_cond_in_channels 3 (RGB) or 4 (RGB+mask), "
+            f"got {args.lllite_cond_in_channels}"
+        )
     if args.lllite_inpaint_masked_input and args.lllite_cond_in_channels != 4:
         logger.warning(
             f"--lllite_inpaint_masked_input is only effective when --lllite_cond_in_channels=4 "
@@ -509,6 +529,7 @@ def train(args):
         use_aspp=args.lllite_use_aspp,
         cond_in_channels=args.lllite_cond_in_channels,
         inpaint_masked_input=args.lllite_inpaint_masked_input,
+        cond_input_space=args.lllite_cond_input,
     )
 
     if args.network_weights is not None:
@@ -637,7 +658,7 @@ def train(args):
 
     # sample image hooks: inject control image / multiplier into LLLite around each prompt
     on_prompt_start, on_prompt_end = _make_lllite_sample_hooks(
-        args, accelerator.unwrap_model(wrapper).lllite, dit_weight_dtype
+        args, accelerator.unwrap_model(wrapper).lllite, dit_weight_dtype, vae
     )
 
     def _sample_images(epoch_arg, step_arg):
@@ -679,6 +700,7 @@ def train(args):
         sai_metadata["lllite.use_aspp"] = "true" if args.lllite_use_aspp else "false"
         if args.lllite_use_aspp:
             sai_metadata["lllite.aspp_dilations"] = ",".join(str(d) for d in unwrapped.aspp_dilations)
+        sai_metadata["lllite.cond_input_space"] = args.lllite_cond_input
         sai_metadata["lllite.cond_in_channels"] = str(args.lllite_cond_in_channels)
         sai_metadata["lllite.inpaint_masked_input"] = (
             "true" if args.lllite_inpaint_masked_input else "false"
@@ -786,17 +808,27 @@ def train(args):
                 padding_mask = torch.zeros(bs, 1, h_latent, w_latent, dtype=dit_weight_dtype, device=accelerator.device)
 
                 # cond image: dataset 側で IMAGE_TRANSFORMS により [-1,1] 正規化済み
-                cond_image = batch["conditioning_images"].to(accelerator.device, dtype=dit_weight_dtype)
+                cond_rgb = batch["conditioning_images"].to(accelerator.device, dtype=dit_weight_dtype)
 
-                # inpainting: ランダム mask をバッチ毎に生成し、cond_image を 4ch (RGB + mask) 化
+                # inpainting: ランダム mask をバッチ毎に生成する
                 if is_inpaint:
-                    bs_c, _, h_c, w_c = cond_image.shape
+                    bs_c, _, h_c, w_c = cond_rgb.shape
                     mask = _generate_random_masks_for_batch(
                         bs_c, h_c, w_c, accelerator.device, dit_weight_dtype
                     )
-                    cond_image = _build_inpaint_cond_image(
-                        cond_image, mask, args.lllite_inpaint_masked_input
-                    )
+                else:
+                    mask = None
+
+                # pixel モード: (B, 3 or 4, H, W) / latent モード: VAE encode 済み (B,16,H/8,W/8)
+                # + pixel 解像度の mask を別テンソルで渡す。VAE encode は autocast の外 (no_grad)。
+                cond_image, cond_mask = build_cond_tensors(
+                    cond_rgb,
+                    mask,
+                    cond_input_space=args.lllite_cond_input,
+                    cond_in_channels=args.lllite_cond_in_channels,
+                    inpaint_masked_input=args.lllite_inpaint_masked_input,
+                    vae=vae,
+                )
 
                 # 5D化
                 noisy_model_input = noisy_model_input.unsqueeze(2)  # (B, C, 1, H, W)
@@ -807,6 +839,7 @@ def train(args):
                         timesteps,
                         prompt_embeds,
                         cond_image=cond_image,
+                        cond_mask=cond_mask,
                         padding_mask=padding_mask,
                         source_attention_mask=attn_mask,
                         t5_input_ids=t5_input_ids,

--- a/docs/anima_train_control_net_lllite.md
+++ b/docs/anima_train_control_net_lllite.md
@@ -12,6 +12,8 @@ The current implementation is the **v2 architecture**, which extends the origina
 * atomic `target_layers` specifiers, including a new **`mlp_fc1_pre`** target that injects LLLite into the MLP block,
 * an optional **ASPP** (Atrous Spatial Pyramid Pooling) tail in `conditioning1`, switchable via `--lllite_use_aspp`.
 
+**v2.1** additionally offers an optional **latent conditioning input** (`--lllite_cond_input latent`): the control image is VAE-encoded and the resulting 16ch latent is fed to `conditioning1` instead of raw pixels, so the pretrained VAE encoder does the heavy feature extraction (see Section 8). The weight format and `lllite.version` are unchanged (`"2"`); pixel-space weights keep working exactly as before.
+
 > **Status:** experimental. Currently supports image generation only (`T=1`). `--blocks_to_swap`, `--cpu_offload_checkpointing`, `--unsloth_offload_checkpointing`, `--deepspeed`, and `--fused_backward_pass` are not yet supported and the training script will assert if any of them is enabled.
 
 An experimental ComfyUI ControlNet-LLLite node for Anima is also available [here](https://github.com/kohya-ss/ComfyUI-Anima-LLLite).
@@ -30,6 +32,8 @@ ControlNet-LLLite は SDXL 向けに導入された LoRA ライクな軽量条�
 * モジュール毎の **depth embedding**（zero-init bias）を shared `cond_emb` に加算し、層別性の必要度を観察するプローブとして利用しています。
 * `target_layers` を atomic specifier 形式でも指定できるよう拡張し、新しく **`mlp_fc1_pre`**（MLP ブロックへの注入）を追加しました。
 * `conditioning1` 末尾に **ASPP** (Atrous Spatial Pyramid Pooling) を任意で挿入できる `--lllite_use_aspp` を追加しました。
+
+**v2.1** ではさらに、制御画像を VAE で encode した 16ch latent を（pixel の代わりに）`conditioning1` に入力する **latent 条件入力**（`--lllite_cond_input latent`）を選べるようになりました。学習済み VAE encoder に特徴抽出の大半を担わせる狙いです（第 8 節）。重みフォーマットと `lllite.version`（`"2"`）は据え置きで、pixel 空間の既存重みはこれまで通り動作します。
 
 > **ステータス:** 実験的実装です。現状は画像生成（`T=1`）のみ対応しています。`--blocks_to_swap` / `--cpu_offload_checkpointing` / `--unsloth_offload_checkpointing` / `--deepspeed` / `--fused_backward_pass` には未対応で、指定すると学習スクリプトが assert で停止します。
 
@@ -182,6 +186,9 @@ The following options are unique to this script. Anima-related arguments (`--qwe
   * Atomic specifiers can be freely combined: e.g. `self_attn_q_pre,mlp_fc1_pre` injects into Q + MLP fc1, `self_attn_q_pre,self_attn_kv_pre,mlp_fc1_pre` covers self-attn QKV + MLP. The resolved canonical atomic set is also written to the weights metadata (see Section 5).
   * `cross_attn.{k,v}_proj` and any `output_proj` are always skipped (the former is incompatible with the conditioning sequence shape; the latter is reserved for future post-projection variants).
 
+* `--lllite_cond_input={pixel,latent}` (default `pixel`)
+  * Input space of the control image. `pixel` (default, v2) feeds the image directly to the stride-16 `conditioning1` stem. `latent` (v2.1) VAE-encodes the control image and feeds the 16ch latent to a dedicated latent stem instead. See Section 8 for details and trade-offs.
+
 * `--lllite_dropout=<float>` (default `None`)
   * Dropout applied to the LLLite mid output (post-FiLM, post-SiLU) during training.
 
@@ -216,6 +223,7 @@ The following options are unique to this script. Anima-related arguments (`--qwe
     * `self_attn_qkv_cross_q` ≡ `self_attn_q_pre,self_attn_kv_pre,cross_attn_q_pre`。
   * atomic specifier は自由に組合せ可能です。例: `self_attn_q_pre,mlp_fc1_pre` は Q + MLP fc1 への注入、`self_attn_q_pre,self_attn_kv_pre,mlp_fc1_pre` は self-attn QKV + MLP 。解決後の canonical atomic 列は重みのメタデータにも記録されます（第 5 節参照）。
   * `cross_attn.{k,v}_proj` と `output_proj` は常時スキップされます（前者は context 側との shape 不整合、後者は将来の post-projection 系拡張のために予約）。
+* `--lllite_cond_input={pixel,latent}`（デフォルト `pixel`）— 制御画像の入力空間。`pixel`（既定、v2）は画像をそのまま stride-16 の `conditioning1` stem に入力します。`latent`（v2.1）は制御画像を VAE で encode し、16ch latent を専用の latent stem に入力します。詳細と長短は第 8 節を参照してください。
 * `--lllite_dropout=<float>`（デフォルト `None`）— LLLite の mid 出力（FiLM 適用後 SiLU 後）に対する学習時 dropout。
 * `--lllite_multiplier=<float>`（デフォルト `1.0`）— 学習中の LLLite 出力倍率。サンプル画像生成時にも、prompt 行で `--am` による上書きが無ければこの値が使われます。**`0.0` を指定すると学習時にも LLLite が完全 bypass され grad が乗らず学習が壊れる**ため、グローバルなデフォルトには `0` を使わないでください（観察用途であれば prompt 行で `--am 0` を指定する方法を推奨。第 4 節参照）。
 * `--network_weights=<path>` — 続きから学習する場合の LLLite 重み（`.safetensors`）のパス。`strict=False` でロードします。`--lllite_target_layers` と保存時の値が一致しているか確認してください（現状自動チェックはしていません）。
@@ -313,10 +321,18 @@ If `--cn` is omitted (or the file does not exist), the prompt is rendered with t
 The saved `.safetensors` contains only the LLLite-side parameters. On disk the per-module keys use a **named-key format**: each module's tensors are prefixed with its `lllite_name` (e.g. `lllite_dit_blocks_0_self_attn_q_proj`), so a single weight file uniquely identifies which DiT block / Linear each module targets. The internal `state_dict` keys (`lllite_modules.{i}.*` and the stacked `depth_embeds`) are rewritten at save time, and any file that still contains `lllite_modules.*` keys is rejected by `load_lllite_weights` as a legacy format. The on-disk layout is as follows (`{j}` indexes the ResBlock, and `{name}` stands for an `lllite_name` such as `lllite_dit_blocks_0_self_attn_q_proj`):
 
 ```
-# conditioning1 trunk (Conv stride-4 ×2 with an intermediate Conv stride-1)
+# conditioning1 stem, pixel mode (Conv stride-4 ×2 with an intermediate Conv stride-1)
 lllite_conditioning1.conv1.{weight,bias},  lllite_conditioning1.norm1.{weight,bias}
 lllite_conditioning1.conv2.{weight,bias},  lllite_conditioning1.norm2.{weight,bias}
 lllite_conditioning1.conv3.{weight,bias},  lllite_conditioning1.norm3.{weight,bias}
+
+# conditioning1 stem, latent mode (--lllite_cond_input latent) — replaces conv1..3 above
+lllite_conditioning1.lat_conv1.{weight,bias}, lllite_conditioning1.lat_norm1.{weight,bias}
+lllite_conditioning1.lat_conv2.{weight,bias}, lllite_conditioning1.lat_norm2.{weight,bias}
+# (latent mode + inpainting only) mask conv pyramid 1 -> 4 -> 8 -> 16ch
+lllite_conditioning1.mask_conv1.{weight,bias}
+lllite_conditioning1.mask_conv2.{weight,bias}
+lllite_conditioning1.mask_conv3.{weight,bias}
 
 # (optional) ResBlocks at trunk width
 lllite_conditioning1.resblocks.{j}.norm1.{weight,bias}, lllite_conditioning1.resblocks.{j}.conv1.{weight,bias}
@@ -352,10 +368,11 @@ The metadata records `modelspec.architecture = "anima-preview/control-net-lllite
 | `lllite.mlp_dim` | per-module MLP / FiLM hidden dim |
 | `lllite.target_layers` | the user-supplied `--lllite_target_layers` string verbatim |
 | `lllite.target_atomics` | resolved canonical atomic specifier list (comma-separated) |
-| `lllite.cond_in_channels` | conditioning1 input channel count (`"3"` standard, `"4"` inpaint) |
+| `lllite.cond_input_space` | `"pixel"` (v2 default) / `"latent"` (v2.1). Absent in older files → treated as `"pixel"` |
+| `lllite.cond_in_channels` | conditioning1 input channel count in **pixel semantics** (`"3"` standard, `"4"` inpaint) — in latent mode the actual stem input is 16 / 32ch |
 | `lllite.inpaint_masked_input` | `"true"` if RGB was masked before concat at train time (inpaint only) |
 
-The inference script (Section 6) reads these back, so you normally do not need to specify the architecture options on the command line again. Currently the inference script **requires** the metadata to reconstruct the architecture: state-dict-only auto-detection (e.g. for hand-edited weight files) is not implemented.
+The inference script (Section 6) reads these back, so you normally do not need to specify the architecture options on the command line again. Because the pixel and latent stems use disjoint key names, loading a pixel-space weight file into a latent-mode model (or vice versa) fails immediately with a `cond input space mismatch` error instead of silently leaving the stem at its random initialization. Currently the inference script **requires** the metadata to reconstruct the architecture: state-dict-only auto-detection (e.g. for hand-edited weight files) is not implemented.
 
 Save cadence options (`--save_every_n_epochs`, `--save_every_n_steps`, `--save_state`, `--save_last_n_epochs`, `--save_last_n_steps`, ...) work the same as in standard training scripts.
 
@@ -365,10 +382,18 @@ Save cadence options (`--save_every_n_epochs`, `--save_every_n_steps`, `--save_s
 保存される `.safetensors` には LLLite 側のパラメータのみが含まれます。ディスク上のモジュール毎キーは **named-key 形式** で、各モジュールのテンソルにそのモジュールの `lllite_name`（例：`lllite_dit_blocks_0_self_attn_q_proj`）が prefix として付きます。これにより重みファイル単独で「どの DiT block のどの Linear 用か」が一意に判別できます。内部 `state_dict` のキー（`lllite_modules.{i}.*` および stack された `depth_embeds`）は保存時に書き換えられ、`lllite_modules.*` キーを含むファイルは `load_lllite_weights` で legacy フォーマットとして reject されます。ディスク上の構造は以下の通りです（`{j}` は ResBlock の index、`{name}` は `lllite_dit_blocks_0_self_attn_q_proj` のような `lllite_name`）：
 
 ```
-# conditioning1 trunk (stride-4 Conv ×2、その間に stride-1 Conv)
+# conditioning1 stem・pixel モード (stride-4 Conv ×2、その間に stride-1 Conv)
 lllite_conditioning1.conv1.{weight,bias},  lllite_conditioning1.norm1.{weight,bias}
 lllite_conditioning1.conv2.{weight,bias},  lllite_conditioning1.norm2.{weight,bias}
 lllite_conditioning1.conv3.{weight,bias},  lllite_conditioning1.norm3.{weight,bias}
+
+# conditioning1 stem・latent モード (--lllite_cond_input latent) — 上記 conv1..3 の代わりに保存される
+lllite_conditioning1.lat_conv1.{weight,bias}, lllite_conditioning1.lat_norm1.{weight,bias}
+lllite_conditioning1.lat_conv2.{weight,bias}, lllite_conditioning1.lat_norm2.{weight,bias}
+# (latent モード + inpainting のときのみ) mask conv pyramid 1 -> 4 -> 8 -> 16ch
+lllite_conditioning1.mask_conv1.{weight,bias}
+lllite_conditioning1.mask_conv2.{weight,bias}
+lllite_conditioning1.mask_conv3.{weight,bias}
 
 # (オプション) trunk 幅で動作する ResBlock
 lllite_conditioning1.resblocks.{j}.norm1.{weight,bias}, lllite_conditioning1.resblocks.{j}.conv1.{weight,bias}
@@ -404,10 +429,11 @@ lllite_conditioning1.out_norm.{weight,bias}
 | `lllite.mlp_dim` | LLLite モジュール毎の MLP / FiLM 中間次元 |
 | `lllite.target_layers` | ユーザが指定した `--lllite_target_layers` 文字列をそのまま記録 |
 | `lllite.target_atomics` | 解決後の canonical atomic specifier 列（カンマ区切り） |
-| `lllite.cond_in_channels` | conditioning1 入力チャネル数（`"3"` 通常、`"4"` inpainting） |
+| `lllite.cond_input_space` | `"pixel"`（v2 既定）/ `"latent"`（v2.1）。旧ファイルでキーが無い場合は `"pixel"` 扱い |
+| `lllite.cond_in_channels` | conditioning1 入力チャネル数（**pixel 意味論**で `"3"` 通常、`"4"` inpainting）。latent モードでは stem の実入力は 16 / 32ch |
 | `lllite.inpaint_masked_input` | 学習時 RGB を mask 域で 0 化してから concat したか（inpaint 専用、`"true"`/`"false"`） |
 
-これらは推論スクリプト（第 6 節）で自動的に読み出されるため、通常はコマンドラインで再指定する必要はありません。現在の推論スクリプトはアーキテクチャ復元に**メタデータが必須**で、state_dict 単独からの自動判定（手編集された重みファイル等）には対応していません。
+これらは推論スクリプト（第 6 節）で自動的に読み出されるため、通常はコマンドラインで再指定する必要はありません。pixel と latent の stem はキー名が分離されているため、pixel 重みを latent モードのモデルに（またはその逆で）読ませようとすると、初期値のまま黙って動くのではなく `cond input space mismatch` エラーで即座に失敗します。現在の推論スクリプトはアーキテクチャ復元に**メタデータが必須**で、state_dict 単独からの自動判定（手編集された重みファイル等）には対応していません。
 
 保存頻度の各オプション（`--save_every_n_epochs`、`--save_every_n_steps`、`--save_state`、`--save_last_n_epochs`、`--save_last_n_steps` など）は通常の学習スクリプトと同様に使えます。
 
@@ -461,7 +487,9 @@ a dog --w 1024 --h 1024 --d 0 --cn lineart_b.png
 * `--lllite_weights <path>` **[required, unless `--latent_path` is given]** — trained LLLite weights.
 * `--control_image <path>` — global control image. Required for single-prompt mode; optional in `--from_file` / `--interactive` mode if every prompt provides `--cn`.
 * `--lllite_multiplier <float>` (default `1.0`) — global LLLite multiplier.
-* `--lllite_cond_emb_dim`, `--lllite_cond_dim`, `--lllite_cond_resblocks`, `--lllite_mlp_dim`, `--lllite_target_layers`, `--lllite_use_aspp` — manual overrides. Normally unnecessary because the values are read from the weights metadata. `--lllite_use_aspp` takes the literal strings `true` / `false`.
+* `--lllite_cond_emb_dim`, `--lllite_cond_dim`, `--lllite_cond_resblocks`, `--lllite_mlp_dim`, `--lllite_target_layers`, `--lllite_use_aspp`, `--lllite_cond_input` — manual overrides. Normally unnecessary because the values are read from the weights metadata. `--lllite_use_aspp` takes the literal strings `true` / `false`; `--lllite_cond_input` takes `pixel` / `latent`.
+
+When the weights were trained with `--lllite_cond_input latent`, the inference script loads the VAE a second time (kept on CPU between prompts) to encode the control image, so `--vae` must be given as usual.
 
 CFG inference (cond / uncond passes) is handled by simply broadcasting the same `cond_emb` to both passes, so control is applied symmetrically.
 
@@ -478,7 +506,8 @@ CFG inference (cond / uncond passes) is handled by simply broadcasting the same 
   * `--lllite_weights <path>` **[必須、ただし `--latent_path` 指定時を除く]** — 学習済み LLLite 重み。
   * `--control_image <path>` — グローバル control 画像。単発推論では必須。`--from_file` / `--interactive` で全プロンプトが `--cn` を持つ場合は省略可。
   * `--lllite_multiplier <float>`（デフォルト `1.0`）— グローバル LLLite 倍率。
-  * `--lllite_cond_emb_dim` / `--lllite_cond_dim` / `--lllite_cond_resblocks` / `--lllite_mlp_dim` / `--lllite_target_layers` / `--lllite_use_aspp` — 通常はメタデータから自動読み込みされるため指定不要。手動上書きが必要な場合のみ指定します。`--lllite_use_aspp` は `true` / `false` の文字列リテラルで指定します。
+  * `--lllite_cond_emb_dim` / `--lllite_cond_dim` / `--lllite_cond_resblocks` / `--lllite_mlp_dim` / `--lllite_target_layers` / `--lllite_use_aspp` / `--lllite_cond_input` — 通常はメタデータから自動読み込みされるため指定不要。手動上書きが必要な場合のみ指定します。`--lllite_use_aspp` は `true` / `false`、`--lllite_cond_input` は `pixel` / `latent` の文字列リテラルで指定します。
+  * `--lllite_cond_input latent` で学習した重みの場合、control 画像の encode 用に VAE をもう一度ロードします（プロンプト間は CPU に退避）。`--vae` は通常通り指定してください。
 
 CFG 推論（cond / uncond の 2 pass）は両 pass に同じ `cond_emb` を配布する形になっており、control は両側に対称に作用します。
 
@@ -491,6 +520,8 @@ CFG 推論（cond / uncond の 2 pass）は両 pass に同じ `cond_emb` を配�
 When `--lllite_cond_in_channels=4` is passed, the LLLite `conditioning1` trunk accepts a 4-channel input instead of the default 3 channels: `[R, G, B, mask]`. The training script generates a fresh random mask per sample at every step (via `library.mask_generator.random_mask`) and concatenates it with the conditioning RGB image. At inference time you pass the control image and the mask separately (the script concatenates them internally).
 
 The default 3-channel behavior (no mask, generic ControlNet usage) is unchanged. The same code path is intentionally generic so that future 4-channel conditioning (e.g. user-supplied control masks for lighting / region control) can reuse the same trunk; for the initial release only inpainting is wired up.
+
+This section describes the pixel path. Inpainting also works with `--lllite_cond_input latent`, where the mask takes a separate route — see Section 8.1.
 
 ### 7.1. Mask Convention / マスク規約
 
@@ -615,9 +646,118 @@ python anima_minimal_inference_control_net_lllite.py \
 
 </details>
 
-## 8. Tips & Limitations / 補足と制限
+## 8. Latent Conditioning Input (v2.1) / 条件画像の latent 入力 (v2.1)
 
-* **Resolution alignment.** The conditioning encoder uses fixed stride 16, so `cond_image` HW must equal `latent HW × 8` (i.e. the original training image size) (the latent is patchified with patch size=2, so stride is 8*2=16). The DataLoader for the ControlNet dataset already resizes the conditioning image to match the training image, so in practice you only need to make sure the control image you pass at inference time matches the requested `--image_size`.
+> **Status:** experimental. Optional; the default remains the v2 pixel path and existing weights are unaffected.
+
+With `--lllite_cond_input latent`, the control image is **VAE-encoded** before it reaches `conditioning1`, and the resulting normalized 16ch latent (the very representation the DiT's `x_embedder` consumes) is fed to a dedicated latent stem instead of the stride-16 pixel stem:
+
+```
+pixel  (default): cond image (B,3,H,W)  -> Conv4x4 s4 -> Conv3x3 s1 -> Conv4x4 s4  -> (B,cond_dim,H/16,W/16)
+latent          : cond image (B,3,H,W)  -> VAE encode -> (B,16,H/8,W/8)
+                                        -> Conv3x3 s1 -> Conv2x2 s2               -> (B,cond_dim,H/16,W/16)
+```
+
+The motivation is leverage: `conditioning1` is computed once per step and shared by every LLLite module, so improving it benefits all of them. In pixel mode that feature extractor is trained from scratch on a few thousand pairs; in latent mode the pretrained VAE encoder (a deep ResBlock network) does the bulk of the work for free, and the stem only has to map an already-rich representation into the trunk. FLUX.1 Canny/Depth (Control LoRA) and SD3.5 ControlNet use VAE-encoded control images the same way, including for near-binary signals like canny.
+
+Practical notes:
+
+* The latent stem reaches the token grid exactly: the latent is `H/8`, the stride-2 conv halves it to `H/16`, which is the DiT token resolution (VAE /8 × patch /2).
+* Since the VAE carries most of the feature extraction, `--lllite_cond_resblocks 1` is expected to be enough — this is worth checking against your pixel-mode baseline before spending capacity there.
+* The control image is encoded **on the fly every step** (under `no_grad`, outside autocast). Caching cond latents to disk is not implemented yet. In latent mode the VAE therefore stays resident on the GPU even with `--cache_latents`, which costs a little VRAM.
+* Sparse control signals (lineart, stick-figure poses) are somewhat out of the VAE's reconstruction domain. A cheap sanity check before a long run is to VAE encode→decode a few of your control images and look at the result.
+* This is orthogonal to `--lllite_target_layers`, `--lllite_use_aspp`, ResBlock count and multiplier — combine freely.
+
+### 8.1. Inpainting in Latent Mode / latent モードでの inpainting
+
+A mask cannot be pushed through the VAE, so in latent mode (`--lllite_cond_in_channels 4`) it takes a separate route: it is passed at **pixel resolution** as its own tensor and downsampled to latent resolution by a small learnable conv pyramid inside `conditioning1`, then concatenated with the cond latent:
+
+```
+mask (B,1,H,W) in {-1,1}
+  -> Conv 2x2 s2 -> SiLU      (B, 4, H/2, W/2)   2x2-scale detail
+  -> Conv 3x3 s2 -> SiLU      (B, 8, H/4, W/4)   4x4 scale
+  -> Conv 3x3 s2 (linear)     (B,16, H/8, W/8)   8x8 scale
+concat with the cond latent -> (B,32,H/8,W/8) -> latent stem
+```
+
+The pyramid has no normalization between stages on purpose: GroupNorm removes the per-map mean/scale, which for a mostly-uniform mask would erase how much of the image is masked (in the limit, a fully-masked and a fully-unmasked image would produce the same features). The SiLU nonlinearity is what keeps the three stages from collapsing into a single linear map. Total cost is ~1.5K parameters.
+
+Channel balance is 16 (latent) + 16 (mask), and the effective receptive field of the pyramid (~14×14 px) slightly overlaps neighboring 8×8 cells, so boundaries that straddle two latent pixels stay continuous. Each token still sees the mask of exactly the 16×16 pixel patch it represents, matching the per-token mask visibility of the pixel path — the v2 property of clean, blend-free mask boundaries is the requirement this design is built around, and is worth verifying visually when you compare the two modes.
+
+`--lllite_inpaint_masked_input` keeps its meaning: the RGB is zeroed inside the mask region **in pixel space, before** the VAE encode. Mask convention, dataset setup (`conditioning_data_dir` = `image_dir`), random-mask generation and the `--mk` prompt-line flag are all unchanged from Section 7.
+
+Example:
+
+```bash
+accelerate launch --num_cpu_threads_per_process 1 anima_train_control_net_lllite.py \
+  --pretrained_model_name_or_path="<path to Anima DiT model>" \
+  --qwen3="<path to Qwen3-0.6B model or directory>" \
+  --vae="<path to Qwen-Image VAE model>" \
+  --dataset_config="my_anima_lllite.toml" \
+  --output_dir="<output directory>" --output_name="my_anima_lllite_latent" \
+  --save_model_as=safetensors \
+  --lllite_cond_input=latent \
+  --cond_emb_dim=32 --lllite_mlp_dim=64 --lllite_cond_dim=64 \
+  --lllite_cond_resblocks=1 --lllite_target_layers=self_attn_q \
+  --learning_rate=1e-4 --optimizer_type="AdamW8bit" --lr_scheduler="constant" \
+  --timestep_sampling="shift" --discrete_flow_shift=3.0 \
+  --max_train_epochs=10 --save_every_n_epochs=1 \
+  --mixed_precision="bf16" --gradient_checkpointing \
+  --cache_latents --cache_text_encoder_outputs \
+  --vae_chunk_size=64 --vae_disable_cache
+```
+
+### 8.2. Limitations / 制限
+
+* Cond latents are not cached to disk; they are re-encoded every step.
+* In latent mode `--lllite_cond_in_channels` must be `3` or `4` (the generic `cond_in_channels` path of Section 7 is pixel-mode only).
+* Pixel-mode and latent-mode weights are not interchangeable; the loader rejects a mix-up explicitly (Section 5).
+* Whether latent conditioning actually beats the pixel stem for a given control signal is an open question — A/B it against a pixel-mode run with the same data and hyperparameters.
+
+<details>
+<summary>日本語</summary>
+
+`--lllite_cond_input latent` を指定すると、制御画像を **VAE で encode** してから `conditioning1` に入力します。入力されるのは DiT の `x_embedder` が消費するのと同じ正規化済み 16ch latent で、stride-16 の pixel stem の代わりに専用の latent stem を通ります。
+
+```
+pixel（既定）: cond 画像 (B,3,H,W) -> Conv4x4 s4 -> Conv3x3 s1 -> Conv4x4 s4 -> (B,cond_dim,H/16,W/16)
+latent       : cond 画像 (B,3,H,W) -> VAE encode -> (B,16,H/8,W/8)
+                                   -> Conv3x3 s1 -> Conv2x2 s2              -> (B,cond_dim,H/16,W/16)
+```
+
+狙いはレバレッジです。`conditioning1` は 1 step に 1 回だけ計算され全 LLLite モジュールに共有されるため、ここを強化すると全モジュールに効きます。pixel モードではこの特徴抽出器を数千ペアでスクラッチ学習していますが、latent モードでは学習済み VAE encoder（各スケールに ResBlock を持つ深いネット）が追加学習パラメータなしでその大半を担い、stem は「すでにリッチな表現を trunk に写す」だけで済みます。FLUX.1 Canny/Depth (Control LoRA) や SD3.5 ControlNet も同じ方式で、canny のようなニアバイナリ画像でも成立することは実証済みです。
+
+補足:
+
+* latent (`H/8`) を stride 2 で落とすと `H/16` = DiT の token 解像度（VAE /8 × patch /2）にちょうど一致します。
+* 特徴抽出の大半を VAE が担うため `--lllite_cond_resblocks 1` で足りる見込みです。pixel モードのベースラインと比較して確認する価値があります。
+* 制御画像は**毎ステップ on-the-fly で encode** します（`no_grad`、autocast の外）。cond latent のディスクキャッシュは未実装です。このため latent モードでは `--cache_latents` 指定時も VAE を GPU に常駐させます（その分 VRAM を消費します）。
+* 線画やポーズ棒人間のようなスパースな制御信号は VAE の再構成ドメインからやや外れます。長時間の学習前に、手持ちの制御画像を VAE で encode→decode して目視確認しておくと安価な事前検証になります。
+* `--lllite_target_layers` / `--lllite_use_aspp` / ResBlock 段数 / multiplier とは直交します。自由に組み合わせられます。
+
+**latent モードでの inpainting**: mask は VAE に通せないため別経路になります。mask は **pixel 解像度のまま別テンソル**で渡し、`conditioning1` 内部の小さな学習可能 conv pyramid で latent 解像度に落としてから cond latent と concat します。
+
+```
+mask (B,1,H,W) {-1,1}
+  -> Conv 2x2 s2 -> SiLU      (B, 4, H/2, W/2)   2x2 の微細パターン担当
+  -> Conv 3x3 s2 -> SiLU      (B, 8, H/4, W/4)   4x4 スケール担当
+  -> Conv 3x3 s2 (linear)     (B,16, H/8, W/8)   8x8 スケール担当
+cond latent と concat -> (B,32,H/8,W/8) -> latent stem
+```
+
+段間に正規化を置いていないのは意図的です。GroupNorm は特徴マップ全体の平均・スケールを除去するため、ほぼ一様な mask では「どれだけの面積がマスクされているか」の情報が失われます（極端には全面マスクと全面非マスクが同じ特徴になります）。3 段が単一の線形写像に縮退するのを防ぐ役割は SiLU が担っています。総パラメータは約 1.5K です。
+
+チャネル配分は latent 16 + mask 16 で対称、pyramid の実効受容野（約 14×14 px）は隣接 8×8 セルに少しはみ出すため、latent 1 画素をまたぐ境界の連続性も拾えます。1 token が担当する 16×16 pixel patch の mask 情報にアクセスできる点は pixel パスと同じです。v2 の「mask 境界のアーティファクトが皆無」という性質を維持することが本設計の必須要件なので、2 モードを比較する際は境界品質を目視で確認してください。
+
+`--lllite_inpaint_masked_input` の意味は変わりません（RGB の mask 域を **pixel 空間で、VAE encode の前に** 0 化します）。マスク規約、データセット設定（`conditioning_data_dir` = `image_dir`）、ランダム mask 生成、prompt 行の `--mk` はすべて第 7 節のままです。
+
+**制限**: cond latent のディスクキャッシュは未対応（毎ステップ再 encode）。latent モードの `--lllite_cond_in_channels` は `3` / `4` のみ（第 7 節の generic な `cond_in_channels` 拡張は pixel モード専用）。pixel 重みと latent 重みは互換性がなく、取り違えは明示的に reject されます（第 5 節）。制御信号ごとに latent が pixel より本当に有利かは未検証なので、同一データ・同一ハイパラでの A/B 比較を推奨します。
+
+</details>
+
+## 9. Tips & Limitations / 補足と制限
+
+* **Resolution alignment.** The conditioning encoder uses fixed stride 16, so `cond_image` HW must equal `latent HW × 8` (i.e. the original training image size) (the latent is patchified with patch size=2, so stride is 8*2=16). In latent mode (Section 8) the control image is still supplied at the original image size; the VAE /8 plus the stem's stride-2 conv give the same total stride of 16. The DataLoader for the ControlNet dataset already resizes the conditioning image to match the training image, so in practice you only need to make sure the control image you pass at inference time matches the requested `--image_size`.
 * **`T=1` only.** Video-style multi-frame inputs are not supported — the wrapper asserts `T==1` at forward time.
 * **Bucket size.** The training script enforces a bucket resolution step of 16 (Qwen-Image VAE /8 × patch /2).
 * **Memory.** `--blocks_to_swap`, `--cpu_offload_checkpointing`, `--unsloth_offload_checkpointing` are not yet supported. If VRAM is tight, prefer `--full_bf16`, smaller `--lllite_mlp_dim`, lower `--cond_emb_dim`, and `--gradient_checkpointing`.
@@ -628,7 +768,7 @@ python anima_minimal_inference_control_net_lllite.py \
 <details>
 <summary>日本語</summary>
 
-* **解像度の整合性.** `conditioning1` の stride は 16 固定なので、`cond_image` の縦横は `latent HW × 8`（つまり元の学習画像サイズ）に一致している必要があります（latent はモデル内で patch size=2 で patchfy されるため、stride は 8*2=16 となる）。ControlNet 形式のデータローダ側で conditioning 画像は教師画像と同じサイズにリサイズされるため、実用上は推論時に渡す control 画像のサイズを `--image_size` と合わせれば OK です。
+* **解像度の整合性.** `conditioning1` の stride は 16 固定なので、`cond_image` の縦横は `latent HW × 8`（つまり元の学習画像サイズ）に一致している必要があります（latent はモデル内で patch size=2 で patchfy されるため、stride は 8*2=16 となる）。latent モード（第 8 節）でも制御画像は元画像サイズのまま渡します（VAE の /8 と stem の stride-2 conv で合計 stride は同じく 16）。ControlNet 形式のデータローダ側で conditioning 画像は教師画像と同じサイズにリサイズされるため、実用上は推論時に渡す control 画像のサイズを `--image_size` と合わせれば OK です。
 * **`T=1` のみ.** 動画的な多フレーム入力はサポートしていません（wrapper の forward 冒頭で assert）。
 * **bucket サイズ.** 学習スクリプトは bucket 解像度ステップを 16（Qwen-Image VAE /8 × patch /2）として検証します。
 * **メモリ.** `--blocks_to_swap`、`--cpu_offload_checkpointing`、`--unsloth_offload_checkpointing` は未対応です。VRAM が厳しい場合は `--full_bf16`、`--lllite_mlp_dim` を下げる、`--cond_emb_dim` を下げる、`--gradient_checkpointing` を有効にする、などで対応してください。

--- a/networks/control_net_lllite_anima.py
+++ b/networks/control_net_lllite_anima.py
@@ -23,6 +23,12 @@ LLM_ADAPTER_NAME = "llm_adapter"
 # state_dict メタデータに記録するアーキテクチャ世代
 LLLITE_ARCH_VERSION = "2"
 
+# cond 画像の入力空間 (v2.1 で追加。メタデータ欠落時は "pixel" = 旧重み互換)
+COND_INPUT_SPACES: Tuple[str, ...] = ("pixel", "latent")
+
+# latent モードで conditioning1 が受け取る VAE latent のチャネル数 (Qwen-Image VAE z_dim)
+LATENT_COND_CHANNELS = 16
+
 
 # ----------------------------------------------------------------------------
 # target_layers: atomic specifiers と preset
@@ -144,16 +150,30 @@ class _ASPP(nn.Module):
 class _Conditioning1(nn.Module):
     """v2 conditioning trunk.
 
-    in (B,C_in,H,W)
+    input_space="pixel" (v2, 既定):
+      in (B,C_in,H,W)                     # 元解像度の cond 画像
       -> Conv 4x4 s=4    + GN + SiLU      # cond_dim/2,  H/4
       -> Conv 3x3 s=1    + GN + SiLU      # cond_dim/2,  H/4   (受容野拡張)
       -> Conv 4x4 s=4    + GN + SiLU      # cond_dim,    H/16  (token 解像度)
-      -> ResBlock x N                     # cond_dim,    H/16
+
+    input_space="latent" (v2.1):
+      in (B,16,h,w)                       # VAE encode 済みの正規化 latent, h=H/8
+      [inpaint 時] mask (B,1,H,W) {-1,1}
+        -> Conv 2x2 s=2 + SiLU            # 4,  H/2
+        -> Conv 3x3 s=2 + SiLU            # 8,  H/4
+        -> Conv 3x3 s=2 (linear)          # 16, h        を latent と concat -> (B,32,h,w)
+      -> Conv 3x3 s=1 p=1 + GN + SiLU     # cond_dim,    h      (latent 解像度で局所混合)
+      -> Conv 2x2 s=2     + GN + SiLU     # cond_dim,    h/2    (= token 解像度, DiT patchify /2 と整合)
+
+    以降は両モード共通:
+      -> ResBlock x N                     # cond_dim
+      -> (ASPP)
       -> Conv 1x1                         # cond_emb_dim
       -> flatten (B, S, cond_emb_dim)
       -> LayerNorm
 
-    C_in は cond_in_channels で指定する。デフォルト 3 (RGB のみ)、4 で inpainting (RGB+mask) 等。
+    cond_in_channels は常に **pixel 意味論** で指定する。デフォルト 3 (RGB のみ)、4 で
+    inpainting (RGB+mask) 等。latent モードでの stem 実入力チャネル数 (16 / 32) は内部で導出する。
     """
 
     def __init__(
@@ -164,19 +184,50 @@ class _Conditioning1(nn.Module):
         use_aspp: bool = False,
         aspp_dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS,
         cond_in_channels: int = 3,
+        input_space: str = "pixel",
     ):
         super().__init__()
         assert cond_dim % 2 == 0, f"cond_dim must be even, got {cond_dim}"
         assert cond_in_channels >= 1, f"cond_in_channels must be >= 1, got {cond_in_channels}"
+        assert input_space in COND_INPUT_SPACES, (
+            f"input_space must be one of {list(COND_INPUT_SPACES)}, got {input_space!r}"
+        )
         ch_half = cond_dim // 2
 
+        if input_space == "latent":
+            # latent モードの cond_in_channels は pixel 意味論のまま (3=RGB, 4=RGB+mask)。
+            # 実際の stem 入力チャネルは 16 (RGB のみ) / 32 (mask pyramid 併用) になる。
+            assert cond_in_channels in (3, 4), (
+                f"latent input space supports cond_in_channels 3 or 4, got {cond_in_channels}"
+            )
+
         self.cond_in_channels = cond_in_channels
-        self.conv1 = nn.Conv2d(cond_in_channels, ch_half, kernel_size=4, stride=4, padding=0)
-        self.norm1 = _gn(ch_half)
-        self.conv2 = nn.Conv2d(ch_half, ch_half, kernel_size=3, stride=1, padding=1)
-        self.norm2 = _gn(ch_half)
-        self.conv3 = nn.Conv2d(ch_half, cond_dim, kernel_size=4, stride=4, padding=0)
-        self.norm3 = _gn(cond_dim)
+        self.input_space = input_space
+        # latent モードの inpainting でのみ mask 用の conv pyramid を持つ
+        # (pixel モードでは mask は cond_image の 4ch 目として conv1 に直接入る)
+        self.use_mask_branch = input_space == "latent" and cond_in_channels == 4
+
+        if input_space == "pixel":
+            self.conv1 = nn.Conv2d(cond_in_channels, ch_half, kernel_size=4, stride=4, padding=0)
+            self.norm1 = _gn(ch_half)
+            self.conv2 = nn.Conv2d(ch_half, ch_half, kernel_size=3, stride=1, padding=1)
+            self.norm2 = _gn(ch_half)
+            self.conv3 = nn.Conv2d(ch_half, cond_dim, kernel_size=4, stride=4, padding=0)
+            self.norm3 = _gn(cond_dim)
+        else:
+            if self.use_mask_branch:
+                # mask (B,1,H,W) {-1,1} -> (B,16,h,w). 各段が 2x2 / 4x4 / 8x8 スケールを分担する。
+                # 段間は SiLU のみ (GN は一様な mask 領域で「マスク面積・絶対レベル」の情報を
+                # 消してしまうため置かない)、最終段は既存 proj と同じく linear。
+                self.mask_conv1 = nn.Conv2d(1, 4, kernel_size=2, stride=2, padding=0)
+                self.mask_conv2 = nn.Conv2d(4, 8, kernel_size=3, stride=2, padding=1)
+                self.mask_conv3 = nn.Conv2d(8, LATENT_COND_CHANNELS, kernel_size=3, stride=2, padding=1)
+
+            stem_in = LATENT_COND_CHANNELS * (2 if self.use_mask_branch else 1)
+            self.lat_conv1 = nn.Conv2d(stem_in, cond_dim, kernel_size=3, stride=1, padding=1)
+            self.lat_norm1 = _gn(cond_dim)
+            self.lat_conv2 = nn.Conv2d(cond_dim, cond_dim, kernel_size=2, stride=2, padding=0)
+            self.lat_norm2 = _gn(cond_dim)
 
         self.resblocks = nn.ModuleList([_ResBlock(cond_dim) for _ in range(n_resblocks)])
 
@@ -186,10 +237,33 @@ class _Conditioning1(nn.Module):
         self.proj = nn.Conv2d(cond_dim, cond_emb_dim, kernel_size=1)
         self.out_norm = nn.LayerNorm(cond_emb_dim)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        h = F.silu(self.norm1(self.conv1(x)))
-        h = F.silu(self.norm2(self.conv2(h)))
-        h = F.silu(self.norm3(self.conv3(h)))
+    def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        if self.input_space == "pixel":
+            assert mask is None, (
+                "pixel input space does not take a separate mask tensor "
+                "(the mask is packed into cond_image as the 4th channel)"
+            )
+            h = F.silu(self.norm1(self.conv1(x)))
+            h = F.silu(self.norm2(self.conv2(h)))
+            h = F.silu(self.norm3(self.conv3(h)))
+        else:
+            if self.use_mask_branch:
+                assert mask is not None, "latent inpainting mode requires a mask tensor"
+                m = F.silu(self.mask_conv1(mask))
+                m = F.silu(self.mask_conv2(m))
+                m = self.mask_conv3(m)  # (B, 16, H/8, W/8)
+                assert m.shape[-2:] == x.shape[-2:], (
+                    f"mask pyramid output {tuple(m.shape[-2:])} does not match cond latent "
+                    f"{tuple(x.shape[-2:])} (mask HW must be cond latent HW * 8)"
+                )
+                x = torch.cat([x, m], dim=1)  # (B, 32, h, w)
+            else:
+                assert mask is None, (
+                    "mask tensor given but this LLLite is not in inpainting mode "
+                    "(cond_in_channels must be 4)"
+                )
+            h = F.silu(self.lat_norm1(self.lat_conv1(x)))
+            h = F.silu(self.lat_norm2(self.lat_conv2(h)))
         for rb in self.resblocks:
             h = rb(h)
         if self.aspp is not None:
@@ -326,10 +400,14 @@ class ControlNetLLLiteDiT(nn.Module):
         aspp_dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS,
         cond_in_channels: int = 3,
         inpaint_masked_input: bool = False,
+        cond_input_space: str = "pixel",
     ):
         super().__init__()
 
         atomics = parse_target_layers(target_layers)
+        assert cond_input_space in COND_INPUT_SPACES, (
+            f"cond_input_space must be one of {list(COND_INPUT_SPACES)}, got {cond_input_space!r}"
+        )
 
         self.cond_emb_dim = cond_emb_dim
         self.mlp_dim = mlp_dim
@@ -345,12 +423,17 @@ class ControlNetLLLiteDiT(nn.Module):
         # 記録するためのフラグで、モデル forward の挙動には影響しない (メタデータ復元用)。
         self.cond_in_channels = cond_in_channels
         self.inpaint_masked_input = inpaint_masked_input
+        # "pixel": cond image をそのまま stem に通す (v2)
+        # "latent": VAE encode 済み latent を stem に通す (v2.1)。inpaint の mask は別テンソル
+        self.cond_input_space = cond_input_space
 
-        # cond image (B, cond_in_channels, H*16, W*16) -> (B, S, cond_emb_dim)
+        # pixel : cond image  (B, cond_in_channels, H*16, W*16) -> (B, S, cond_emb_dim)
+        # latent: cond latent (B, 16, H*2, W*2) (+ mask (B,1,H*16,W*16)) -> (B, S, cond_emb_dim)
         self.conditioning1 = _Conditioning1(
             cond_dim, cond_emb_dim, cond_resblocks,
             use_aspp=use_aspp, aspp_dilations=aspp_dilations,
             cond_in_channels=cond_in_channels,
+            input_space=cond_input_space,
         )
 
         modules = self._create_modules(dit, cond_emb_dim, mlp_dim, atomics, dropout, multiplier)
@@ -369,6 +452,7 @@ class ControlNetLLLiteDiT(nn.Module):
         logger.info(
             f"ControlNet-LLLite (Anima v{LLLITE_ARCH_VERSION}): created {n} modules for "
             f"target={target_layers!r} (atomics={list(atomics)}), "
+            f"cond_input={cond_input_space}, "
             f"cond_in_channels={cond_in_channels}, cond_dim={cond_dim}, cond_resblocks={cond_resblocks}, {aspp_info}, "
             f"cond_emb_dim={cond_emb_dim}, mlp_dim={mlp_dim}{inpaint_info}"
         )
@@ -440,14 +524,19 @@ class ControlNetLLLiteDiT(nn.Module):
 
         return modules
 
-    def set_cond_image(self, cond_image: Optional[torch.Tensor]):
-        """cond_image: (B, 3, H*16, W*16). None で解除."""
+    def set_cond_image(self, cond_image: Optional[torch.Tensor], cond_mask: Optional[torch.Tensor] = None):
+        """cond_image を conditioning1 に通し、全 LLLite モジュールに cond_emb を配る。None で解除。
+
+        pixel モード : cond_image = (B, cond_in_channels, H*16, W*16)、cond_mask は不可
+        latent モード: cond_image = (B, 16, H*2, W*2) の正規化済み VAE latent、
+                       inpaint (cond_in_channels=4) のとき cond_mask = (B, 1, H*16, W*16) in [-1, 1]
+        """
         if cond_image is None:
             for m in self.lllite_modules:
                 m.cond_emb = None
                 m.depth_emb = None
             return
-        cx = self.conditioning1(cond_image)  # (B, S, cond_emb_dim)
+        cx = self.conditioning1(cond_image, cond_mask)  # (B, S, cond_emb_dim)
         for m in self.lllite_modules:
             # 共有の cx を全モジュールに同一テンソルとして持たせ (N コピーを避ける)、
             # depth embedding はこのモジュール用の (cond_emb_dim,) スライスだけを渡す。
@@ -489,28 +578,125 @@ class AnimaControlNetLLLiteWrapper(nn.Module):
         timesteps: torch.Tensor,
         context: torch.Tensor,
         cond_image: Optional[torch.Tensor] = None,
+        cond_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         # T=1 固定
         assert x.shape[2] == 1, f"Anima LLLite supports T=1 only, got T={x.shape[2]}"
         if cond_image is not None:
-            # 解像度整合チェック: x は VAE latent (/8)、cond_image は元画像 (/1)。
-            # patchify (/2) は DiT 内部 (prepare_embedded_sequence) で実施されるため、
-            # ここでは latent HW * 8 == cond_image HW を期待する。
-            # conditioning1 (stride 16) は cond_image を /16 = latent/2 = token 空間に揃える。
-            expected_h = x.shape[-2] * 8
-            expected_w = x.shape[-1] * 8
-            assert cond_image.shape[-2] == expected_h and cond_image.shape[-1] == expected_w, (
-                f"cond_image HW mismatch: latent={x.shape[-2]}x{x.shape[-1]} -> expected "
-                f"{expected_h}x{expected_w}, got {cond_image.shape[-2]}x{cond_image.shape[-1]}"
-            )
-            expected_c = self.lllite.cond_in_channels
-            assert cond_image.shape[1] == expected_c, (
-                f"cond_image channel mismatch: expected {expected_c} (cond_in_channels), "
-                f"got {cond_image.shape[1]}"
-            )
-            self.lllite.set_cond_image(cond_image)
+            latent_h, latent_w = x.shape[-2], x.shape[-1]
+            if self.lllite.cond_input_space == "pixel":
+                # 解像度整合チェック: x は VAE latent (/8)、cond_image は元画像 (/1)。
+                # patchify (/2) は DiT 内部 (prepare_embedded_sequence) で実施されるため、
+                # ここでは latent HW * 8 == cond_image HW を期待する。
+                # conditioning1 (stride 16) は cond_image を /16 = latent/2 = token 空間に揃える。
+                expected_h = latent_h * 8
+                expected_w = latent_w * 8
+                assert cond_image.shape[-2] == expected_h and cond_image.shape[-1] == expected_w, (
+                    f"cond_image HW mismatch: latent={latent_h}x{latent_w} -> expected "
+                    f"{expected_h}x{expected_w}, got {cond_image.shape[-2]}x{cond_image.shape[-1]}"
+                )
+                expected_c = self.lllite.cond_in_channels
+                assert cond_image.shape[1] == expected_c, (
+                    f"cond_image channel mismatch: expected {expected_c} (cond_in_channels), "
+                    f"got {cond_image.shape[1]}"
+                )
+                assert cond_mask is None, (
+                    "cond_mask is only used with cond_input_space='latent'; in pixel mode the mask "
+                    "must be packed into cond_image as the 4th channel"
+                )
+            else:
+                # latent モード: cond_image は VAE encode 済み latent なので x と同一解像度
+                assert cond_image.shape[-2] == latent_h and cond_image.shape[-1] == latent_w, (
+                    f"cond latent HW mismatch: expected {latent_h}x{latent_w} (same as x), "
+                    f"got {cond_image.shape[-2]}x{cond_image.shape[-1]}"
+                )
+                assert cond_image.shape[1] == LATENT_COND_CHANNELS, (
+                    f"cond latent channel mismatch: expected {LATENT_COND_CHANNELS}, "
+                    f"got {cond_image.shape[1]}"
+                )
+                if self.lllite.cond_in_channels == 4:
+                    assert cond_mask is not None, (
+                        "cond_mask is required for inpainting (cond_in_channels=4) in latent mode"
+                    )
+                    expected_h = latent_h * 8
+                    expected_w = latent_w * 8
+                    assert cond_mask.shape[1] == 1 and (
+                        cond_mask.shape[-2] == expected_h and cond_mask.shape[-1] == expected_w
+                    ), (
+                        f"cond_mask shape mismatch: expected (B,1,{expected_h},{expected_w}), "
+                        f"got {tuple(cond_mask.shape)}"
+                    )
+                else:
+                    assert cond_mask is None, (
+                        f"cond_mask given but cond_in_channels={self.lllite.cond_in_channels} "
+                        "(mask is only used in inpainting mode)"
+                    )
+            self.lllite.set_cond_image(cond_image, cond_mask)
         return self.dit(x, timesteps, context, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# cond tensor 組み立て (学習ループ / sample hook / 推論スクリプトで共有)
+# ---------------------------------------------------------------------------
+
+
+def build_cond_tensors(
+    rgb: torch.Tensor,
+    mask: Optional[torch.Tensor] = None,
+    *,
+    cond_input_space: str = "pixel",
+    cond_in_channels: int = 3,
+    inpaint_masked_input: bool = False,
+    vae=None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """cond 画像 (と inpaint mask) から wrapper / set_cond_image に渡す組を作る。
+
+    Args:
+        rgb: (B, 3, H, W), [-1, 1] 正規化済み
+        mask: (B, 1, H, W) in {0, 1} (1=inpaint 域)。cond_in_channels=4 のとき必須
+        cond_input_space: "pixel" (v2) or "latent" (v2.1)
+        cond_in_channels: pixel 意味論のチャネル数 (3=RGB, 4=RGB+mask)
+        inpaint_masked_input: True なら mask 域の RGB を 0 に潰してから使う
+        vae: latent モードで必須。encode_pixels_to_latents を持つ Qwen-Image VAE
+
+    Returns:
+        (cond_image, cond_mask)
+          pixel : cond_image=(B,3 or 4,H,W)、cond_mask=None
+          latent: cond_image=(B,16,H/8,W/8) の正規化済み latent、
+                  cond_mask=(B,1,H,W) in [-1,1] (inpaint 時のみ、それ以外は None)
+
+    mask のチャネル正規化 ({0,1} -> {-1,1}) はここで行う。両モードで規約を揃えるため、
+    latent モードでも mask は pixel 解像度のまま返す (conditioning1 内の pyramid が /8 に落とす)。
+    """
+    assert cond_input_space in COND_INPUT_SPACES, (
+        f"cond_input_space must be one of {list(COND_INPUT_SPACES)}, got {cond_input_space!r}"
+    )
+    is_inpaint = cond_in_channels == 4
+    if is_inpaint:
+        assert mask is not None, "mask is required when cond_in_channels=4 (inpainting)"
+    if mask is not None and not is_inpaint:
+        raise ValueError(f"mask given but cond_in_channels={cond_in_channels} (expected 4)")
+
+    if is_inpaint and inpaint_masked_input:
+        keep = (mask < 0.5).to(rgb.dtype)  # (B, 1, H, W)
+        rgb = rgb * keep
+
+    # mask channel: {0, 1} -> {-1, 1} (= (mask - 0.5) * 2). matches transforms.Normalize([0.5], [0.5])
+    mask_pm1 = (mask.to(rgb.dtype) * 2.0 - 1.0) if is_inpaint else None
+
+    if cond_input_space == "pixel":
+        cond_image = torch.cat([rgb, mask_pm1], dim=1) if is_inpaint else rgb
+        return cond_image, None
+
+    assert vae is not None, "vae is required for cond_input_space='latent'"
+    with torch.no_grad():
+        # VAE は fp32/bf16 の自前 dtype で動かす。autocast (特に fp16) 下では conv が fp16 に
+        # 落ちて NaN になりうるため明示的に無効化する。
+        with torch.autocast(device_type=rgb.device.type, enabled=False):
+            cond_latent = vae.encode_pixels_to_latents(rgb.to(device=vae.device, dtype=vae.dtype))
+    cond_latent = cond_latent.to(device=rgb.device, dtype=rgb.dtype)
+    return cond_latent, mask_pm1
 
 
 # ---------------------------------------------------------------------------
@@ -640,6 +826,21 @@ def load_lllite_weights(lllite: ControlNetLLLiteDiT, file: str, strict: bool = F
             f"(keys starting with '{_INTERNAL_MODULES_PREFIX}'). The current code uses a "
             f"named-key format (per-module key prefix = lllite_name, e.g. "
             f"'lllite_dit_blocks_0_self_attn_q_proj.down.weight'). Re-train with the current codebase."
+        )
+
+    # pixel / latent の取り違え検出。stem のキー名が分離しているため、strict=False で
+    # 黙って初期値のまま学習/推論が進むのを防ぐ (missing/unexpected は無視されてしまうため)。
+    file_space = None
+    if any(k.startswith(_SAVED_COND_PREFIX + "lat_conv1.") for k in weights_sd):
+        file_space = "latent"
+    elif any(k.startswith(_SAVED_COND_PREFIX + "conv1.") for k in weights_sd):
+        file_space = "pixel"
+    if file_space is not None and file_space != lllite.cond_input_space:
+        raise RuntimeError(
+            f"cond input space mismatch: weights at {file} were trained with "
+            f"cond_input_space='{file_space}', but this LLLite was built with "
+            f"cond_input_space='{lllite.cond_input_space}'. "
+            f"Check --lllite_cond_input / the 'lllite.cond_input_space' metadata."
         )
 
     converted = _from_saved_state_dict(lllite, weights_sd)
@@ -828,6 +1029,147 @@ if __name__ == "__main__":
         if "channel mismatch" not in msg and "expected 4" not in msg:
             raise
     logger.info("  4ch (inpainting) build / forward / channel assert OK")
+
+    # ------------------------------------------------------------------
+    # v2.1: latent cond input space
+    # ------------------------------------------------------------------
+    H_l, W_l = 8, 8                       # token grid
+    LAT_H, LAT_W = H_l * 2, W_l * 2       # VAE latent 解像度 (= token * 2)
+    IMG_H, IMG_W = H_l * 16, W_l * 16     # 元画像解像度 (= latent * 8)
+
+    # 3ch 相当 (RGB のみ) の latent モード
+    dit_lat = _DummyDiT(num_blocks=2, dim=64, ctx_dim=128)
+    lllite_lat = ControlNetLLLiteDiT(
+        dit_lat, cond_emb_dim=32, mlp_dim=64, target_layers="self_attn_q",
+        cond_dim=64, cond_resblocks=1, cond_input_space="latent",
+    )
+    assert lllite_lat.cond_input_space == "latent"
+    assert lllite_lat.conditioning1.lat_conv1.in_channels == LATENT_COND_CHANNELS
+    keys_lat = list(lllite_lat.state_dict().keys())
+    assert not any(k.startswith("conditioning1.conv1.") for k in keys_lat), keys_lat[:8]
+    assert not any("mask_conv" in k for k in keys_lat), keys_lat[:8]
+    assert any(k.startswith("conditioning1.lat_conv1.") for k in keys_lat), keys_lat[:8]
+    lllite_lat.apply_to()
+    wrapper_lat = AnimaControlNetLLLiteWrapper(dit_lat, lllite_lat)
+    cond_lat = torch.randn(1, LATENT_COND_CHANNELS, LAT_H, LAT_W)
+    wrapper_lat.lllite.set_cond_image(cond_lat)
+    cx_lat = wrapper_lat.lllite.lllite_modules[0].cond_emb
+    assert cx_lat is not None and cx_lat.shape == (1, H_l * W_l, 32), f"latent cond_emb shape: {cx_lat.shape}"
+    mod_lat = wrapper_lat.lllite.lllite_modules[0]
+    x_lat_seq = torch.randn(1, H_l * W_l, mod_lat.org_module[0].in_features)
+    assert torch.allclose(mod_lat(x_lat_seq), mod_lat.org_forward(x_lat_seq)), "latent zero-init forward mismatch"
+    logger.info("  latent 3ch build / set_cond_image / zero-init forward OK")
+
+    # 4ch 相当 (RGB+mask) の latent モード: mask pyramid が生える
+    dit_lat4 = _DummyDiT(num_blocks=2, dim=64, ctx_dim=128)
+    lllite_lat4 = ControlNetLLLiteDiT(
+        dit_lat4, cond_emb_dim=32, mlp_dim=64, target_layers="self_attn_q",
+        cond_dim=64, cond_resblocks=1, cond_in_channels=4, inpaint_masked_input=True,
+        cond_input_space="latent",
+    )
+    assert lllite_lat4.conditioning1.use_mask_branch is True
+    assert lllite_lat4.conditioning1.lat_conv1.in_channels == LATENT_COND_CHANNELS * 2
+    keys_lat4 = list(lllite_lat4.state_dict().keys())
+    for k in ("conditioning1.mask_conv1.weight", "conditioning1.mask_conv2.weight", "conditioning1.mask_conv3.weight"):
+        assert k in keys_lat4, f"missing {k}"
+    assert not any("mask_norm" in k for k in keys_lat4), "mask pyramid should not have norms"
+    lllite_lat4.apply_to()
+    wrapper_lat4 = AnimaControlNetLLLiteWrapper(dit_lat4, lllite_lat4)
+    cond_lat4 = torch.randn(1, LATENT_COND_CHANNELS, LAT_H, LAT_W)
+    mask_pm1 = torch.randint(0, 2, (1, 1, IMG_H, IMG_W)).float() * 2.0 - 1.0
+    wrapper_lat4.lllite.set_cond_image(cond_lat4, mask_pm1)
+    cx_lat4 = wrapper_lat4.lllite.lllite_modules[0].cond_emb
+    assert cx_lat4 is not None and cx_lat4.shape == (1, H_l * W_l, 32), f"latent 4ch cond_emb shape: {cx_lat4.shape}"
+
+    # wrapper の shape assert: latent モードで pixel 解像度の cond を渡すと落ちる / mask 必須
+    x_lat5d = torch.randn(1, 16, 1, LAT_H, LAT_W)
+    try:
+        wrapper_lat4(x_lat5d, torch.zeros(1), torch.zeros(1, 1, 1), cond_image=torch.randn(1, 3, IMG_H, IMG_W))
+        raise AssertionError("expected latent cond HW/channel assert")
+    except AssertionError as e:
+        assert "cond latent" in str(e), str(e)
+    try:
+        wrapper_lat4(x_lat5d, torch.zeros(1), torch.zeros(1, 1, 1), cond_image=cond_lat4)
+        raise AssertionError("expected missing cond_mask assert")
+    except AssertionError as e:
+        assert "cond_mask is required" in str(e), str(e)
+    # 3ch latent モードに mask を渡すと拒否される
+    try:
+        wrapper_lat(x_lat5d, torch.zeros(1), torch.zeros(1, 1, 1), cond_image=cond_lat, cond_mask=mask_pm1)
+        raise AssertionError("expected unexpected cond_mask assert")
+    except AssertionError as e:
+        assert "cond_mask given" in str(e), str(e)
+    logger.info("  latent 4ch (mask pyramid) build / forward / wrapper asserts OK")
+
+    # build_cond_tensors: pixel / latent 両モード
+    rgb_t = torch.randn(2, 3, IMG_H, IMG_W).clamp(-1, 1)
+    mask_t = (torch.rand(2, 1, IMG_H, IMG_W) > 0.5).float()
+
+    ci_p, cm_p = build_cond_tensors(rgb_t, None, cond_input_space="pixel", cond_in_channels=3)
+    assert ci_p.shape == rgb_t.shape and cm_p is None
+    ci_p4, cm_p4 = build_cond_tensors(
+        rgb_t, mask_t, cond_input_space="pixel", cond_in_channels=4, inpaint_masked_input=True
+    )
+    assert ci_p4.shape == (2, 4, IMG_H, IMG_W) and cm_p4 is None
+    assert torch.allclose(ci_p4[:, 3:], mask_t * 2 - 1), "pixel mask channel must be in {-1,1}"
+    assert (ci_p4[:, :3][mask_t.expand(-1, 3, -1, -1) >= 0.5] == 0).all(), "masked_input should zero RGB"
+
+    class _FakeVae:
+        """encode_pixels_to_latents だけを持つ最小のスタブ (/8 に落として 16ch にする)."""
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        def encode_pixels_to_latents(self, pixels: torch.Tensor) -> torch.Tensor:
+            pooled = F.avg_pool2d(pixels, 8)  # (B, 3, H/8, W/8)
+            return pooled.repeat(1, 6, 1, 1)[:, :LATENT_COND_CHANNELS]
+
+    ci_l, cm_l = build_cond_tensors(
+        rgb_t, mask_t, cond_input_space="latent", cond_in_channels=4,
+        inpaint_masked_input=False, vae=_FakeVae(),
+    )
+    assert ci_l.shape == (2, LATENT_COND_CHANNELS, IMG_H // 8, IMG_W // 8), ci_l.shape
+    assert cm_l is not None and cm_l.shape == (2, 1, IMG_H, IMG_W)
+    assert cm_l.abs().eq(1.0).all(), "latent-mode mask must be in {-1,1} at pixel resolution"
+    logger.info("  build_cond_tensors (pixel / latent) OK")
+
+    # latent モードの save/load round-trip と pixel/latent 取り違え検出
+    import tempfile
+
+    tmp_lat = tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False).name
+    try:
+        save_lllite_model(tmp_lat, lllite_lat4, dtype=torch.float32, metadata={
+            "lllite.version": LLLITE_ARCH_VERSION,
+            "lllite.cond_input_space": "latent",
+        })
+        dit_lat4_b = _DummyDiT(num_blocks=2, dim=64, ctx_dim=128)
+        lllite_lat4_b = ControlNetLLLiteDiT(
+            dit_lat4_b, cond_emb_dim=32, mlp_dim=64, target_layers="self_attn_q",
+            cond_dim=64, cond_resblocks=1, cond_in_channels=4, inpaint_masked_input=True,
+            cond_input_space="latent",
+        )
+        load_lllite_weights(lllite_lat4_b, tmp_lat, strict=True)
+        sd_la = lllite_lat4.state_dict()
+        sd_lb = lllite_lat4_b.state_dict()
+        assert set(sd_la.keys()) == set(sd_lb.keys())
+        for k in sd_la:
+            assert torch.allclose(sd_la[k].float(), sd_lb[k].float()), f"latent round-trip mismatch at {k}"
+        logger.info("  latent save / load round-trip OK")
+
+        # latent 重みを pixel モデルに読ませると明示エラー
+        dit_px = _DummyDiT(num_blocks=2, dim=64, ctx_dim=128)
+        lllite_px = ControlNetLLLiteDiT(
+            dit_px, cond_emb_dim=32, mlp_dim=64, target_layers="self_attn_q",
+            cond_dim=64, cond_resblocks=1, cond_in_channels=4, cond_input_space="pixel",
+        )
+        try:
+            load_lllite_weights(lllite_px, tmp_lat, strict=False)
+            raise AssertionError("expected cond input space mismatch error")
+        except RuntimeError as e:
+            assert "cond input space mismatch" in str(e), str(e)
+        logger.info("  pixel/latent weight mix-up detection OK")
+    finally:
+        if os.path.exists(tmp_lat):
+            os.unlink(tmp_lat)
 
     # 非デフォルト dilations
     lllite_dil = ControlNetLLLiteDiT(

--- a/tools/dev/manual_test_anima_lllite_dryrun.py
+++ b/tools/dev/manual_test_anima_lllite_dryrun.py
@@ -7,9 +7,11 @@ Verifies, end-to-end on CPU:
   4. wrapper.forward propagates cond and reaches each patched Linear
   5. backward gives grads to LLLite params, but not to DiT params
   6. save_lllite_model -> reload into a fresh LLLite -> state_dicts match
+  7. cond_input_space="latent" (v2.1): latent stem / mask pyramid build, forward, grads,
+     save-load round-trip and pixel<->latent weight mix-up detection
 
 Run:
-    python tests/manual_test_anima_lllite_dryrun.py
+    python tools/dev/manual_test_anima_lllite_dryrun.py
 """
 
 import os
@@ -20,13 +22,15 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-# repo root on sys.path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# repo root on sys.path (this file lives in tools/dev/)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from library.anima_models import Attention  # real Anima Attention
 from networks.control_net_lllite_anima import (
+    LATENT_COND_CHANNELS,
     ControlNetLLLiteDiT,
     AnimaControlNetLLLiteWrapper,
+    build_cond_tensors,
     save_lllite_model,
     load_lllite_weights,
 )
@@ -240,7 +244,153 @@ def main():
         assert _state_dicts_equal(sd_orig, sd_after)
         print("[9] load round-trip OK (state_dicts match exactly)")
 
+    check_latent_cond()
+
     print("\nAll dry-run checks PASSED.")
+
+
+class _StubVae:
+    """Minimal stand-in for the Qwen-Image VAE: /8 downsample into LATENT_COND_CHANNELS."""
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    def encode_pixels_to_latents(self, pixels: torch.Tensor) -> torch.Tensor:
+        pooled = F.avg_pool2d(pixels, 8)  # (B, 3, H/8, W/8)
+        return pooled.repeat(1, 6, 1, 1)[:, :LATENT_COND_CHANNELS]
+
+
+def check_latent_cond():
+    """v2.1: cond_input_space='latent' の構築 / forward / backward / round-trip / 取り違え検出."""
+    torch.manual_seed(1)
+
+    num_blocks = 2
+    query_dim = 64
+    context_dim = 96
+    target_layers = "self_attn_q_pre"
+
+    B = 2
+    lat_H, lat_W = 8, 8                      # VAE latent 解像度 (= x の HW)
+    img_H, img_W = lat_H * 8, lat_W * 8      # 元画像解像度
+    S_ctx = 5
+
+    x = torch.randn(B, query_dim, 1, lat_H, lat_W)
+    t = torch.zeros(B)
+    ctx = torch.randn(B, S_ctx, context_dim)
+    rgb = torch.randn(B, 3, img_H, img_W).clamp(-1, 1)
+    mask = (torch.rand(B, 1, img_H, img_W) > 0.5).float()
+    vae = _StubVae()
+
+    for cond_in_channels in (3, 4):
+        dit = _StubDiT(num_blocks=num_blocks, query_dim=query_dim, context_dim=context_dim)
+        dit.requires_grad_(False)
+        lllite = ControlNetLLLiteDiT(
+            dit,
+            cond_emb_dim=32,
+            mlp_dim=64,
+            target_layers=target_layers,
+            cond_in_channels=cond_in_channels,
+            inpaint_masked_input=(cond_in_channels == 4),
+            cond_input_space="latent",
+        )
+        lllite.apply_to()
+        wrapper = AnimaControlNetLLLiteWrapper(dit, lllite)
+
+        cond_image, cond_mask = build_cond_tensors(
+            rgb,
+            mask if cond_in_channels == 4 else None,
+            cond_input_space="latent",
+            cond_in_channels=cond_in_channels,
+            inpaint_masked_input=(cond_in_channels == 4),
+            vae=vae,
+        )
+        assert cond_image.shape == (B, LATENT_COND_CHANNELS, lat_H, lat_W), cond_image.shape
+        if cond_in_channels == 4:
+            assert cond_mask is not None and cond_mask.shape == (B, 1, img_H, img_W)
+        else:
+            assert cond_mask is None
+
+        # zero-init: cond ありでも cond なしと一致する
+        out_no_cond = wrapper(x, t, ctx)
+        out_zero_init = wrapper(x, t, ctx, cond_image=cond_image, cond_mask=cond_mask)
+        assert torch.allclose(out_no_cond, out_zero_init, atol=1e-6), (
+            f"latent (cin={cond_in_channels}) zero-init mismatch"
+        )
+
+        # perturb して cond が出力を動かすことを確認
+        with torch.no_grad():
+            for m in lllite.lllite_modules:
+                m.up.weight.normal_(0, 0.01)
+        out_perturbed = wrapper(x, t, ctx, cond_image=cond_image, cond_mask=cond_mask)
+        assert not torch.allclose(out_no_cond, out_perturbed, atol=1e-6), (
+            f"latent (cin={cond_in_channels}) cond path did not move the output"
+        )
+
+        # backward: latent stem (と mask pyramid) に勾配が流れる
+        lllite.train()
+        wrapper(x, t, ctx, cond_image=cond_image, cond_mask=cond_mask).float().pow(2).mean().backward()
+        stem_grads = {
+            n: p.grad for n, p in lllite.named_parameters()
+            if n.startswith("conditioning1.lat_") or n.startswith("conditioning1.mask_")
+        }
+        assert stem_grads, "no latent stem params found"
+        for n, g in stem_grads.items():
+            assert g is not None and g.abs().sum().item() > 0, f"no grad on {n}"
+        if cond_in_channels == 4:
+            assert any(n.startswith("conditioning1.mask_conv") for n in stem_grads), (
+                "mask pyramid params missing in inpaint mode"
+            )
+        assert not any(
+            p.grad is not None and p.grad.abs().sum().item() > 0 for p in dit.parameters()
+        ), "DiT params should not receive grad"
+
+        print(
+            f"[L1] latent cond_in_channels={cond_in_channels}: build / zero-init / cond effect / "
+            f"grads OK ({len(stem_grads)} stem params)"
+        )
+
+        # save / load round-trip
+        with tempfile.TemporaryDirectory() as tmp:
+            ckpt = os.path.join(tmp, "lllite_latent.safetensors")
+            save_lllite_model(ckpt, lllite, dtype=torch.float32, metadata={
+                "lllite.cond_input_space": "latent",
+                "lllite.cond_in_channels": str(cond_in_channels),
+            })
+            dit_b = _StubDiT(num_blocks=num_blocks, query_dim=query_dim, context_dim=context_dim)
+            lllite_b = ControlNetLLLiteDiT(
+                dit_b, cond_emb_dim=32, mlp_dim=64, target_layers=target_layers,
+                cond_in_channels=cond_in_channels, cond_input_space="latent",
+            )
+            load_lllite_weights(lllite_b, ckpt, strict=True)
+            assert _state_dicts_equal(lllite.state_dict(), lllite_b.state_dict())
+            print(f"[L2] latent cond_in_channels={cond_in_channels}: save/load round-trip OK")
+
+            # pixel モデルに latent 重みを読ませると明示的に失敗する
+            dit_px = _StubDiT(num_blocks=num_blocks, query_dim=query_dim, context_dim=context_dim)
+            lllite_px = ControlNetLLLiteDiT(
+                dit_px, cond_emb_dim=32, mlp_dim=64, target_layers=target_layers,
+                cond_in_channels=cond_in_channels, cond_input_space="pixel",
+            )
+            try:
+                load_lllite_weights(lllite_px, ckpt, strict=False)
+                raise AssertionError("loading latent weights into a pixel model should fail")
+            except RuntimeError as e:
+                assert "cond input space mismatch" in str(e), str(e)
+
+            # 逆方向: pixel 重みを latent モデルに読ませても失敗する
+            ckpt_px = os.path.join(tmp, "lllite_pixel.safetensors")
+            save_lllite_model(ckpt_px, lllite_px, dtype=torch.float32)
+            lllite_lat_c = ControlNetLLLiteDiT(
+                _StubDiT(num_blocks=num_blocks, query_dim=query_dim, context_dim=context_dim),
+                cond_emb_dim=32, mlp_dim=64, target_layers=target_layers,
+                cond_in_channels=cond_in_channels, cond_input_space="latent",
+            )
+            try:
+                load_lllite_weights(lllite_lat_c, ckpt_px, strict=False)
+                raise AssertionError("loading pixel weights into a latent model should fail")
+            except RuntimeError as e:
+                assert "cond input space mismatch" in str(e), str(e)
+            print(f"[L3] latent cond_in_channels={cond_in_channels}: pixel/latent mix-up rejected")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds an optional **latent conditioning input** mode to Anima ControlNet-LLLite: the conditioning image can be fed as a VAE-encoded latent instead of raw pixels (`--lllite_cond_input latent`, default remains `pixel`).

- **Latent stem**: in latent mode, the pixel conv stem (stride-4 Conv ×2) is replaced by a lightweight stem that consumes the VAE latent directly, so the conditioning signal enters in the same representation space as the denoised latents.
- **Inpainting supported**: in latent mode + inpainting, the mask is downsampled through a small conv pyramid (1→4→8→16 ch) and concatenated to the latent stem features.
- **Both modes coexist**: `pixel` and `latent` stems are selected per-network; saved weights record which stem was used, and inference / minimal inference scripts pick this up automatically.

Docs updated (`docs/anima_train_control_net_lllite.md`, new section 8) with usage, weight-key layout, and limitations. Dry-run manual test extended to cover the latent path.

## Motivation / results

In real training runs (character expression-editing task), latent conditioning converged roughly **10× faster** in terms of steps to comparable quality, at about **+12% wall-clock per step**, with no boundary artifacts around masked regions.

## Notes

- Draft: published so interested users can try it; merge timing TBD.
- The experimental **v3 semantic trunk** builds on top of this branch (see the follow-up stacked PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)