### PR TITLE
Fix IndexError in resize_lora.py for layers with fewer singular values than target rank

### DIFF
--- a/networks/resize_lora.py
+++ b/networks/resize_lora.py
@@ -191,6 +191,10 @@ def rank_resize(S, rank, dynamic_method, dynamic_param, scale=1):
         new_rank = rank
         new_alpha = float(scale * new_rank)
 
+    if new_rank > len(S):  # cap rank at number of available singular values (e.g. matrices with a size-1 dimension)
+        new_rank = len(S)
+        new_alpha = float(scale * new_rank)
+
     # Calculate resize info
     s_sum = torch.sum(torch.abs(S))
     s_rank = torch.sum(torch.abs(S[:new_rank]))


### PR DESCRIPTION
## Summary
- Fixes an `IndexError` in `networks/resize_lora.py` when resizing a LoRA that contains a layer whose merged weight matrix has a size-1 dimension (e.g. a projection to a single scalar output). SVD on such a matrix returns only 1 singular value, but `rank_resize()` only capped `new_rank` at the requested target rank, not at the number of singular values actually available, so `S[new_rank - 1]` indexed out of bounds.
- Caps `new_rank` at `len(S)` in `rank_resize()`.

```
  Traceback (most recent call last):                                                                        
    File "/mnt/900/builds/sd-scripts/networks/resize_lora.py", line 439, in <module>                        
      resize(args)                                                                                          
    File "/mnt/900/builds/sd-scripts/networks/resize_lora.py", line 345, in resize                          
      state_dict, old_dim, new_alpha = resize_lora_model(                                                   
                                       ^^^^^^^^^^^^^^^^^^                                                   
    File "/mnt/900/builds/sd-scripts/networks/resize_lora.py", line 278, in resize_lora_model               
      param_dict = extract_linear(full_weight_matrix, new_rank, dynamic_method, dynamic_param, device,      
  scale, svd_lowrank_niter)                                                                                 
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  ^^^^^^^^^^^^^^^^^^^^^                                                                                     
    File "/mnt/900/builds/sd-scripts/networks/resize_lora.py", line 122, in extract_linear                  
      param_dict = rank_resize(S, lora_rank, dynamic_method, dynamic_param, scale)                          
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          
    File "/mnt/900/builds/sd-scripts/networks/resize_lora.py", line 207, in rank_resize                     
      param_dict["max_ratio"] = S[0] / S[new_rank - 1]                                                      
                                       ~^^^^^^^^^^^^^^                                                      
  IndexError: index 3 is out of bounds for dimension 0 with size 1   
  ```

Specifically when resizing a Krea 2 LoRA ran into this issue going from 16 to 4 rank.

## Test plan
- [x] Reproduced the crash resizing a real LoRA with `--new_rank 4` that has a `lora_up.weight` of shape `[1, 16]`
- [x] Verified `rank_resize()` returns `new_rank=1` for a single-singular-value input instead of raising
- [x] Re-ran the full resize command end-to-end and confirmed it completes and saves the output file

AI Assisted