### PR TITLE
fix resize_images resolution width/height order

### DIFF
--- a/tools/resize_images_to_resolution.py
+++ b/tools/resize_images_to_resolution.py
@@ -55,7 +55,7 @@ def resize_images(src_img_folder, dst_img_folder, max_resolution="512x512", divi
         new_height = int(img.shape[0] * math.sqrt(scale_factor))
         new_width = int(img.shape[1] * math.sqrt(scale_factor))
 
-        img = resize_image(img,  img.shape[0], img.shape[1], new_height, new_width, interpolation)
+        img = resize_image(img, img.shape[1], img.shape[0], new_width, new_height, interpolation)
       else:
         new_height, new_width = img.shape[0:2]
 


### PR DESCRIPTION
The order was wrong here so it was resizing into crop on the wrong side. You can test the current behavior with the following and then test it with this PR. The PR version worked for me. 

```bash
resolution=1280x1280
source=/path/to/source
output=/path/to/output-$resolution

uv run --no-sync python tools/resize_images_to_resolution.py $source $output --max_resolution $resolution --divisible_by 32 --interpolation lanczos4
```