### PR TITLE
Replace deprecated torch.cuda.amp API with torch.amp equivalents

### DIFF
--- a/library/ipex/hijacks.py
+++ b/library/ipex/hijacks.py
@@ -438,6 +438,10 @@ def ipex_hijacks():
         torch.nn.functional.scaled_dot_product_attention = dynamic_scaled_dot_product_attention
 
     # AMP:
+    # torch.cuda.amp is deprecated since torch 2.3/2.4, but aliasing it here
+    # (to the torch.amp / torch.xpu.amp implementations below) keeps
+    # third-party code importing torch.cuda.amp working without the
+    # FutureWarning until the alias is removed.
     torch.amp.grad_scaler.GradScaler.__init__ = GradScaler_init
     torch.is_autocast_enabled = torch_is_autocast_enabled
     torch.get_autocast_gpu_dtype = torch_get_autocast_dtype

--- a/library/sdxl_original_control_net.py
+++ b/library/sdxl_original_control_net.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     # import transformers
     # optimizer = transformers.optimization.Adafactor(unet.parameters(), relative_step=True)  # working at 22.2GB with torch2
 
-    scaler = torch.cuda.amp.GradScaler(enabled=True)
+    scaler = torch.amp.GradScaler("cuda", enabled=True)
 
     logger.info("start training")
     steps = 10
@@ -250,7 +250,7 @@ if __name__ == "__main__":
         vector = torch.randn(batch_size, sdxl_original_unet.ADM_IN_CHANNELS).cuda()
         cond_img = torch.rand(batch_size, 3, 1024, 1024).cuda()
 
-        with torch.cuda.amp.autocast(enabled=True, dtype=torch.bfloat16):
+        with torch.amp.autocast("cuda", enabled=True, dtype=torch.bfloat16):
             input_resi_add, mid_add = control_net(x, t, txt, vector, cond_img)
             output = unet(x, t, txt, vector, input_resi_add, mid_add)
             target = torch.randn_like(output)

--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -1263,7 +1263,7 @@ if __name__ == "__main__":
 
     optimizer = transformers.optimization.Adafactor(unet.parameters(), relative_step=True)  # working at 22.2GB with torch2
 
-    scaler = torch.cuda.amp.GradScaler(enabled=True)
+    scaler = torch.amp.GradScaler("cuda", enabled=True)
 
     logger.info("start training")
     steps = 10
@@ -1279,7 +1279,7 @@ if __name__ == "__main__":
         ctx = torch.randn(batch_size, 77, 2048).cuda()
         y = torch.randn(batch_size, ADM_IN_CHANNELS).cuda()
 
-        with torch.cuda.amp.autocast(enabled=True):
+        with torch.amp.autocast("cuda", enabled=True):
             output = unet(x, t, ctx, y)
             target = torch.randn_like(output)
             loss = torch.nn.functional.mse_loss(output, target)

--- a/networks/control_net_lllite.py
+++ b/networks/control_net_lllite.py
@@ -415,7 +415,7 @@ if __name__ == "__main__":
 
     optimizer = bitsandbytes.adam.Adam8bit(control_net.prepare_optimizer_params(), 1e-3)
 
-    scaler = torch.cuda.amp.GradScaler(enabled=True)
+    scaler = torch.amp.GradScaler("cuda", enabled=True)
 
     logger.info("start training")
     steps = 10
@@ -431,7 +431,7 @@ if __name__ == "__main__":
         ctx = torch.randn(batch_size, 77, 2048).cuda()
         y = torch.randn(batch_size, sdxl_original_unet.ADM_IN_CHANNELS).cuda()
 
-        with torch.cuda.amp.autocast(enabled=True):
+        with torch.amp.autocast("cuda", enabled=True):
             control_net.set_cond_image(conditioning_image)
 
             output = unet(x, t, ctx, y)

--- a/networks/control_net_lllite_for_train.py
+++ b/networks/control_net_lllite_for_train.py
@@ -468,7 +468,7 @@ if __name__ == "__main__":
 
     optimizer = bitsandbytes.adam.Adam8bit(params, 1e-3)
 
-    scaler = torch.cuda.amp.GradScaler(enabled=True)
+    scaler = torch.amp.GradScaler("cuda", enabled=True)
 
     logger.info("start training")
     steps = 10
@@ -484,7 +484,7 @@ if __name__ == "__main__":
         ctx = torch.randn(batch_size, 77, 2048).cuda()
         y = torch.randn(batch_size, sdxl_original_unet.ADM_IN_CHANNELS).cuda()
 
-        with torch.cuda.amp.autocast(enabled=True, dtype=torch.bfloat16):
+        with torch.amp.autocast("cuda", enabled=True, dtype=torch.bfloat16):
             output = unet(x, t, ctx, y, conditioning_image)
             target = torch.randn_like(output)
             loss = torch.nn.functional.mse_loss(output, target)


### PR DESCRIPTION
Fixes #2420

### Summary

`torch.cuda.amp.GradScaler` has been deprecated since torch 2.3 and `torch.cuda.amp.autocast` since torch 2.4, both scheduled for removal. This PR migrates the eight `__main__` self-test usages to `torch.amp`, which provides the same APIs (GradScaler since torch 2.3, autocast since torch 2.0) and is compatible with the torch ≥ 2.6.0 floor the README already declares. The IPEX hijack aliasing in `library/ipex/hijacks.py` already targets `torch.amp`, so it only gets a clarifying comment.

Changes:

- **`library/sdxl_original_unet.py`** (2) — `torch.cuda.amp.GradScaler(enabled=True)` → `torch.amp.GradScaler("cuda", enabled=True)`; `with torch.cuda.amp.autocast(enabled=True):` → `with torch.amp.autocast("cuda", enabled=True):`
- **`library/sdxl_original_control_net.py`** (2) — same migration, keeping `dtype=torch.bfloat16`
- **`networks/control_net_lllite.py`** (2) — same migration
- **`networks/control_net_lllite_for_train.py`** (2) — same migration, keeping `dtype=torch.bfloat16`
- **`library/ipex/hijacks.py`** (0) — comment only: the `torch.cuda.amp` aliasing in `ipex_hijacks()` (IPEX-only path) replaces `torch.cuda.amp` with the `torch.amp` / `torch.xpu.amp` implementations, so deprecated names are never invoked; the comment documents why the references stay

All eight changes are inside `if __name__ == "__main__":` self-test blocks (developer smoke tests), none on the main training path (`train_network.py` / `sdxl_train.py` / `train_util.py` have zero `torch.cuda.amp` references).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Validation

Verified on torch 2.11.0 (CPU build) with `warnings.simplefilter("error", FutureWarning)`:

- `torch.amp.GradScaler("cuda", enabled=True)` constructs and runs warning-free.
- `torch.amp.autocast("cuda", enabled=True)` and the `dtype=torch.bfloat16` variant enter cleanly (autocast is disabled when CUDA is unavailable, by design).
- Control group: `torch.cuda.amp.GradScaler(enabled=True)` raises `FutureWarning` under the same filter — the migration is effective and the filter is sensitive.
- IPEX hijack pattern verified: reading `torch.cuda.amp.custom_fwd` (attribute access, not a call) emits no warning, and after `torch.cuda.amp = torch.amp` the alias resolves to the `torch.amp` implementation.
- `py_compile` passes on all five touched files.

### User impact

No behavior change; the `FutureWarning` emitted when running the self-test blocks on the documented torch ≥ 2.6.0 install path is eliminated, as is the risk of breakage when torch removes `torch.cuda.amp`.

### Notes for reviewers

- `torch.amp.autocast` exists since torch 2.0 and `torch.amp.GradScaler` since torch 2.3, so no version branching is needed on the declared floor (README: "PyTorch 2.6.0 or later is required").
- Same migration as [ultralytics/yolov5#13244](https://github.com/ultralytics/yolov5/pull/13244) and [huggingface/lerobot#3167](https://github.com/huggingface/lerobot/pull/3167).
