### PR TITLE
[Bugfix] Crash prevention in .down.alpha layers.

### DIFF
--- a/networks/resize_lora.py
+++ b/networks/resize_lora.py
@@ -233,7 +233,7 @@ def resize_lora_model(lora_sd, new_rank, new_conv_rank, save_dtype, device, dyna
             for _format in LORA_DOWN_UP_FORMATS:
                 # Currently we only match lora_down_name in the last two parts of key
                 # because ("down", "up") are general words and may appear in block_down_name
-                if len(key_parts) >= 2 and _format[0] == key_parts[-2]:
+                if len(key_parts) >= 2 and _format[0] == key_parts[-2] and "alpha" != key_parts[-1]:
                     block_down_name = ".".join(key_parts[:-2])
                     lora_down_name = "." + _format[0]
                     lora_up_name = "." + _format[1]


### PR DESCRIPTION
I've encountered a lora (now deleted) that has layers diffusion_model.blocks.0.mlp.down.alpha/lora_down.weight/lora_up.weight. Checking the last two parts causes mlp.down.alpha to be detected as a down layer (instead of lora_down.weight as intended), which then crashes in `old_rank = lora_down_weight.size()[0]`.
Double checking the lack of .alpha key corrected this error and should have no downside since alpha is assumed to be reserved in another place.
Edit: Have encountered another one since by someone else.