### PR TITLE
Add support for expanded Anima 2.9B model by detecting block count from keys

### DIFF
--- a/library/anima_utils.py
+++ b/library/anima_utils.py
@@ -3,6 +3,7 @@
 import os
 from typing import Dict, List, Optional, Union
 import torch
+from safetensors import safe_open
 from safetensors.torch import load_file, save_file
 from accelerate.utils import set_module_tensor_to_device  # kept for potential future use
 from accelerate import init_empty_weights
@@ -64,6 +65,10 @@ def load_anima_model(
     loading_device = torch.device(loading_device)
 
     # We currently support fixed DiT config for Anima models
+    # Detect block.39 from the checkpoint
+    with safe_open(dit_path, framework="pt") as f:
+        is_2_9b = any(k.endswith("blocks.39.mlp.layer1.weight") for k in f.keys())  # 2.9B has 40 blocks
+
     dit_config = {
         "max_img_h": 512,
         "max_img_w": 512,
@@ -82,7 +87,7 @@ def load_anima_model(
         "max_fps": 30,
         "use_adaln_lora": True,
         "adaln_lora_dim": 256,
-        "num_blocks": 28,
+        "num_blocks": 40 if is_2_9b else 28,
         "num_heads": 16,
         "extra_per_block_abs_pos_emb": False,
         "rope_h_extrapolation_ratio": 4.0,


### PR DESCRIPTION
### Problem

`load_anima_model()` hardcodes `"num_blocks": 28`, so expanded Anima 2.9B checkpoints (40 blocks) fail to load.

### Fix

Probe the checkpoint for a block-39 key and set `num_blocks` accordingly:

```python
with safe_open(dit_path, framework="pt") as f:
    is_2_9b = any(k.endswith("blocks.39.mlp.layer1.weight") for k in f.keys())
```

`safe_open` reads only the header, so this does not add a tensor read. `endswith` is used rather than a prefixed key so it works regardless of whether the checkpoint uses `net.`, `model.diffusion_model.`, or no prefix — matching the variants `rename_hook` already handles below.

Forge-Neo uses the same block-39 probe ([d1b4fdf](https://github.com/Haoming02/sd-webui-forge-classic/commit/d1b4fdfe37040dcce25b0bfd0cb34dc0380d87cf)). ComfyUI solves the same problem differently, by counting blocks from the state dict ([725e6ec](https://github.com/comfyanonymous/ComfyUI/commit/725e6ec60621c6f001af04769173e7dbb3c53541)); that generalises to any block count, and I'm happy to switch to it if preferred.

### Testing

Verified against a real 40-block checkpoint (5.8GB, `net.` prefix):

- detection returns 40; actual block indices in the file are `0..39`
- built `Anima(num_blocks=40)` and compared state-dict keys against the checkpoint after `rename_hook`: 928 vs 928 keys, 0 unexpected, 0 missing (excluding the buffers the loader already filters)
- 28-block checkpoints are unaffected — the probe simply does not match